### PR TITLE
feat(core): add deterministic identity foundation

### DIFF
--- a/src/milhouse/core/__init__.py
+++ b/src/milhouse/core/__init__.py
@@ -1,0 +1,18 @@
+"""Deterministic core primitives shared by Milhouse subsystems."""
+
+from milhouse.core.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    canonical_json_text,
+)
+from milhouse.core.clock import Clock, FixedClock, SystemClock, format_timestamp
+
+__all__ = [
+    "CanonicalizationError",
+    "Clock",
+    "FixedClock",
+    "SystemClock",
+    "canonical_json_bytes",
+    "canonical_json_text",
+    "format_timestamp",
+]

--- a/src/milhouse/core/canonical.py
+++ b/src/milhouse/core/canonical.py
@@ -1,0 +1,209 @@
+"""Canonical JSON bytes used by Milhouse hashes and durable projections."""
+
+from __future__ import annotations
+
+import json
+import math
+import unicodedata
+from datetime import datetime
+from decimal import Decimal
+
+from milhouse.core.clock import format_timestamp
+
+MIN_CANONICAL_INT = -(2**63)
+MAX_CANONICAL_INT = 2**63 - 1
+DEFAULT_MAX_DEPTH = 32
+DEFAULT_MAX_NODES = 10_000
+DEFAULT_MAX_BYTES = 262_144
+
+
+class CanonicalizationError(ValueError):
+    """Safe, stable failure raised for values outside CanonicalJSONV1."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+def _normalize_string(value: str) -> str:
+    if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
+        raise CanonicalizationError(
+            "MH_CANONICAL_UNICODE", "surrogate code points are not supported"
+        )
+    normalized_lines = value.replace("\r\n", "\n").replace("\r", "\n")
+    try:
+        return unicodedata.normalize("NFC", normalized_lines)
+    except ValueError as error:
+        raise CanonicalizationError(
+            "MH_CANONICAL_UNICODE", "the string cannot be normalized"
+        ) from error
+
+
+def _quote_string(value: str) -> str:
+    return json.dumps(
+        _normalize_string(value),
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    )
+
+
+def _serialize_integer(value: int) -> str:
+    if value < MIN_CANONICAL_INT or value > MAX_CANONICAL_INT:
+        raise CanonicalizationError(
+            "MH_CANONICAL_INTEGER_RANGE", "an integer is outside the signed 64-bit domain"
+        )
+    return str(value)
+
+
+def _serialize_float(value: float) -> str:
+    if not math.isfinite(value):
+        raise CanonicalizationError("MH_CANONICAL_FLOAT", "a float must be finite")
+    if value == 0:
+        return "0"
+    if value.is_integer():
+        return _serialize_integer(int(value))
+
+    decimal_value = Decimal(repr(value))
+    parts = decimal_value.as_tuple()
+    digits = "".join(str(digit) for digit in parts.digits)
+    exponent = parts.exponent
+    if not isinstance(exponent, int):  # pragma: no cover - finite input guarantees an integer
+        raise CanonicalizationError("MH_CANONICAL_FLOAT", "a float exponent is invalid")
+
+    digit_count = len(digits)
+    decimal_position = digit_count + exponent
+    if digit_count <= decimal_position <= 21:
+        body = digits + ("0" * (decimal_position - digit_count))
+    elif 0 < decimal_position <= 21:
+        body = f"{digits[:decimal_position]}.{digits[decimal_position:]}"
+    elif -6 < decimal_position <= 0:
+        body = f"0.{('0' * -decimal_position)}{digits}"
+    else:
+        scientific_exponent = decimal_position - 1
+        mantissa = digits[0] if digit_count == 1 else f"{digits[0]}.{digits[1:]}"
+        exponent_text = (
+            f"+{scientific_exponent}" if scientific_exponent >= 0 else str(scientific_exponent)
+        )
+        body = f"{mantissa}e{exponent_text}"
+    return f"-{body}" if parts.sign else body
+
+
+class _CanonicalEncoder:
+    def __init__(self, *, max_depth: int, max_nodes: int) -> None:
+        self.max_depth = max_depth
+        self.max_nodes = max_nodes
+        self.nodes = 0
+
+    def encode(self, value: object) -> str:
+        return self._encode_value(value, container_depth=0)
+
+    def _count_node(self) -> None:
+        self.nodes += 1
+        if self.nodes > self.max_nodes:
+            raise CanonicalizationError(
+                "MH_CANONICAL_NODES", "the canonical value exceeds the node limit"
+            )
+
+    def _encode_value(self, value: object, *, container_depth: int) -> str:
+        self._count_node()
+        if value is None:
+            return "null"
+        if type(value) is bool:
+            return "true" if value else "false"
+        if type(value) is int:
+            return _serialize_integer(value)
+        if type(value) is float:
+            return _serialize_float(value)
+        if type(value) is str:
+            return _quote_string(value)
+        if type(value) is datetime:
+            try:
+                return _quote_string(format_timestamp(value))
+            except (OverflowError, ValueError) as error:
+                raise CanonicalizationError(
+                    "MH_CANONICAL_TIMESTAMP", "a timestamp must be aware and valid"
+                ) from error
+        if type(value) is list:
+            return self._encode_array(value, container_depth=container_depth + 1)
+        if type(value) is dict:
+            return self._encode_object(value, container_depth=container_depth + 1)
+        raise CanonicalizationError(
+            "MH_CANONICAL_TYPE", "the value type is not supported by canonical JSON"
+        )
+
+    def _check_depth(self, container_depth: int) -> None:
+        if container_depth > self.max_depth:
+            raise CanonicalizationError(
+                "MH_CANONICAL_DEPTH", "the canonical value exceeds the container-depth limit"
+            )
+
+    def _encode_array(self, value: list[object], *, container_depth: int) -> str:
+        self._check_depth(container_depth)
+        members = [self._encode_value(member, container_depth=container_depth) for member in value]
+        return f"[{','.join(members)}]"
+
+    def _encode_object(self, value: dict[object, object], *, container_depth: int) -> str:
+        self._check_depth(container_depth)
+        normalized: dict[str, object] = {}
+        for key, member in value.items():
+            if type(key) is not str:
+                raise CanonicalizationError(
+                    "MH_CANONICAL_KEY_TYPE", "canonical object keys must be strings"
+                )
+            normalized_key = _normalize_string(key)
+            if normalized_key in normalized:
+                raise CanonicalizationError(
+                    "MH_CANONICAL_KEY_COLLISION",
+                    "object keys collide after canonical normalization",
+                )
+            normalized[normalized_key] = member
+
+        items: list[str] = []
+        for key in sorted(normalized, key=lambda candidate: candidate.encode("utf-8")):
+            encoded_value = self._encode_value(normalized[key], container_depth=container_depth)
+            items.append(f"{_quote_string(key)}:{encoded_value}")
+        return f"{{{','.join(items)}}}"
+
+
+def canonical_json_bytes(
+    value: object,
+    *,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_nodes: int = DEFAULT_MAX_NODES,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> bytes:
+    """Serialize one supported value to bounded CanonicalJSONV1 UTF-8 bytes."""
+
+    for name, limit in (
+        ("max_depth", max_depth),
+        ("max_nodes", max_nodes),
+        ("max_bytes", max_bytes),
+    ):
+        if type(limit) is not int or limit < 1:
+            raise ValueError(f"{name} must be a positive integer")
+
+    text = _CanonicalEncoder(max_depth=max_depth, max_nodes=max_nodes).encode(value)
+    encoded = text.encode("utf-8")
+    if len(encoded) > max_bytes:
+        raise CanonicalizationError(
+            "MH_CANONICAL_SIZE", "the canonical value exceeds the UTF-8 byte limit"
+        )
+    return encoded
+
+
+def canonical_json_text(
+    value: object,
+    *,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_nodes: int = DEFAULT_MAX_NODES,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> str:
+    """Serialize one supported value to canonical text without a trailing newline."""
+
+    return canonical_json_bytes(
+        value,
+        max_depth=max_depth,
+        max_nodes=max_nodes,
+        max_bytes=max_bytes,
+    ).decode("utf-8")

--- a/src/milhouse/core/clock.py
+++ b/src/milhouse/core/clock.py
@@ -1,0 +1,53 @@
+"""UTC clock injection and canonical timestamp handling."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+
+class Clock(Protocol):
+    """Source of wall-clock instants for deterministic domain construction."""
+
+    def now(self) -> datetime:
+        """Return an aware UTC instant truncated to milliseconds."""
+
+
+def truncate_to_milliseconds(value: datetime) -> datetime:
+    """Normalize an aware instant to UTC and truncate sub-millisecond precision."""
+
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("MH_TIME_NAIVE: an aware timestamp is required")
+    normalized = value.astimezone(UTC)
+    return normalized.replace(microsecond=(normalized.microsecond // 1000) * 1000)
+
+
+def format_timestamp(value: datetime) -> str:
+    """Return the canonical RFC3339 UTC millisecond representation."""
+
+    normalized = truncate_to_milliseconds(value)
+    return (
+        f"{normalized.year:04d}-{normalized.month:02d}-{normalized.day:02d}"
+        f"T{normalized.hour:02d}:{normalized.minute:02d}:{normalized.second:02d}."
+        f"{normalized.microsecond // 1000:03d}Z"
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class FixedClock:
+    """Clock whose value is fixed for tests and reproducible operations."""
+
+    instant: datetime
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "instant", truncate_to_milliseconds(self.instant))
+
+    def now(self) -> datetime:
+        return self.instant
+
+
+@dataclass(frozen=True, slots=True)
+class SystemClock:
+    """Production wall clock."""
+
+    def now(self) -> datetime:
+        return truncate_to_milliseconds(datetime.now(UTC))

--- a/src/milhouse/domain/__init__.py
+++ b/src/milhouse/domain/__init__.py
@@ -1,0 +1,17 @@
+"""Canonical Milhouse domain contracts."""
+
+from milhouse.domain.identity import (
+    RecordDedupeV1,
+    RecordIdentityV1,
+    derive_content_hash,
+    derive_dedupe_key,
+    derive_record_id,
+)
+
+__all__ = [
+    "RecordDedupeV1",
+    "RecordIdentityV1",
+    "derive_content_hash",
+    "derive_dedupe_key",
+    "derive_record_id",
+]

--- a/src/milhouse/domain/identity.py
+++ b/src/milhouse/domain/identity.py
@@ -1,0 +1,234 @@
+"""Strict record identity projections and deterministic digest wires."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import math
+import re
+from typing import Annotated, Literal, Self
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+from milhouse.core.canonical import (
+    MAX_CANONICAL_INT,
+    MIN_CANONICAL_INT,
+    CanonicalizationError,
+    canonical_json_bytes,
+)
+
+MachineIdV1 = Annotated[str, StringConstraints(pattern=r"^[a-z][a-z0-9_-]{0,63}$")]
+MachineNameV1 = Annotated[
+    str,
+    StringConstraints(
+        pattern=r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+        max_length=128,
+    ),
+]
+Sha256HexV1 = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{64}$")]
+InstallationIdV1 = Annotated[
+    str,
+    StringConstraints(pattern=r"^mh_in1_[0-9a-f]{12}4[0-9a-f]{3}[89ab][0-9a-f]{15}$"),
+]
+ObservationNamespaceIdV1 = Annotated[
+    str,
+    StringConstraints(pattern=r"^mh_ns1_[0-9a-f]{12}4[0-9a-f]{3}[89ab][0-9a-f]{15}$"),
+]
+RedactionVersionV1 = Annotated[str, StringConstraints(pattern=r"^r[1-9][0-9]*-e[1-9][0-9]*$")]
+RecordTypeV1 = Literal[
+    "event",
+    "metric",
+    "span",
+    "run",
+    "alert",
+    "incident",
+    "feedback_item",
+    "feedback_transition",
+    "audit",
+]
+ScopeV1 = Literal["installation", "target"]
+ObservationScalarV1 = bool | int | float | str
+
+_RECORD_ID = re.compile(r"^mh_[a-z2-7]{51}[aq]$")
+_DEDUPE_KEY = re.compile(r"^mh_d1_[a-z2-7]{51}[aq]$")
+_RECORD_ID_DOMAIN = b"milhouse-record-id-v1\0"
+_CONTENT_DOMAIN = b"milhouse-content-v1\0"
+_DEDUPE_DOMAIN = b"milhouse-dedupe-v1\0"
+
+
+class IdentityError(ValueError):
+    """Safe identity derivation or validation failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+
+class SourceIdentityV1(_StrictModel):
+    id: MachineIdV1
+    type: MachineNameV1
+    observation_namespace_id: ObservationNamespaceIdV1
+    source_generation_digest: Sha256HexV1
+
+
+class DedupeSourceV1(_StrictModel):
+    type: MachineNameV1
+    id: MachineIdV1
+    observation_namespace_id: ObservationNamespaceIdV1
+
+
+class ObservationCoordinateV1(_StrictModel):
+    kind: MachineNameV1
+    parts: dict[MachineNameV1, ObservationScalarV1]
+
+    @field_validator("parts")
+    @classmethod
+    def validate_parts(
+        cls, value: dict[MachineNameV1, ObservationScalarV1]
+    ) -> dict[MachineNameV1, ObservationScalarV1]:
+        if not 1 <= len(value) <= 16:
+            raise ValueError("MH_IDENTITY_OBSERVATION_PARTS: expected 1 through 16 parts")
+        for part in value.values():
+            if type(part) is int and not MIN_CANONICAL_INT <= part <= MAX_CANONICAL_INT:
+                raise ValueError(
+                    "MH_IDENTITY_OBSERVATION_INTEGER: integer part is outside signed 64-bit"
+                )
+            if type(part) is float:
+                if not math.isfinite(part):
+                    raise ValueError("MH_IDENTITY_OBSERVATION_FLOAT: float part must be finite")
+                if part.is_integer() and not MIN_CANONICAL_INT <= int(part) <= MAX_CANONICAL_INT:
+                    raise ValueError(
+                        "MH_IDENTITY_OBSERVATION_FLOAT: integral float is outside signed 64-bit"
+                    )
+            if type(part) is str and not 1 <= len(part.encode("utf-8")) <= 256:
+                raise ValueError(
+                    "MH_IDENTITY_OBSERVATION_STRING: string part exceeds its byte bound"
+                )
+        return value
+
+
+class RecordIdentityV1(_StrictModel):
+    identity_version: Literal[1] = 1
+    installation_id: InstallationIdV1
+    schema_version: Literal["1.0"] = "1.0"
+    redaction_version: RedactionVersionV1
+    source: SourceIdentityV1
+    scope: ScopeV1
+    target_id: MachineIdV1 | None = None
+    record_type: RecordTypeV1
+    name: MachineNameV1
+    source_event_id: Annotated[str, Field(min_length=1, max_length=256)] | None = None
+    source_entity_id: Annotated[str, Field(min_length=1, max_length=256)] | None = None
+    observation: ObservationCoordinateV1
+
+    @field_validator("source_event_id", "source_entity_id")
+    @classmethod
+    def validate_optional_opaque_id(cls, value: str | None) -> str | None:
+        if value is not None and len(value.encode("utf-8")) > 256:
+            raise ValueError("MH_IDENTITY_OPAQUE_ID: identifier exceeds its UTF-8 byte bound")
+        return value
+
+    @model_validator(mode="after")
+    def validate_scope(self) -> Self:
+        if self.scope == "target" and self.target_id is None:
+            raise ValueError("MH_IDENTITY_TARGET_REQUIRED: target scope requires target_id")
+        if self.scope == "installation" and self.target_id is not None:
+            raise ValueError("MH_IDENTITY_TARGET_FORBIDDEN: installation scope forbids target_id")
+        return self
+
+
+class RecordDedupeV1(_StrictModel):
+    dedupe_version: Literal[1] = 1
+    installation_id: InstallationIdV1
+    source: DedupeSourceV1
+    scope: ScopeV1
+    target_id: MachineIdV1 | None = None
+    record_type: RecordTypeV1
+    name: MachineNameV1
+    observation: ObservationCoordinateV1
+
+    @model_validator(mode="after")
+    def validate_scope(self) -> Self:
+        if self.scope == "target" and self.target_id is None:
+            raise ValueError("MH_DEDUPE_TARGET_REQUIRED: target scope requires target_id")
+        if self.scope == "installation" and self.target_id is not None:
+            raise ValueError("MH_DEDUPE_TARGET_FORBIDDEN: installation scope forbids target_id")
+        return self
+
+    @classmethod
+    def from_identity(cls, identity: RecordIdentityV1) -> Self:
+        return cls(
+            installation_id=identity.installation_id,
+            source=DedupeSourceV1(
+                type=identity.source.type,
+                id=identity.source.id,
+                observation_namespace_id=identity.source.observation_namespace_id,
+            ),
+            scope=identity.scope,
+            target_id=identity.target_id,
+            record_type=identity.record_type,
+            name=identity.name,
+            observation=identity.observation,
+        )
+
+
+def _domain_digest(domain: bytes, projection: object) -> bytes:
+    if not domain.endswith(b"\0") or any(byte > 0x7F for byte in domain):
+        raise ValueError("digest domains must be NUL-terminated ASCII")
+    try:
+        canonical = canonical_json_bytes(projection)
+    except CanonicalizationError as error:
+        raise IdentityError("MH_IDENTITY_PROJECTION", "projection is not canonical") from error
+    return hashlib.sha256(domain + canonical).digest()
+
+
+def _base32_digest(digest: bytes) -> str:
+    return base64.b32encode(digest).decode("ascii").lower().rstrip("=")
+
+
+def derive_record_id(identity: RecordIdentityV1) -> str:
+    projection = identity.model_dump(mode="python", exclude_none=True)
+    return f"mh_{_base32_digest(_domain_digest(_RECORD_ID_DOMAIN, projection))}"
+
+
+def derive_content_hash(content_projection: dict[str, object]) -> str:
+    if type(content_projection) is not dict:
+        raise IdentityError("MH_CONTENT_PROJECTION", "content projection must be an object")
+    return _domain_digest(_CONTENT_DOMAIN, content_projection).hex()
+
+
+def derive_dedupe_key(dedupe: RecordDedupeV1) -> str:
+    projection = dedupe.model_dump(mode="python", exclude_none=True)
+    return f"mh_d1_{_base32_digest(_domain_digest(_DEDUPE_DOMAIN, projection))}"
+
+
+def _validate_digest_token(value: str, *, prefix: str, pattern: re.Pattern[str]) -> str:
+    if type(value) is not str or pattern.fullmatch(value) is None:
+        raise IdentityError("MH_IDENTITY_TOKEN", "digest token has an invalid wire format")
+    encoded = value[len(prefix) :]
+    try:
+        decoded = base64.b32decode(f"{encoded.upper()}====", casefold=False)
+    except ValueError as error:
+        raise IdentityError("MH_IDENTITY_TOKEN", "digest token is not canonical base32") from error
+    if len(decoded) != 32 or _base32_digest(decoded) != encoded:
+        raise IdentityError("MH_IDENTITY_TOKEN", "digest token has noncanonical pad bits")
+    return value
+
+
+def validate_record_id(value: str) -> str:
+    return _validate_digest_token(value, prefix="mh_", pattern=_RECORD_ID)
+
+
+def validate_dedupe_key(value: str) -> str:
+    return _validate_digest_token(value, prefix="mh_d1_", pattern=_DEDUPE_KEY)

--- a/tests/property/test_canonical_properties.py
+++ b/tests/property/test_canonical_properties.py
@@ -1,0 +1,45 @@
+import json
+import unicodedata
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from milhouse.core.canonical import canonical_json_bytes
+
+JSON_SCALAR = st.none() | st.booleans() | st.integers(min_value=-(2**63), max_value=2**63 - 1)
+CANONICAL_KEY = st.text(
+    alphabet=st.characters(
+        blacklist_categories=("Cs",),
+        blacklist_characters="\r",
+    ),
+    max_size=16,
+).map(lambda value: unicodedata.normalize("NFC", value))
+JSON_VALUE = st.recursive(
+    JSON_SCALAR,
+    lambda children: (
+        st.lists(children, max_size=8)
+        | st.dictionaries(
+            CANONICAL_KEY,
+            children,
+            max_size=8,
+        )
+    ),
+    max_leaves=40,
+)
+
+
+@pytest.mark.property
+@given(JSON_VALUE)
+def test_canonical_json_round_trips_supported_structures(value: object) -> None:
+    encoded = canonical_json_bytes(value)
+
+    assert canonical_json_bytes(json.loads(encoded)) == encoded
+
+
+@pytest.mark.property
+@given(st.dictionaries(CANONICAL_KEY.filter(bool), JSON_SCALAR, max_size=16))
+def test_canonical_json_is_independent_of_mapping_insertion_order(value: dict[str, object]) -> None:
+    reversed_value = dict(reversed(list(value.items())))
+
+    assert canonical_json_bytes(value) == canonical_json_bytes(reversed_value)

--- a/tests/unit/test_canonical.py
+++ b/tests/unit/test_canonical.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from milhouse.core.canonical import CanonicalizationError, canonical_json_bytes
+
+
+def test_canonical_json_normalizes_strings_keys_and_line_endings() -> None:
+    value = {
+        "z": "line one\r\nline two\rline three",
+        "e\u0301": "e\u0301",
+        "a": "\b\t\n\f\r\u001f",
+    }
+
+    assert canonical_json_bytes(value) == (
+        b'{"a":"\\b\\t\\n\\f\\n\\u001f",'
+        b'"z":"line one\\nline two\\nline three",'
+        b'"\xc3\xa9":"\xc3\xa9"}'
+    )
+
+
+def test_canonical_json_sorts_normalized_utf8_keys_and_preserves_array_order() -> None:
+    assert canonical_json_bytes({"\ue000": [3, 2, 1], "\u0080": True, "a": None}) == (
+        b'{"a":null,"\xc2\x80":true,"\xee\x80\x80":[3,2,1]}'
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (-0.0, b"0"),
+        (100.0, b"100"),
+        (1e-6, b"0.000001"),
+        (1e-7, b"1e-7"),
+        (5e-324, b"5e-324"),
+        (333333333.33333329, b"333333333.3333333"),
+        (0.002, b"0.002"),
+        (1e-27, b"1e-27"),
+    ],
+)
+def test_canonical_json_uses_ecmascript_number_format(value: float, expected: bytes) -> None:
+    assert canonical_json_bytes(value) == expected
+
+
+def test_integral_float_inside_int64_uses_the_equal_integer_bytes() -> None:
+    value = 5.968169141485936e18
+    equal_integer = int(value)
+
+    assert canonical_json_bytes(value) == str(equal_integer).encode("ascii")
+    assert canonical_json_bytes(value) == canonical_json_bytes(equal_integer)
+
+
+def test_canonical_json_normalizes_aware_timestamps_to_truncated_utc_milliseconds() -> None:
+    source = datetime(
+        2026,
+        7,
+        21,
+        12,
+        34,
+        56,
+        987654,
+        tzinfo=timezone(timedelta(hours=-5)),
+    )
+
+    assert canonical_json_bytes(source) == b'"2026-07-21T17:34:56.987Z"'
+
+
+@pytest.mark.parametrize(
+    ("value", "code"),
+    [
+        ({"e\u0301": 1, "\u00e9": 2}, "MH_CANONICAL_KEY_COLLISION"),
+        ({1: "not a string key"}, "MH_CANONICAL_KEY_TYPE"),
+        ((1, 2), "MH_CANONICAL_TYPE"),
+        ({1, 2}, "MH_CANONICAL_TYPE"),
+        (b"bytes", "MH_CANONICAL_TYPE"),
+        (Decimal("1.5"), "MH_CANONICAL_TYPE"),
+        (float("nan"), "MH_CANONICAL_FLOAT"),
+        (float("inf"), "MH_CANONICAL_FLOAT"),
+        (2**63, "MH_CANONICAL_INTEGER_RANGE"),
+        (float(2**63), "MH_CANONICAL_INTEGER_RANGE"),
+        (1e20, "MH_CANONICAL_INTEGER_RANGE"),
+        (1e21, "MH_CANONICAL_INTEGER_RANGE"),
+        ("\ud800", "MH_CANONICAL_UNICODE"),
+        (datetime(2026, 1, 1), "MH_CANONICAL_TIMESTAMP"),
+        (
+            datetime(1, 1, 1, tzinfo=timezone(timedelta(hours=14))),
+            "MH_CANONICAL_TIMESTAMP",
+        ),
+    ],
+)
+def test_canonical_json_rejects_ambiguous_or_unsupported_values(value: object, code: str) -> None:
+    with pytest.raises(CanonicalizationError) as captured:
+        canonical_json_bytes(value)
+
+    assert captured.value.code == code
+    assert repr(value) not in str(captured.value)
+
+
+def test_canonical_json_enforces_depth_node_and_byte_bounds() -> None:
+    nested: object = 0
+    for _ in range(33):
+        nested = [nested]
+
+    with pytest.raises(CanonicalizationError) as depth_error:
+        canonical_json_bytes(nested)
+    assert depth_error.value.code == "MH_CANONICAL_DEPTH"
+
+    with pytest.raises(CanonicalizationError) as node_error:
+        canonical_json_bytes([0, 1, 2], max_nodes=3)
+    assert node_error.value.code == "MH_CANONICAL_NODES"
+
+    with pytest.raises(CanonicalizationError) as byte_error:
+        canonical_json_bytes("abcd", max_bytes=5)
+    assert byte_error.value.code == "MH_CANONICAL_SIZE"

--- a/tests/unit/test_clock.py
+++ b/tests/unit/test_clock.py
@@ -1,0 +1,25 @@
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from milhouse.core.clock import FixedClock, SystemClock, format_timestamp, truncate_to_milliseconds
+
+
+def test_fixed_clock_returns_one_normalized_instant() -> None:
+    source = datetime(2026, 7, 21, 1, 2, 3, 456789, tzinfo=timezone(timedelta(hours=2)))
+    clock = FixedClock(source)
+
+    assert clock.now() == datetime(2026, 7, 20, 23, 2, 3, 456000, tzinfo=UTC)
+    assert format_timestamp(clock.now()) == "2026-07-20T23:02:03.456Z"
+
+
+def test_system_clock_is_aware_utc_and_millisecond_bounded() -> None:
+    observed = SystemClock().now()
+
+    assert observed.tzinfo is UTC
+    assert observed.microsecond % 1000 == 0
+
+
+def test_clock_rejects_naive_instants() -> None:
+    with pytest.raises(ValueError, match="MH_TIME_NAIVE"):
+        truncate_to_milliseconds(datetime(2026, 7, 21))

--- a/tests/unit/test_identity.py
+++ b/tests/unit/test_identity.py
@@ -1,0 +1,151 @@
+import re
+
+import pytest
+from pydantic import ValidationError
+
+from milhouse.domain.identity import (
+    DedupeSourceV1,
+    IdentityError,
+    ObservationCoordinateV1,
+    RecordDedupeV1,
+    RecordIdentityV1,
+    SourceIdentityV1,
+    derive_content_hash,
+    derive_dedupe_key,
+    derive_record_id,
+    validate_dedupe_key,
+    validate_record_id,
+)
+
+
+def _source(*, generation: str = "0" * 64) -> SourceIdentityV1:
+    return SourceIdentityV1(
+        id="example-source",
+        type="source.event",
+        observation_namespace_id="mh_ns1_00000000000040008000000000000000",
+        source_generation_digest=generation,
+    )
+
+
+def _identity(**overrides: object) -> RecordIdentityV1:
+    values: dict[str, object] = {
+        "installation_id": "mh_in1_00000000000040008000000000000000",
+        "redaction_version": "r1-e1",
+        "source": _source(),
+        "scope": "target",
+        "target_id": "example-target",
+        "record_type": "event",
+        "name": "source.event",
+        "source_event_id": "event-1",
+        "source_entity_id": "entity-1",
+        "observation": ObservationCoordinateV1(
+            kind="source.revision",
+            parts={"revision": 1},
+        ),
+    }
+    values.update(overrides)
+    return RecordIdentityV1.model_validate(values)
+
+
+def test_record_and_dedupe_ids_are_deterministic_canonical_sha256_tokens() -> None:
+    identity = _identity()
+    dedupe = RecordDedupeV1.from_identity(identity)
+
+    record_id = derive_record_id(identity)
+    dedupe_key = derive_dedupe_key(dedupe)
+    expected_token = "".join(
+        ("mh_d1_yfzuu5qthlz3", "ocli7jeuybxump5", "uxg4a2ibabe6frv", "zohslqhwyq")
+    )
+
+    assert record_id == "mh_g3hdcz3y6hf7wf5puc2h77nm554bfl3e45vrdfyyartayjdogdga"
+    assert dedupe_key == expected_token
+    assert re.fullmatch(r"mh_[a-z2-7]{51}[aq]", record_id)
+    assert re.fullmatch(r"mh_d1_[a-z2-7]{51}[aq]", dedupe_key)
+    assert validate_record_id(record_id) == record_id
+    assert validate_dedupe_key(dedupe_key) == dedupe_key
+
+
+def test_generation_and_redaction_changes_do_not_change_dedupe_coordinates() -> None:
+    original = _identity()
+    changed = _identity(
+        source=_source(generation="1" * 64),
+        redaction_version="r2-e3",
+    )
+
+    assert derive_record_id(original) != derive_record_id(changed)
+    assert derive_dedupe_key(RecordDedupeV1.from_identity(original)) == derive_dedupe_key(
+        RecordDedupeV1.from_identity(changed)
+    )
+
+
+def test_installation_and_observation_changes_change_record_and_dedupe_ids() -> None:
+    original = _identity()
+    changed_installation = _identity(installation_id="mh_in1_11111111111141118111111111111111")
+    changed_observation = _identity(
+        observation=ObservationCoordinateV1(
+            kind="source.revision",
+            parts={"revision": 2},
+        )
+    )
+
+    for changed in (changed_installation, changed_observation):
+        assert derive_record_id(original) != derive_record_id(changed)
+        assert derive_dedupe_key(RecordDedupeV1.from_identity(original)) != derive_dedupe_key(
+            RecordDedupeV1.from_identity(changed)
+        )
+
+
+def test_content_hash_is_domain_separated_and_order_independent() -> None:
+    first = {"content_version": 1, "name": "source.event", "data": {"status": "ok"}}
+    reordered = {"data": {"status": "ok"}, "name": "source.event", "content_version": 1}
+
+    assert derive_content_hash(first) == derive_content_hash(reordered)
+    assert derive_content_hash(first) == (
+        "ae0a88c0cec9980e744d6c50ccb986d1a39664a887c86254cd5cbacdceae760e"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "mh_" + "a" * 51 + "b",
+        "mh_" + "A" * 52,
+        "mh_d1_" + "a" * 51 + "b",
+        1,
+    ],
+)
+def test_digest_token_validation_rejects_noncanonical_or_wrong_tokens(value: object) -> None:
+    validator = (
+        validate_dedupe_key
+        if isinstance(value, str) and value.startswith("mh_d1_")
+        else validate_record_id
+    )
+    with pytest.raises(IdentityError):
+        validator(value)  # type: ignore[arg-type]
+
+
+def test_identity_models_reject_unknown_fields_coercion_and_scope_mismatch() -> None:
+    with pytest.raises(ValidationError):
+        RecordIdentityV1.model_validate(
+            {
+                **_identity().model_dump(mode="python"),
+                "unknown": "field",
+            }
+        )
+
+    with pytest.raises(ValidationError):
+        ObservationCoordinateV1.model_validate(
+            {"kind": "source.revision", "parts": {"revision": b"1"}}
+        )
+
+    with pytest.raises(ValidationError):
+        _identity(scope="installation")
+
+    installation_identity = _identity(scope="installation", target_id=None)
+    dedupe = RecordDedupeV1.from_identity(installation_identity)
+    assert dedupe.source == DedupeSourceV1(
+        type="source.event",
+        id="example-source",
+        observation_namespace_id="mh_ns1_00000000000040008000000000000000",
+    )
+    assert dedupe.target_id is None


### PR DESCRIPTION
## Summary
- add bounded canonical JSON with Unicode/line normalization, deterministic key order, signed-64-bit and finite-float rules, and canonical UTC timestamps
- add injectable system/fixed clocks
- add strict record/dedupe identity projections and domain-separated SHA-256 wire IDs
- add golden, unit, and property coverage

## Validation
- `make quality`
- `make test` (749 passed, 1 skipped)
- `make test-coverage` (97.62% line, 96.47% branch)
- `make build package-check artifact-smoke`
- `make secret-scan-self-test secret-scan`
- private-identifier scan passed
- 50,000 accepted non-integral binary64 values cross-checked against ECMAScript `JSON.stringify` with zero mismatches

## Scope
This is a bounded W02 production foundation. It does not claim G02 completion; configuration, privacy/redaction, pseudonyms, safe rendering, durations, and structured logging remain separate W02 slices.