### PR TITLE
fix(tooling): remediate Dependabot updater failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: uv
-    directory: "/"
-    schedule:
-      interval: weekly
-      day: monday
-      time: "07:00"
-      timezone: America/Chicago
-    open-pull-requests-limit: 5
-    groups:
-      python-development:
-        dependency-type: development
-      python-runtime:
-        dependency-type: production
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -21,11 +8,3 @@ updates:
       time: "07:30"
       timezone: America/Chicago
     open-pull-requests-limit: 5
-  - package-ecosystem: docker
-    directory: "/ops/clickhouse"
-    schedule:
-      interval: weekly
-      day: monday
-      time: "08:00"
-      timezone: America/Chicago
-    open-pull-requests-limit: 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,9 @@
   package inventory and empty-environment smoke checks, repository validators, and fail-closed
   security tooling.
 - Add least-privilege immutable-action CI with a fail-closed aggregate `required-ci` result.
+- Require every configured Dependabot ecosystem to resolve to a canonical directory and a
+  Milhouse-approved manifest; retain GitHub Actions updates while deferring Python updates until the
+  hosted updater supports the required uv version and container updates until their owning package
+  selects the matching `docker` or `docker-compose` ecosystem.
 - Replace scaffold setup guidance with W01 contributor, development, dependency, package, and
   security workflow documentation while reserving product initialization for W06.

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ test-coverage:
 		--critical 'scripts/run_make.py' \
 		--critical 'scripts/run_uv.py' \
 		--critical 'scripts/secret_scan.py' \
+		--critical 'scripts/validate_config.py' \
 		--critical 'scripts/validate_workflows.py' \
 		--critical 'scripts/milhouse_tools/strict_data.py' \
 		--critical-branch 95

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,8 +176,14 @@ documenting the matrix or passing only the local interpreter is not equivalent.
 
 The `docs-check` target validates local Markdown targets and anchors and applies a bounded external
 link check. The `repo-check` target parses repository TOML, JSON, YAML, and package resources
-strictly. Keep examples fake and provider-neutral. Do not commit credentials, private paths, raw
-telemetry, generated reports, state, agent content, or donor fixtures.
+strictly. Dependabot entries must use canonical in-repository directories, resolve to
+Milhouse-approved regular manifests, and use the ecosystem matching that manifest (`docker-compose`
+for Compose, not `docker`). Automated version updates currently cover GitHub Actions. The exact
+Python lock remains enforced by lock and compatibility checks and scanned for known vulnerabilities
+by required-CI `pip-audit`; automated Python version updates wait until GitHub's hosted updater can
+run the uv version Milhouse requires. Container update tracking returns with its owning package and
+matching ecosystem. Keep examples fake and provider-neutral. Do not commit credentials, private
+paths, raw telemetry, generated reports, state, agent content, or donor fixtures.
 
 Before handoff, follow [Contributing](../CONTRIBUTING.md), run the checks required by the active
 work package, inspect the combined tree, and report any unverified external behavior separately.

--- a/docs/gate-evidence/G01.md
+++ b/docs/gate-evidence/G01.md
@@ -1,8 +1,8 @@
 # G01 evidence — package and quality-toolchain foundation
 
 Status: **in progress**. This record describes the W01 candidate built from protected-main parent
-`79b9fdca3c567b1de48a3136fbe4ba0dd981926a`. It does not mark G01 passed before exact-head hosted
-checks, independent review, protected merge, and post-merge verification are complete.
+`79b9fdca3c567b1de48a3136fbe4ba0dd981926a` and its post-merge remediation. It does not mark G01
+passed before the remediation is independently reviewed, protected-merged, and post-merge verified.
 
 ## Local candidate evidence — 2026-07-19
 
@@ -11,14 +11,14 @@ project environment ran tests with CPython 3.13.2; the fresh bootstrap proof use
 
 | Assertion | Canonical evidence | Result |
 |---|---|---|
-| Lock, formatting, lint, strict typing, repository configuration, docs, workflow, and skill validation | `./scripts/run_make.py quality` | Passed; 52 Python files formatted, 24 typed source files clean, 18 structured files valid, 60 Markdown files/144 links/20 bounded external probes valid, one aggregate workflow valid, zizmor reported no findings, and all five skills/aliases passed |
-| Complete offline topology | `./scripts/run_make.py test` | 694 collected; 693 passed and one privileged bind-mount capability test skipped on macOS |
-| Coverage | `./scripts/run_make.py test-coverage` | 97.97% line and 97.11% branch overall; all 14 exact W01 critical files independently matched and passed at 95.00%-100.00% branch coverage |
+| Lock, formatting, lint, strict typing, repository configuration, docs, workflow, and skill validation | `./scripts/run_make.py quality` | Passed; 52 Python files formatted, 24 typed source files clean, 18 structured files valid, 60 Markdown files/153 links/28 bounded external probes valid, one aggregate workflow valid, zizmor reported no findings, and all five skills/aliases passed |
+| Complete offline topology | `./scripts/run_make.py test` | 711 collected; 710 passed and one privileged bind-mount capability test skipped on macOS |
+| Coverage | `./scripts/run_make.py test-coverage` | 98.02% line and 97.27% branch overall; all 15 exact W01 critical files independently matched and passed at 95.00%-100.00% branch coverage |
 | Dependency vulnerabilities | `./scripts/run_make.py audit` | No known vulnerabilities in the hash-locked complete group/extra export |
 | Dependency licenses | `./scripts/run_make.py license-check` | 135 current-host packages passed; two reviewed development-only exceptions, five exact conditional artifacts, and two Windows-only lock members verified |
 | Source and distribution validation | `./scripts/run_make.py build` then `./scripts/run_make.py package-check` | Exact one wheel and one sdist passed metadata, content, source-parity, license, entry-point, resource, RECORD, and bounded archive checks; held no-follow source descriptors and byte-identical private snapshots bind inspection, installation, and reported hashes |
 | Empty-environment installs | `./scripts/run_make.py artifact-smoke` | Wheel and sdist-derived wheel each passed separate base and `receiver` environments; the base CLI/version/import/resources and exact locked receiver-extra install plus `pip check` passed with the source checkout removed from import resolution |
-| Repository privacy and secrets | `./scripts/run_make.py secret-scan` and `./scripts/run_make.py secret-scan-self-test` after staging the complete tree | 154 tracked UTF-8 files and the complete staged worktree passed; gitleaks `--log-opts=--all` reported 15 commits in the evidence-update pre-commit checkout with no finding, including the immutable four-commit protected-main ancestry ending at parent `79b9fdca3c567b1de48a3136fbe4ba0dd981926a`; runtime-planted current-tree and committed-history values were both detected |
+| Repository privacy and secrets | `./scripts/run_make.py secret-scan` and `./scripts/run_make.py secret-scan-self-test` after staging the complete tree | 154 tracked UTF-8 files and the complete staged worktree passed; gitleaks `--log-opts=--all` reported 17 commits in the remediation pre-commit checkout with no finding, including protected W01 merge `f6ba1dabc8251447dd5d09ea3b6b48b11a102d51`; runtime-planted current-tree and committed-history values were both detected |
 
 Critical branch results from the complete coverage run:
 
@@ -35,6 +35,7 @@ Critical branch results from the complete coverage run:
 100.00%  6/6      scripts/run_make.py
 100.00%  16/16    scripts/run_uv.py
 96.43%   27/28    scripts/secret_scan.py
+97.87%   92/94    scripts/validate_config.py
 100.00%  276/276  scripts/validate_workflows.py
 95.00%   57/60    scripts/milhouse_tools/strict_data.py
 ```
@@ -152,19 +153,55 @@ inspection and wheel/sdist empty-environment smoke with the hashes recorded abov
 evidence-only commit changes no package, executable, workflow, configuration, or test file and must
 itself pass the same hosted checks before exact-head review.
 
-## Exact-candidate checks still required
+The final PR head `90bc82364c3a9cfc051277044a1499a1276f5a8e`, tree
+`a4998414e838515959159215b29c9ed51746f5f8`, passed all 18 hosted checks in
+[`29703381346`](https://github.com/that1guy15/Milhouse-oss/actions/runs/29703381346), including
+[`required-ci`](https://github.com/that1guy15/Milhouse-oss/actions/runs/29703381346/job/88236230390)
+and separate GitHub Advanced Security
+[`CodeQL`](https://github.com/that1guy15/Milhouse-oss/runs/88236215762). Three report-only reviews
+found no P0-P3 issue across gate completeness, privacy/security, or OSS maintenance and provenance.
+Protected squash merge [#2](https://github.com/that1guy15/Milhouse-oss/pull/2) produced DCO-signed
+main commit `f6ba1dabc8251447dd5d09ea3b6b48b11a102d51` with the exact reviewed tree. Post-merge
+[`required-ci`](https://github.com/that1guy15/Milhouse-oss/actions/runs/29703712329/job/88237115534)
+and every other job in
+[`29703712329`](https://github.com/that1guy15/Milhouse-oss/actions/runs/29703712329) passed.
 
-- Pass the hosted checks on the evidence-only final PR head. The DCO-signed restoration head,
-  rebuilt wheel/sdist hashes, complete hosted green run, and intentional required-gate
-  failure/blocked-merge proof are recorded above.
-- Obtain report-only independent G01 review with no unresolved P0/P1 finding and explicit P2
-  disposition.
-- Merge through protected `main`, confirm the merged tree matches the reviewed candidate, and pass
-  post-merge `required-ci` before changing G01 to passed.
+The merge also activated Dependabot configuration for the first time. Two configured ecosystems
+failed even though protected CI passed:
+
+- Docker run
+  [`29703713874`](https://github.com/that1guy15/Milhouse-oss/actions/runs/29703713874)
+  reported `dependency_file_not_found`: the configured `docker` ecosystem found no Dockerfile or
+  Kubernetes YAML in `/ops/clickhouse`. The existing `docker-compose.yml` belongs to GitHub's
+  separately named `docker-compose` ecosystem.
+- uv run [`29703713818`](https://github.com/that1guy15/Milhouse-oss/actions/runs/29703713818)
+  reported four `tool_version_not_supported` failures for `coverage[toml]`, `mypy`,
+  `clickhouse-connect`, and `uvicorn[standard]`. The hosted updater supplied uv `0.11.8`, which
+  cannot satisfy the project's required `>=0.11.29,<0.12` range.
+
+The GitHub Actions updater
+[`29703713859`](https://github.com/that1guy15/Milhouse-oss/actions/runs/29703713859) succeeded. G01
+nevertheless stayed open because both configured failing jobs were part of the delivered
+dependency-update policy. The remediation removes the incompatible uv entry and the misclassified
+premature Docker entry while retaining GitHub Actions updates. Python updates return only when the
+hosted updater supports Milhouse's required uv version; container update tracking returns with its
+owning work package and the ecosystem matching its approved manifest. Repository validation now
+rejects noncanonical, missing, symlinked, or manifestless Dependabot directories and distinguishes
+`docker` from `docker-compose`. The validator is included in the exact 95% critical-branch
+inventory.
+
+## Remediation checks still required
+
+- Pass local and hosted checks on the exact remediation head, including the new semantic policy
+  regressions and 15-file critical coverage inventory.
+- Obtain report-only review with explicit disposition of both failed updater jobs and no unresolved
+  P0-P2 finding.
+- Merge the remediation through protected `main`, verify post-merge `required-ci`, and confirm no
+  incompatible uv or misclassified Docker updater is scheduled before recording G01 as passed.
 
 ## Gate conclusion
 
-Not yet accepted. The Plan 9.2 local correction and staged-tree privacy scans are green, and the
-hosted required-gate failure/blocked-merge and restored-head green proofs are complete.
-Evidence-head hosted checks, exact-head review, protected merge, and post-merge evidence remain
-open.
+Not yet accepted. The W01 candidate passed independent review, protected merge, exact-tree
+verification, and post-merge required CI. The newly observed Dependabot ecosystem and hosted-tool
+compatibility defects are locally remediated, but exact-head hosted checks, independent review,
+protected merge, and post-merge verification remain open.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -12,8 +12,8 @@ status and evidence; it does not amend the plan.
 | Product phase | **Pre-alpha; not released and not ready for production use** |
 | Plan | Version 1.0, approved for implementation by the owner on 2026-07-18 |
 | Target release | Milhouse OSS 1.0 |
-| Working branch | `codex/w01-quality-foundation` |
-| Git state | Protected `main` at signed squash commit `79b9fdca3c567b1de48a3136fbe4ba0dd981926a`; PR #2 is the protected W01 delivery path from that exact parent |
+| Working branch | `codex/w01-dependabot-remediation` |
+| Git state | Protected `main` at signed W01 squash commit `f6ba1dabc8251447dd5d09ea3b6b48b11a102d51`; its tree exactly matched reviewed PR #2 head `90bc82364c3a9cfc051277044a1499a1276f5a8e` |
 | Public source baseline | `that1guy15/Milhouse-oss@fb81a7faf2c101e8bb3f08ef9120d82c2b20600b` |
 | Private reference baseline | `that1guy15/milhouse@18ee9514ee11413812fde8fe361405b3686e025f` |
 | External mutation authority | Owner authorized build-branch pushes, pull requests, and merges to `main` after required checks on 2026-07-19. Tags, package publication, announcements, live-provider calls, and unrelated external mutation remain separately controlled |
@@ -73,7 +73,7 @@ evidence. A later regression returns the affected gate to **In progress**.
 | Package | Depends on | State | Gate evidence required before `Passed` | External owner/reviewer action |
 |---|---|---|---|---|
 | W00 — authority, governance, ADRs | Owner plan approval | **Passed** | PR #1 merged as signed squash commit `79b9fdca3c567b1de48a3136fbe4ba0dd981926a`; reviewed head tree matched protected `main`; post-merge `test` and `gitleaks` passed | E01 and E02 complete for G00; third-party PVR delivery remains E01/E05 at G17 |
-| W01 — package and quality toolchain | G00 | **In progress** | [G01 evidence](gate-evidence/G01.md): local quality, coverage, audit, license, build, artifact-install, fresh-bootstrap, exact-candidate scans, and hosted failure/green assertions pass; evidence-head checks, independent review, protected merge, and post-merge verification remain | Aggregate `required-ci` migration and solo-maintainer protected-PR path are complete |
+| W01 — package and quality toolchain | G00 | **In progress** | [G01 evidence](gate-evidence/G01.md): candidate review, protected merge, exact-tree equality, and post-merge required CI passed; first-run Dependabot jobs exposed a misclassified Docker ecosystem and an incompatible hosted uv version, whose fail-closed policy remediation still requires hosted review, merge, and post-merge verification | Aggregate `required-ci` migration and solo-maintainer protected-PR path are complete |
 | W02 — domain, config, identity, privacy | G01 | Pending | Strict examples/schema; cross-process deterministic IDs; adversarial no-secret egress tests; critical branch coverage | None beyond review |
 | W03 — SQLite, spool, replay, retention | G02 | Pending | Every durable-write kill point; concurrency; corruption recovery; replay of 10,000 records twice; permissions; privacy-expiry behavior | Access to a supported local filesystem/host if not available to engineering |
 | W04 — ClickHouse and recovery | G02; G04b also requires G03 | Pending | G04a auth/migrations/checksums; G04b idempotent delivery, 24-hour simulated outage drain, and verified native restore | Docker-capable supported host if not available to engineering |

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Iterable, Sequence
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import NoReturn
 
 if __package__:
@@ -49,21 +49,6 @@ EXPECTED_DEPENDABOT_POLICY = {
     "version": 2,
     "updates": [
         {
-            "package-ecosystem": "uv",
-            "directory": "/",
-            "schedule": {
-                "interval": "weekly",
-                "day": "monday",
-                "time": "07:00",
-                "timezone": "America/Chicago",
-            },
-            "open-pull-requests-limit": 5,
-            "groups": {
-                "python-development": {"dependency-type": "development"},
-                "python-runtime": {"dependency-type": "production"},
-            },
-        },
-        {
             "package-ecosystem": "github-actions",
             "directory": "/",
             "schedule": {
@@ -73,17 +58,6 @@ EXPECTED_DEPENDABOT_POLICY = {
                 "timezone": "America/Chicago",
             },
             "open-pull-requests-limit": 5,
-        },
-        {
-            "package-ecosystem": "docker",
-            "directory": "/ops/clickhouse",
-            "schedule": {
-                "interval": "weekly",
-                "day": "monday",
-                "time": "08:00",
-                "timezone": "America/Chicago",
-            },
-            "open-pull-requests-limit": 3,
         },
     ],
 }
@@ -260,9 +234,93 @@ def validate_pyproject_policy(value: object, path: Path) -> None:
         raise DataError(f"{path}: Ruff per-file ignores differ from policy")
 
 
-def validate_dependabot_policy(value: object, path: Path) -> None:
-    """Require exact ecosystems and bounded schedules for dependency updates."""
+def _dependabot_directory(repository_root: Path, value: object, label: str) -> Path:
+    if not isinstance(value, str):
+        raise DataError(f"{label}: directory must be an absolute repository path")
+    if (
+        not value.startswith("/")
+        or "\\" in value
+        or "//" in value
+        or (value != "/" and value.endswith("/"))
+        or (value != "/" and any(part in {"", ".", ".."} for part in value[1:].split("/")))
+    ):
+        raise DataError(f"{label}: directory must be a canonical absolute repository path")
 
+    relative_parts = PurePosixPath(value).parts[1:]
+    candidate = repository_root.joinpath(*relative_parts)
+    current = repository_root
+    for part in relative_parts:
+        current /= part
+        if current.is_symlink():
+            raise DataError(f"{label}: directory traverses a symlink")
+    if not candidate.is_dir():
+        raise DataError(f"{label}: directory does not exist")
+    return candidate
+
+
+def _regular_file(path: Path) -> bool:
+    return path.is_file() and not path.is_symlink()
+
+
+def _validate_dependabot_manifests(value: object, path: Path) -> None:
+    root = require_mapping(value, str(path))
+    updates = root.get("updates")
+    if not isinstance(updates, list):
+        raise DataError(f"{path}: Dependabot updates must be a list")
+
+    repository_root = path.parent.parent
+    for index, raw_update in enumerate(updates):
+        label = f"{path}: Dependabot update {index}"
+        update = require_mapping(raw_update, label)
+        ecosystem = update.get("package-ecosystem")
+        try:
+            directory = _dependabot_directory(repository_root, update.get("directory"), label)
+            if ecosystem == "uv":
+                required = (directory / "pyproject.toml", directory / "uv.lock")
+                if not all(_regular_file(candidate) for candidate in required):
+                    raise DataError(
+                        f"{label}: uv requires regular pyproject.toml and uv.lock files"
+                    )
+            elif ecosystem == "github-actions":
+                workflows = directory / ".github" / "workflows"
+                manifests = (
+                    candidate
+                    for pattern in ("*.yml", "*.yaml")
+                    for candidate in workflows.glob(pattern)
+                )
+                if (
+                    workflows.is_symlink()
+                    or not workflows.is_dir()
+                    or not any(_regular_file(item) for item in manifests)
+                ):
+                    raise DataError(f"{label}: github-actions requires a regular workflow manifest")
+            elif ecosystem == "docker":
+                manifests = (
+                    candidate
+                    for candidate in directory.iterdir()
+                    if candidate.name == "Dockerfile" or candidate.name.startswith("Dockerfile.")
+                )
+                if not any(_regular_file(item) for item in manifests):
+                    raise DataError(
+                        f"{label}: Milhouse docker policy requires a regular Dockerfile manifest"
+                    )
+            elif ecosystem == "docker-compose":
+                names = (
+                    "compose.yml",
+                    "compose.yaml",
+                    "docker-compose.yml",
+                    "docker-compose.yaml",
+                )
+                if not any(_regular_file(directory / name) for name in names):
+                    raise DataError(f"{label}: docker-compose requires a regular Compose manifest")
+        except OSError:
+            raise DataError("Dependabot manifest inspection failed safely") from None
+
+
+def validate_dependabot_policy(value: object, path: Path) -> None:
+    """Require exact ecosystems, usable manifests, and bounded schedules."""
+
+    _validate_dependabot_manifests(value, path)
     if value != EXPECTED_DEPENDABOT_POLICY:
         raise DataError(f"{path}: Dependabot ecosystems or schedules differ from policy")
 

--- a/tests/security/test_makefile_safety.py
+++ b/tests/security/test_makefile_safety.py
@@ -20,6 +20,7 @@ CRITICAL_COVERAGE_FILES = {
     "scripts/run_make.py",
     "scripts/run_uv.py",
     "scripts/secret_scan.py",
+    "scripts/validate_config.py",
     "scripts/validate_workflows.py",
     "scripts/milhouse_tools/strict_data.py",
 }

--- a/tests/unit/test_tool_validate_config.py
+++ b/tests/unit/test_tool_validate_config.py
@@ -58,6 +58,25 @@ def _gate_policy() -> dict[str, object]:
     }
 
 
+def _dependabot_repository(tmp_path: Path) -> Path:
+    config = tmp_path / ".github" / "dependabot.yml"
+    config.parent.mkdir(parents=True)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fixture'\n", encoding="utf-8")
+    (tmp_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    workflows = config.parent / "workflows"
+    workflows.mkdir()
+    (workflows / "ci.yml").write_text("name: fixture\n", encoding="utf-8")
+    return config
+
+
+def _uv_update() -> dict[str, object]:
+    return {
+        "package-ecosystem": "uv",
+        "directory": "/",
+        "schedule": {"interval": "weekly"},
+    }
+
+
 def test_config_discovery_accepts_supported_files_and_recurses_deterministically(
     tmp_path: Path,
 ) -> None:
@@ -275,6 +294,20 @@ def test_pyproject_semantic_gate_policy_rejects_local_value_diagnostics() -> Non
         validate_pyproject_policy(document, REPO_ROOT / "pyproject.toml")
 
 
+def test_pyproject_semantic_gate_policy_rejects_nonlist_addopts() -> None:
+    document = _gate_policy()
+    tool = document["tool"]
+    assert isinstance(tool, dict)
+    pytest_config = tool["pytest"]
+    assert isinstance(pytest_config, dict)
+    ini_options = pytest_config["ini_options"]
+    assert isinstance(ini_options, dict)
+    ini_options["addopts"] = "--strict-config"
+
+    with pytest.raises(DataError, match="must be a string list"):
+        validate_pyproject_policy(document, REPO_ROOT / "pyproject.toml")
+
+
 @pytest.mark.parametrize("name", ("pytest.ini", ".pytest.ini", "tox.ini", "setup.cfg"))
 def test_pyproject_semantic_gate_policy_rejects_competing_pytest_configuration(
     tmp_path: Path,
@@ -295,10 +328,201 @@ def test_pyproject_semantic_gate_policy_rejects_dangling_competing_symlink(
         validate_pyproject_policy(_gate_policy(), tmp_path / "pyproject.toml")
 
 
-def test_dependabot_policy_requires_uv_and_exact_bounded_schedules() -> None:
+def test_dependabot_policy_requires_github_actions_and_exact_bounded_schedule() -> None:
     path = REPO_ROOT / ".github" / "dependabot.yml"
     assert main([str(path)]) == 0
     validate_dependabot_policy(deepcopy(EXPECTED_DEPENDABOT_POLICY), path)
+
+
+def test_dependabot_policy_rejects_ecosystem_without_a_supported_manifest() -> None:
+    policy = deepcopy(EXPECTED_DEPENDABOT_POLICY)
+    updates = policy["updates"]
+    assert isinstance(updates, list)
+    updates.append(
+        {
+            "package-ecosystem": "docker",
+            "directory": "/ops/clickhouse",
+            "schedule": {"interval": "weekly"},
+        }
+    )
+
+    with pytest.raises(DataError, match="docker policy requires a regular Dockerfile manifest"):
+        validate_dependabot_policy(policy, REPO_ROOT / ".github" / "dependabot.yml")
+
+
+@pytest.mark.parametrize("directory", [None, "/missing"])
+def test_dependabot_policy_rejects_invalid_or_missing_directories(
+    tmp_path: Path, directory: object
+) -> None:
+    config = _dependabot_repository(tmp_path)
+    policy = deepcopy(EXPECTED_DEPENDABOT_POLICY)
+    updates = policy["updates"]
+    assert isinstance(updates, list)
+    first = updates[0]
+    assert isinstance(first, dict)
+    first["directory"] = directory
+
+    message = "absolute repository path" if directory is None else "directory does not exist"
+    with pytest.raises(DataError, match=message):
+        validate_dependabot_policy(policy, config)
+
+
+def test_dependabot_policy_rejects_symlink_directory(tmp_path: Path) -> None:
+    config = _dependabot_repository(tmp_path)
+    target = tmp_path / "target"
+    target.mkdir()
+    (tmp_path / "linked").symlink_to(target)
+    policy = deepcopy(EXPECTED_DEPENDABOT_POLICY)
+    updates = policy["updates"]
+    assert isinstance(updates, list)
+    first = updates[0]
+    assert isinstance(first, dict)
+    first["directory"] = "/linked"
+
+    with pytest.raises(DataError, match="directory traverses a symlink"):
+        validate_dependabot_policy(policy, config)
+
+
+def test_dependabot_policy_rejects_nonlist_updates(tmp_path: Path) -> None:
+    config = _dependabot_repository(tmp_path)
+    policy = deepcopy(EXPECTED_DEPENDABOT_POLICY)
+    policy["updates"] = {"not": "a list"}
+
+    with pytest.raises(DataError, match="updates must be a list"):
+        validate_dependabot_policy(policy, config)
+
+
+def test_dependabot_policy_rejects_missing_actions_manifest(tmp_path: Path) -> None:
+    config = _dependabot_repository(tmp_path)
+    (tmp_path / ".github" / "workflows" / "ci.yml").unlink()
+
+    with pytest.raises(DataError, match="github-actions requires"):
+        validate_dependabot_policy(deepcopy(EXPECTED_DEPENDABOT_POLICY), config)
+
+
+def test_dependabot_policy_rejects_missing_uv_manifest(tmp_path: Path) -> None:
+    config = _dependabot_repository(tmp_path)
+    (tmp_path / "uv.lock").unlink()
+    policy: dict[str, object] = {"version": 2, "updates": [_uv_update()]}
+
+    with pytest.raises(DataError, match="uv requires"):
+        validate_dependabot_policy(policy, config)
+
+
+def test_dependabot_policy_checks_uv_manifests_before_exact_policy(tmp_path: Path) -> None:
+    config = _dependabot_repository(tmp_path)
+    policy = deepcopy(EXPECTED_DEPENDABOT_POLICY)
+    updates = policy["updates"]
+    assert isinstance(updates, list)
+    updates.append(_uv_update())
+
+    with pytest.raises(DataError, match="ecosystems or schedules differ"):
+        validate_dependabot_policy(policy, config)
+
+
+def test_dependabot_policy_rejects_symlink_workflow_directory(tmp_path: Path) -> None:
+    config = _dependabot_repository(tmp_path)
+    workflows = config.parent / "workflows"
+    (workflows / "ci.yml").unlink()
+    workflows.rmdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "ci.yml").write_text("name: outside\n", encoding="utf-8")
+    workflows.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(DataError, match="github-actions requires"):
+        validate_dependabot_policy(deepcopy(EXPECTED_DEPENDABOT_POLICY), config)
+
+
+def test_dependabot_policy_normalizes_manifest_filesystem_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _dependabot_repository(tmp_path)
+
+    def fail_glob(_path: Path, _pattern: str) -> object:
+        raise PermissionError("synthetic-private-path")
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+    with pytest.raises(DataError) as captured:
+        validate_dependabot_policy(deepcopy(EXPECTED_DEPENDABOT_POLICY), config)
+
+    assert str(captured.value) == "Dependabot manifest inspection failed safely"
+    assert "synthetic-private-path" not in str(captured.value)
+
+
+def test_dependabot_policy_checks_dockerfile_before_exact_policy(tmp_path: Path) -> None:
+    config = _dependabot_repository(tmp_path)
+    docker = tmp_path / "ops" / "clickhouse"
+    docker.mkdir(parents=True)
+    (docker / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    policy = deepcopy(EXPECTED_DEPENDABOT_POLICY)
+    updates = policy["updates"]
+    assert isinstance(updates, list)
+    updates.append(
+        {
+            "package-ecosystem": "docker",
+            "directory": "/ops/clickhouse",
+            "schedule": {"interval": "weekly"},
+        }
+    )
+
+    with pytest.raises(DataError, match="ecosystems or schedules differ"):
+        validate_dependabot_policy(policy, config)
+
+
+def test_dependabot_policy_checks_compose_manifest_before_exact_policy(tmp_path: Path) -> None:
+    config = _dependabot_repository(tmp_path)
+    compose = tmp_path / "ops" / "clickhouse"
+    compose.mkdir(parents=True)
+    (compose / "docker-compose.yml").write_text(
+        "services:\n  clickhouse:\n    image: clickhouse/clickhouse-server:24.8\n",
+        encoding="utf-8",
+    )
+    policy = deepcopy(EXPECTED_DEPENDABOT_POLICY)
+    updates = policy["updates"]
+    assert isinstance(updates, list)
+    updates.append(
+        {
+            "package-ecosystem": "docker-compose",
+            "directory": "/ops/clickhouse",
+            "schedule": {"interval": "weekly"},
+        }
+    )
+
+    with pytest.raises(DataError, match="ecosystems or schedules differ"):
+        validate_dependabot_policy(policy, config)
+
+
+def test_dependabot_policy_rejects_missing_compose_manifest(tmp_path: Path) -> None:
+    config = _dependabot_repository(tmp_path)
+    compose = tmp_path / "ops" / "clickhouse"
+    compose.mkdir(parents=True)
+    policy: dict[str, object] = {
+        "version": 2,
+        "updates": [
+            {
+                "package-ecosystem": "docker-compose",
+                "directory": "/ops/clickhouse",
+                "schedule": {"interval": "weekly"},
+            }
+        ],
+    }
+
+    with pytest.raises(DataError, match="docker-compose requires a regular Compose manifest"):
+        validate_dependabot_policy(policy, config)
+
+
+@pytest.mark.parametrize("directory", ["ops/clickhouse", "/ops/../clickhouse", "/ops//clickhouse"])
+def test_dependabot_policy_rejects_noncanonical_directories(directory: str) -> None:
+    policy = deepcopy(EXPECTED_DEPENDABOT_POLICY)
+    updates = policy["updates"]
+    assert isinstance(updates, list)
+    first = updates[0]
+    assert isinstance(first, dict)
+    first["directory"] = directory
+
+    with pytest.raises(DataError, match="canonical absolute repository path"):
+        validate_dependabot_policy(policy, REPO_ROOT / ".github" / "dependabot.yml")
 
 
 @pytest.mark.parametrize("mutation", ["pip", "daily", "missing", "extra"])


### PR DESCRIPTION
## Summary

- Remove the uv update job because hosted Dependabot supplies uv 0.11.8 and cannot satisfy the project requirement >=0.11.29,<0.12.
- Remove the misclassified docker job; the existing Compose file belongs to the distinct docker-compose ecosystem and container update tracking remains with its owning work package.
- Fail closed on noncanonical, missing, symlinked, or manifestless Dependabot paths, distinguish docker from docker-compose, normalize filesystem errors, and enroll the validator in exact critical coverage.

## Trigger evidence

- uv failure: https://github.com/that1guy15/Milhouse-oss/actions/runs/29703713818 (four tool_version_not_supported results)
- docker failure: https://github.com/that1guy15/Milhouse-oss/actions/runs/29703713874 (dependency_file_not_found)
- retained GitHub Actions success: https://github.com/that1guy15/Milhouse-oss/actions/runs/29703713859

## Exact candidate

- Commit: 2e980b8e75025310e5e33c2ae2acd6da9476b82c
- Tree: 67dde595818a388989d9749ebc92601ee4ceabaa
- DCO: 1/1 commit passed

## Verification

- quality: PASS (52 formatted files, 24 typed files, 18 structured files, docs 60/153/28, workflow/zizmor/five skills green)
- tests/coverage: 711 collected; 710 passed and one expected macOS capability skip; 98.02% line and 97.27% branch; all 15 exact critical files passed; validate_config.py 92/94 branches (97.87%)
- focused policy tests: 77/77 passed
- privacy: 154 tracked text files, staged tree, and 17-commit history passed; planted tree/history self-test passed
- three independent report-only reviews of the exact tree: no P0-P3 findings

## Gate state

G01 remains in progress. It may close only after this exact PR head passes hosted checks, the protected merge tree matches the reviewed tree, post-merge required-ci passes, and the default-branch Dependabot schedule shows no incompatible uv or misclassified docker job.