### PR TITLE
feat(config): add strict configuration foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,31 +1,20 @@
 # Required local settings
-MILHOUSE_CONFIG=./config/milhouse.toml
-MILHOUSE_CLICKHOUSE_DSN=http://localhost:8123/
+MILHOUSE_CONFIG=./config/example.toml
+MILHOUSE_CLICKHOUSE_URL=http://localhost:8123
 
-# Optional ClickHouse credentials
-MILHOUSE_CLICKHOUSE_USER=default
+# ClickHouse credentials for the canonical example
+MILHOUSE_CLICKHOUSE_USER=milhouse
 MILHOUSE_CLICKHOUSE_PASSWORD=
+
+# Optional authenticated receiver sources
+MILHOUSE_INGEST_EXAMPLE_SECRET=
+MILHOUSE_GITHUB_WEBHOOK_SECRET=
 
 # Optional Cloudflare collectors
 MILHOUSE_CLOUDFLARE_ACCOUNT_ID=
 MILHOUSE_CLOUDFLARE_TOKEN=
 MILHOUSE_CLOUDFLARE_WORKERS_TOKEN=
 
-# Optional generic service/admin collectors
-MILHOUSE_ADMIN_BASE_URL=
-MILHOUSE_ADMIN_TOKEN=
-
 # Optional Telegram notifications
 MILHOUSE_TELEGRAM_BOT_TOKEN=
 MILHOUSE_TELEGRAM_CHAT_ID=
-
-# Optional AI trace correlation
-OPENAI_API_KEY=
-ANTHROPIC_API_KEY=
-LANGSMITH_API_KEY=
-LANGSMITH_PROJECT=
-
-# Privacy and retention
-MILHOUSE_REDACTION_STRICT=true
-MILHOUSE_AGENT_TRACE_ENABLED=false
-MILHOUSE_RETENTION_DAYS=30

--- a/config/example.toml
+++ b/config/example.toml
@@ -1,58 +1,200 @@
+config_version = 1
+
 [project]
 name = "example-team"
 default_target = "example-app"
-feedback_dir = ".milhouse"
+timezone = "UTC"
 
-[store]
-kind = "clickhouse"
-dsn_env = "MILHOUSE_CLICKHOUSE_DSN"
-jsonl_spool = "spool"
-state_dir = "data/state"
-clickhouse_database = "milhouse"
+[paths]
+home = "../data"
+spool = "spool"
+reports = "reports"
+logs = "logs"
+backups = "backups"
+
+[secrets]
+env_files = ["../.env"]
+
+[identity]
+pseudonym_key_path = "control/pseudonym.key"
+
+[plugins]
+allow_third_party = false
+
+[runtime]
+mode = "full"
+log_level = "INFO"
+max_batch_records = 500
+max_batch_bytes = 5242880
+
+[storage.clickhouse]
+enabled = true
+url_env = "MILHOUSE_CLICKHOUSE_URL"
+username_env = "MILHOUSE_CLICKHOUSE_USER"
+password_env = "MILHOUSE_CLICKHOUSE_PASSWORD"
+database = "milhouse"
+connect_timeout_seconds = 5
 
 [privacy]
-strict_redaction = true
-agent_trace_enabled = false
-retain_days = 30
-store_raw_agent_transcripts = false
+strict = true
+agent_summaries_enabled = false
+agent_trace_events_enabled = false
+trace_excerpts_enabled = false
+hash_local_paths = true
 
-[[targets]]
-name = "example-app"
-kind = "web-service"
-environment = "production"
-base_url = "https://example.com"
+[retention]
+events_days = 30
+metrics_days = 90
+runs_days = 180
+alerts_days = 365
+feedback_days = 365
+agent_summaries_days = 30
+trace_events_days = 14
+reports_days = 90
+logs_days = 14
 
-[[collectors.site_canary]]
-target = "example-app"
-url = "https://example.com/health"
+[scheduler]
+enabled = true
+jitter_seconds = 5
+shutdown_timeout_seconds = 30
+
+[reports.daily]
+enabled = true
+
+[reports.weekly]
+enabled = true
+
+[[jobs]]
+id = "replay-pending"
+type = "spool_replay"
+enabled = true
+schedule = "interval"
 interval_seconds = 60
-timeout_seconds = 10
-expected_status = 200
+timeout_seconds = 30
+missed_run_policy = "run_once"
 
-[[collectors.browser_errors]]
-target = "example-app"
-source = "http"
-endpoint = "/milhouse/browser-error"
-enabled = false
+[[jobs]]
+id = "collect-example-canary"
+type = "collector"
+collector = "example-canary"
+enabled = true
+schedule = "interval"
+interval_seconds = 60
+timeout_seconds = 15
+missed_run_policy = "run_once"
 
-[[collectors.backend_errors]]
-target = "example-app"
-source = "http"
-endpoint = "/milhouse/backend-error"
-enabled = false
+[[jobs]]
+id = "verify-feedback"
+type = "feedback_verification"
+enabled = true
+schedule = "interval"
+interval_seconds = 300
+timeout_seconds = 60
+missed_run_policy = "run_once"
 
-[[collectors.deploy_events]]
-target = "example-app"
-source = "github-actions"
-enabled = false
+[[jobs]]
+id = "weekly-report"
+type = "weekly_report"
+enabled = true
+schedule = "weekly"
+weekday = "monday"
+local_time = "08:00"
+timeout_seconds = 120
+missed_run_policy = "run_once"
 
 [mcp]
 enabled = true
-read_only_by_default = true
+transport = "stdio"
+allow_writes = false
+default_limit = 100
+maximum_limit = 500
+maximum_window_days = 30
 
-[notifications.telegram]
+[postmortem]
+auto_on_doh_marker = true
+default_window_hours = 24
+scan_project_docs = true
+
+[receiver]
+enabled = false
+bind = "127.0.0.1"
+port = 8787
+allow_remote = false
+max_body_bytes = 262144
+requests_per_minute = 60
+clock_skew_seconds = 300
+
+[[receiver.sources]]
+id = "example-backend"
+type = "hmac_v1"
+target = "example-app"
+secret_env = "MILHOUSE_INGEST_EXAMPLE_SECRET"
+allowed_paths = [
+  "/v1/ingest/events",
+  "/v1/ingest/backend-errors",
+  "/v1/ingest/browser-errors",
+]
+
+[[receiver.sources]]
+id = "example-github-webhook"
+type = "github_webhook"
+target = "example-app"
+secret_env = "MILHOUSE_GITHUB_WEBHOOK_SECRET"
+repository = "example/example-app"
+
+[[targets]]
+id = "example-app"
+name = "Example App"
+kind = "web_service"
+environment = "production"
+base_url = "https://example.com"
+repo_path = "/absolute/path/to/example-app"
+
+[[collectors]]
+id = "example-canary"
+type = "site_canary"
+target = "example-app"
+url = "https://example.com/health"
+expected_statuses = [200]
+request_timeout_seconds = 10
+
+[[providers]]
+id = "example-cloudflare"
+type = "cloudflare"
+account_id_env = "MILHOUSE_CLOUDFLARE_ACCOUNT_ID"
+token_env = "MILHOUSE_CLOUDFLARE_TOKEN"
+
+[[notifications]]
+id = "team-telegram"
+type = "telegram"
 enabled = false
 bot_token_env = "MILHOUSE_TELEGRAM_BOT_TOKEN"
 chat_id_env = "MILHOUSE_TELEGRAM_CHAT_ID"
-weekly_summary = true
 urgent_alerts = true
+weekly_summary = true
+
+[[alert_rules]]
+id = "example-canary-state"
+type = "canary_state"
+collector = "example-canary"
+consecutive_failures = 2
+consecutive_successes = 2
+cooldown_seconds = 300
+
+[[incident_rules]]
+id = "example-availability-incident"
+target = "example-app"
+alert_rule_ids = ["example-canary-state"]
+group_dimensions = []
+correlation_horizon_seconds = 900
+quiet_window_seconds = 300
+
+[[feedback_rules]]
+id = "example-canary-recurrence"
+type = "recurrence"
+target = "example-app"
+record_names = ["canary.state_changed"]
+minimum_occurrences = 2
+window_seconds = 86400
+priority = "P1"
+actionability = "needs_approval"

--- a/config/examples/ai-agent-workflows.toml
+++ b/config/examples/ai-agent-workflows.toml
@@ -1,32 +1,146 @@
+config_version = 1
+
 [project]
 name = "agent-workflow-example"
 default_target = "example-app"
-feedback_dir = ".milhouse"
+timezone = "UTC"
 
-[store]
-kind = "clickhouse"
-dsn_env = "MILHOUSE_CLICKHOUSE_DSN"
-jsonl_spool = "spool"
-state_dir = "data/state"
+[paths]
+home = "../../data/ai-agent-workflows"
+spool = "spool"
+reports = "reports"
+logs = "logs"
+backups = "backups"
+
+[secrets]
+env_files = []
+
+[identity]
+pseudonym_key_path = "control/pseudonym.key"
+
+[plugins]
+allow_third_party = false
+
+[runtime]
+mode = "spool_only"
+log_level = "INFO"
+max_batch_records = 250
+max_batch_bytes = 2097152
+
+[storage.clickhouse]
+enabled = false
+url_env = "MILHOUSE_CLICKHOUSE_URL"
+username_env = "MILHOUSE_CLICKHOUSE_USER"
+password_env = "MILHOUSE_CLICKHOUSE_PASSWORD"
+database = "milhouse"
+connect_timeout_seconds = 5
 
 [privacy]
-strict_redaction = true
-agent_trace_enabled = true
-store_raw_agent_transcripts = false
-retain_days = 14
+strict = true
+agent_summaries_enabled = true
+agent_trace_events_enabled = true
+trace_excerpts_enabled = false
+hash_local_paths = true
 
-[[collectors.agent_sessions]]
-agent = "codex"
-enabled = true
-source = "local-session-summary"
-paths = []
+[retention]
+events_days = 30
+metrics_days = 90
+runs_days = 180
+alerts_days = 365
+feedback_days = 365
+agent_summaries_days = 30
+trace_events_days = 14
+reports_days = 90
+logs_days = 14
 
-[[collectors.agent_sessions]]
-agent = "claude-code"
+[scheduler]
 enabled = true
-source = "local-session-summary"
-paths = []
+jitter_seconds = 5
+shutdown_timeout_seconds = 30
 
-[[collectors.feedback_outbox]]
+[reports.daily]
+enabled = false
+
+[reports.weekly]
 enabled = true
-repo_globs = ["~/work/*/.milhouse/feedback-outbox.jsonl"]
+
+[[jobs]]
+id = "collect-codex-sessions"
+type = "collector"
+collector = "codex-sessions"
+enabled = true
+schedule = "interval"
+interval_seconds = 300
+timeout_seconds = 60
+missed_run_policy = "run_once"
+
+[[jobs]]
+id = "collect-claude-sessions"
+type = "collector"
+collector = "claude-sessions"
+enabled = true
+schedule = "interval"
+interval_seconds = 300
+timeout_seconds = 60
+missed_run_policy = "run_once"
+
+[[jobs]]
+id = "curate-feedback"
+type = "feedback_curation"
+enabled = true
+schedule = "interval"
+interval_seconds = 300
+timeout_seconds = 60
+missed_run_policy = "run_once"
+
+[mcp]
+enabled = true
+transport = "stdio"
+allow_writes = false
+default_limit = 100
+maximum_limit = 500
+maximum_window_days = 30
+
+[postmortem]
+auto_on_doh_marker = true
+default_window_hours = 24
+scan_project_docs = true
+
+[receiver]
+enabled = false
+bind = "127.0.0.1"
+port = 8787
+allow_remote = false
+max_body_bytes = 262144
+requests_per_minute = 60
+clock_skew_seconds = 300
+
+[[targets]]
+id = "example-app"
+name = "Example App"
+kind = "local_app"
+environment = "development"
+repo_path = "/absolute/path/to/example-app"
+
+[[collectors]]
+id = "codex-sessions"
+type = "codex_session"
+target = "example-app"
+sessions_root = "/absolute/path/to/codex/sessions"
+target_repo_mapping = { example-repo = "example-app" }
+trace_categories = ["summary", "tool_event"]
+
+[[collectors]]
+id = "claude-sessions"
+type = "claude_session"
+target = "example-app"
+projects_root = "/absolute/path/to/claude/projects"
+target_repo_mapping = { example-repo = "example-app" }
+trace_categories = ["summary", "tool_event"]
+
+[[collectors]]
+id = "feedback-outbox"
+type = "file_outbox"
+target = "example-app"
+path = ".milhouse/feedback-outbox.jsonl"
+producer_allowlist = ["codex", "claude-code"]

--- a/config/examples/cloudflare-sites.toml
+++ b/config/examples/cloudflare-sites.toml
@@ -1,34 +1,140 @@
+config_version = 1
+
 [project]
 name = "cloudflare-example"
 default_target = "marketing-site"
-feedback_dir = ".milhouse"
+timezone = "UTC"
 
-[store]
-kind = "clickhouse"
-dsn_env = "MILHOUSE_CLICKHOUSE_DSN"
-jsonl_spool = "spool"
-state_dir = "data/state"
+[paths]
+home = "../../data/cloudflare-sites"
+spool = "spool"
+reports = "reports"
+logs = "logs"
+backups = "backups"
 
-[cloudflare]
+[secrets]
+env_files = ["../../.env"]
+
+[identity]
+pseudonym_key_path = "control/pseudonym.key"
+
+[plugins]
+allow_third_party = false
+
+[runtime]
+mode = "full"
+log_level = "INFO"
+max_batch_records = 500
+max_batch_bytes = 5242880
+
+[storage.clickhouse]
+enabled = true
+url_env = "MILHOUSE_CLICKHOUSE_URL"
+username_env = "MILHOUSE_CLICKHOUSE_USER"
+password_env = "MILHOUSE_CLICKHOUSE_PASSWORD"
+database = "milhouse"
+connect_timeout_seconds = 5
+
+[privacy]
+strict = true
+agent_summaries_enabled = false
+agent_trace_events_enabled = false
+trace_excerpts_enabled = false
+hash_local_paths = true
+
+[retention]
+events_days = 30
+metrics_days = 90
+runs_days = 180
+alerts_days = 365
+feedback_days = 365
+agent_summaries_days = 30
+trace_events_days = 14
+reports_days = 90
+logs_days = 14
+
+[scheduler]
+enabled = true
+jitter_seconds = 5
+shutdown_timeout_seconds = 30
+
+[reports.daily]
+enabled = true
+
+[reports.weekly]
+enabled = true
+
+[[jobs]]
+id = "collect-site-canary"
+type = "collector"
+collector = "marketing-canary"
+enabled = true
+schedule = "interval"
+interval_seconds = 60
+timeout_seconds = 15
+missed_run_policy = "run_once"
+
+[[jobs]]
+id = "collect-cloudflare-metrics"
+type = "collector"
+collector = "cloudflare-metrics"
+enabled = true
+schedule = "interval"
+interval_seconds = 300
+timeout_seconds = 60
+missed_run_policy = "run_once"
+
+[mcp]
+enabled = true
+transport = "stdio"
+allow_writes = false
+default_limit = 100
+maximum_limit = 500
+maximum_window_days = 30
+
+[postmortem]
+auto_on_doh_marker = true
+default_window_hours = 24
+scan_project_docs = true
+
+[receiver]
+enabled = false
+bind = "127.0.0.1"
+port = 8787
+allow_remote = false
+max_body_bytes = 262144
+requests_per_minute = 60
+clock_skew_seconds = 300
+
+[[targets]]
+id = "marketing-site"
+name = "Marketing Site"
+kind = "cloudflare_worker"
+environment = "production"
+base_url = "https://www.example.com"
+
+[[providers]]
+id = "cloudflare-primary"
+type = "cloudflare"
 account_id_env = "MILHOUSE_CLOUDFLARE_ACCOUNT_ID"
 token_env = "MILHOUSE_CLOUDFLARE_TOKEN"
 workers_token_env = "MILHOUSE_CLOUDFLARE_WORKERS_TOKEN"
 
-[[targets]]
-name = "marketing-site"
-kind = "cloudflare-worker"
-environment = "production"
-base_url = "https://www.example.com"
-
-[[collectors.site_canary]]
+[[collectors]]
+id = "marketing-canary"
+type = "site_canary"
 target = "marketing-site"
 url = "https://www.example.com"
-interval_seconds = 60
-timeout_seconds = 10
-expected_status = 200
+expected_statuses = [200]
+request_timeout_seconds = 10
 
-[[collectors.cloudflare_web_analytics]]
+[[collectors]]
+id = "cloudflare-metrics"
+type = "cloudflare"
 target = "marketing-site"
-enabled = false
-zone_tag_env = "MILHOUSE_EXAMPLE_ZONE_TAG"
-rum_site_tag_env = "MILHOUSE_EXAMPLE_RUM_SITE_TAG"
+provider = "cloudflare-primary"
+zone_account_mapping = { example-zone = "primary" }
+metric_families = ["requests", "errors"]
+late_arrival_overlap_seconds = 300
+page_size = 100
+window_seconds = 300

--- a/config/examples/local-only.toml
+++ b/config/examples/local-only.toml
@@ -1,28 +1,102 @@
+config_version = 1
+
 [project]
 name = "local-lab"
 default_target = "local-tool"
-feedback_dir = ".milhouse"
+timezone = "UTC"
 
-[store]
-kind = "clickhouse"
-dsn_env = "MILHOUSE_CLICKHOUSE_DSN"
-jsonl_spool = "spool"
-state_dir = "data/state"
+[paths]
+home = "../../data/local-only"
+spool = "spool"
+reports = "reports"
+logs = "logs"
+backups = "backups"
+
+[secrets]
+env_files = []
+
+[identity]
+pseudonym_key_path = "control/pseudonym.key"
+
+[plugins]
+allow_third_party = false
+
+[runtime]
+mode = "spool_only"
+log_level = "INFO"
+max_batch_records = 100
+max_batch_bytes = 1048576
+
+[storage.clickhouse]
+enabled = false
+url_env = "MILHOUSE_CLICKHOUSE_URL"
+username_env = "MILHOUSE_CLICKHOUSE_USER"
+password_env = "MILHOUSE_CLICKHOUSE_PASSWORD"
+database = "milhouse"
+connect_timeout_seconds = 5
 
 [privacy]
-strict_redaction = true
-agent_trace_enabled = false
-store_raw_agent_transcripts = false
+strict = true
+agent_summaries_enabled = false
+agent_trace_events_enabled = false
+trace_excerpts_enabled = false
+hash_local_paths = true
+
+[retention]
+events_days = 30
+metrics_days = 90
+runs_days = 180
+alerts_days = 365
+feedback_days = 365
+agent_summaries_days = 30
+trace_events_days = 14
+reports_days = 90
+logs_days = 14
+
+[scheduler]
+enabled = false
+jitter_seconds = 5
+shutdown_timeout_seconds = 30
+
+[reports.daily]
+enabled = false
+
+[reports.weekly]
+enabled = false
+
+[mcp]
+enabled = true
+transport = "stdio"
+allow_writes = false
+default_limit = 100
+maximum_limit = 500
+maximum_window_days = 30
+
+[postmortem]
+auto_on_doh_marker = false
+default_window_hours = 24
+scan_project_docs = false
+
+[receiver]
+enabled = false
+bind = "127.0.0.1"
+port = 8787
+allow_remote = false
+max_body_bytes = 262144
+requests_per_minute = 60
+clock_skew_seconds = 300
 
 [[targets]]
-name = "local-tool"
-kind = "local-app"
+id = "local-tool"
+name = "Local Tool"
+kind = "local_app"
 environment = "development"
 base_url = "http://localhost:3000"
 
-[[collectors.site_canary]]
+[[collectors]]
+id = "local-canary"
+type = "site_canary"
 target = "local-tool"
 url = "http://localhost:3000"
-interval_seconds = 60
-timeout_seconds = 5
-expected_status = 200
+expected_statuses = [200]
+request_timeout_seconds = 5

--- a/src/milhouse/config/__init__.py
+++ b/src/milhouse/config/__init__.py
@@ -1,0 +1,34 @@
+"""Milhouse configuration v1: strict Pydantic models, loader, and JSON Schema."""
+
+from __future__ import annotations
+
+from milhouse.config.loader import (
+    CONFIG_PATH_ENV_VAR,
+    MAX_CONFIG_BYTES,
+    ConfigError,
+    load_config,
+    load_config_file,
+    resolve_config_path,
+)
+from milhouse.config.models import CONFIG_VERSION, MilhouseConfig
+from milhouse.config.schema import (
+    JSON_SCHEMA_DIALECT,
+    JSON_SCHEMA_ID,
+    generate_json_schema,
+    generate_json_schema_bytes,
+)
+
+__all__ = [
+    "CONFIG_PATH_ENV_VAR",
+    "CONFIG_VERSION",
+    "JSON_SCHEMA_DIALECT",
+    "JSON_SCHEMA_ID",
+    "MAX_CONFIG_BYTES",
+    "ConfigError",
+    "MilhouseConfig",
+    "generate_json_schema",
+    "generate_json_schema_bytes",
+    "load_config",
+    "load_config_file",
+    "resolve_config_path",
+]

--- a/src/milhouse/config/loader.py
+++ b/src/milhouse/config/loader.py
@@ -1,0 +1,215 @@
+"""Config path precedence, bounded TOML loading, and stable load errors."""
+
+from __future__ import annotations
+
+import errno
+import os
+import re
+import stat
+import tomllib
+from collections.abc import Mapping
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from milhouse.config.models import CONFIG_VERSION, MilhouseConfig
+
+CONFIG_PATH_ENV_VAR = "MILHOUSE_CONFIG"
+MAX_CONFIG_BYTES = 1_048_576
+
+_TOML_LOCATION_PATTERN = re.compile(r"at line (\d+), column (\d+)")
+
+
+class ConfigError(Exception):
+    """A stable, value-free configuration loading or validation failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+def resolve_config_path(
+    cli_path: str | Path | None,
+    *,
+    platform_default: str | Path,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    """Resolve the config file path: ``--config``, then ``MILHOUSE_CONFIG``, then the
+    caller-supplied platform default. The current working directory is never searched."""
+
+    if cli_path is not None:
+        if str(cli_path) == "":
+            raise ConfigError("config.path.invalid", "--config must not be empty")
+        return Path(cli_path)
+
+    environment = os.environ if env is None else env
+    env_value = environment.get(CONFIG_PATH_ENV_VAR)
+    if env_value:
+        return Path(env_value)
+
+    return Path(platform_default)
+
+
+def _read_config_text(path: Path) -> str:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    flags |= nofollow
+    before: os.stat_result | None = None
+
+    try:
+        if nofollow == 0:
+            before = os.lstat(path)
+            if stat.S_ISLNK(before.st_mode):
+                raise ConfigError("config.file.not_regular", "config path must not be a symlink")
+        descriptor = os.open(path, flags)
+    except FileNotFoundError:
+        raise ConfigError("config.file.not_found", "config file was not found") from None
+    except ConfigError:
+        raise
+    except ValueError:
+        raise ConfigError("config.path.invalid", "config path is invalid") from None
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise ConfigError(
+                "config.file.not_regular", "config path must not be a symlink"
+            ) from None
+        raise ConfigError("config.file.unreadable", "config file could not be opened") from None
+
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ConfigError("config.file.not_regular", "config path must be a regular file")
+        if before is not None and (before.st_dev, before.st_ino) != (
+            metadata.st_dev,
+            metadata.st_ino,
+        ):
+            raise ConfigError(
+                "config.file.changed", "config file changed while it was being opened"
+            )
+        if metadata.st_size > MAX_CONFIG_BYTES:
+            raise ConfigError(
+                "config.file.too_large",
+                f"config file exceeds the {MAX_CONFIG_BYTES}-byte bound",
+            )
+    except ConfigError:
+        os.close(descriptor)
+        raise
+    except OSError:
+        os.close(descriptor)
+        raise ConfigError("config.file.unreadable", "config file could not be read") from None
+
+    try:
+        stream = os.fdopen(descriptor, "rb", closefd=True)
+    except OSError:
+        os.close(descriptor)
+        raise ConfigError("config.file.unreadable", "config file could not be read") from None
+
+    try:
+        with stream:
+            raw = stream.read(MAX_CONFIG_BYTES + 1)
+            after_read = os.fstat(stream.fileno())
+            if (
+                metadata.st_dev,
+                metadata.st_ino,
+                metadata.st_size,
+                metadata.st_mtime_ns,
+                metadata.st_ctime_ns,
+            ) != (
+                after_read.st_dev,
+                after_read.st_ino,
+                after_read.st_size,
+                after_read.st_mtime_ns,
+                after_read.st_ctime_ns,
+            ):
+                raise ConfigError(
+                    "config.file.changed", "config file changed while it was being read"
+                )
+    except ConfigError:
+        raise
+    except OSError:
+        raise ConfigError("config.file.unreadable", "config file could not be read") from None
+
+    if not raw:
+        raise ConfigError("config.file.empty", "config file is empty")
+    if len(raw) > MAX_CONFIG_BYTES:
+        raise ConfigError(
+            "config.file.too_large",
+            f"config file exceeds the {MAX_CONFIG_BYTES}-byte bound",
+        )
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        raise ConfigError(
+            "config.file.unreadable", "config file could not be read as UTF-8"
+        ) from None
+
+
+def _extract_toml_location(message: str) -> str | None:
+    match = _TOML_LOCATION_PATTERN.search(message)
+    if match is None:
+        return None
+    return f"line {match.group(1)}, column {match.group(2)}"
+
+
+def _parse_toml(text: str) -> dict[str, object]:
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        location = _extract_toml_location(str(exc))
+        message = "config file contains invalid TOML syntax"
+        if location:
+            message = f"{message} ({location})"
+        raise ConfigError("config.toml.syntax", message) from None
+    return data
+
+
+def _check_config_version(data: Mapping[str, object]) -> None:
+    version = data.get("config_version")
+    if type(version) is int and version == CONFIG_VERSION:
+        return
+    raise ConfigError("config.version.unsupported", f"config_version must equal {CONFIG_VERSION}")
+
+
+def _validate_model(data: Mapping[str, object]) -> MilhouseConfig:
+    try:
+        return MilhouseConfig.model_validate(data)
+    except ValidationError as exc:
+        details = "; ".join(
+            f"{'.'.join(str(part) for part in error['loc'])}: {error['msg']}"
+            for error in exc.errors()
+        )
+        raise ConfigError(
+            "config.schema.invalid", details or "config failed schema validation"
+        ) from None
+
+
+def load_config_file(path: str | Path) -> MilhouseConfig:
+    """Load and strictly validate a bounded, regular-file TOML config document."""
+
+    text = _read_config_text(Path(path))
+    data = _parse_toml(text)
+    _check_config_version(data)
+    return _validate_model(data)
+
+
+def load_config(
+    cli_path: str | Path | None,
+    *,
+    platform_default: str | Path,
+    env: Mapping[str, str] | None = None,
+) -> tuple[MilhouseConfig, Path]:
+    """Resolve the config path by precedence, then load and validate it."""
+
+    path = resolve_config_path(cli_path, platform_default=platform_default, env=env)
+    return load_config_file(path), path
+
+
+__all__ = [
+    "CONFIG_PATH_ENV_VAR",
+    "MAX_CONFIG_BYTES",
+    "ConfigError",
+    "load_config",
+    "load_config_file",
+    "resolve_config_path",
+]

--- a/src/milhouse/config/models.py
+++ b/src/milhouse/config/models.py
@@ -1,0 +1,950 @@
+"""Strict Pydantic v2 domain models for Milhouse configuration v1."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from datetime import UTC, datetime, timedelta
+from typing import Annotated, Literal, Protocol
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    IPvAnyAddress,
+    StringConstraints,
+    UrlConstraints,
+    model_validator,
+)
+from pydantic_core import Url
+
+CONFIG_VERSION = 1
+
+_ID_PATTERN = r"^[a-z][a-z0-9_-]{0,63}$"
+_ENV_VAR_PATTERN = r"^[A-Z][A-Z0-9_]{0,127}$"
+_DIMENSION_KEY_PATTERN = r"^[a-z][a-z0-9_]{0,63}$"
+_MACHINE_NAME_PATTERN = r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$"
+_LOCAL_TIME_PATTERN = r"^([01][0-9]|2[0-3]):[0-5][0-9]$"
+_REPOSITORY_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,99}/[A-Za-z0-9][A-Za-z0-9._-]{0,99}$"
+_DISTRIBUTION_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+_PLUGIN_VERSION_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9.+_-]{0,63}$"
+_ENTRY_POINT_PATTERN = r"^[A-Za-z_][A-Za-z0-9_.]{0,127}:[A-Za-z_][A-Za-z0-9_.]{0,127}$"
+_CLICKHOUSE_IDENTIFIER_PATTERN = _ID_PATTERN
+_ADMIN_API_PATH_PATTERN = r"^/[A-Za-z0-9/_-]{0,255}$"
+_TIMEZONE_PATTERN = r"^[A-Za-z0-9_+\-/]{1,64}$"
+_NO_CONTROL_CHARS_PATTERN = r"^[^\x00-\x1f\x7f]{1,4096}$"
+_GITHUB_API_VERSION_PATTERN = r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+
+_SECONDS_MAX = 86400
+_DAYS_MAX = 3650
+_BYTES_MAX = 1_073_741_824
+_COUNT_MAX = 1_000_000
+
+
+def _validate_timezone(value: str) -> str:
+    try:
+        ZoneInfo(value)
+    except (ValueError, ZoneInfoNotFoundError) as exc:
+        raise ValueError("timezone must be a known IANA zone name") from exc
+    return value
+
+
+def _reject_dotdot_segments(value: str, *, allow_leading_slash: bool) -> list[str]:
+    if value.startswith("/"):
+        if not allow_leading_slash:
+            raise ValueError("path must be relative, not absolute")
+        segments = value[1:].split("/")
+    else:
+        segments = value.split("/")
+    if any(segment in ("", ".", "..") for segment in segments):
+        raise ValueError("path must not contain empty, '.', or '..' segments")
+    return segments
+
+
+def _validate_relative_path(value: str) -> str:
+    _reject_dotdot_segments(value, allow_leading_slash=False)
+    return value
+
+
+def _validate_absolute_path(value: str) -> str:
+    if not value.startswith("/"):
+        raise ValueError("path must be an absolute canonical path")
+    _reject_dotdot_segments(value, allow_leading_slash=True)
+    return value
+
+
+def _validate_class_specific_path(value: str) -> str:
+    _reject_dotdot_segments(value, allow_leading_slash=True)
+    return value
+
+
+def _validate_future_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() != timedelta(0):
+        raise ValueError("timestamp must be RFC3339 with a zero UTC offset")
+    if value <= datetime.now(UTC):
+        raise ValueError("timestamp must be in the future")
+    return value
+
+
+def _require_unique(values: Sequence[str], *, label: str) -> list[str]:
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            raise ValueError(f"{label} contains a duplicate entry")
+        seen.add(value)
+    return list(values)
+
+
+Identifier = Annotated[str, StringConstraints(pattern=_ID_PATTERN)]
+EnvVarRef = Annotated[str, StringConstraints(pattern=_ENV_VAR_PATTERN)]
+DimensionKey = Annotated[str, StringConstraints(pattern=_DIMENSION_KEY_PATTERN)]
+MachineName = Annotated[str, StringConstraints(pattern=_MACHINE_NAME_PATTERN, max_length=128)]
+LocalTime = Annotated[str, StringConstraints(pattern=_LOCAL_TIME_PATTERN)]
+RepositorySlug = Annotated[str, StringConstraints(pattern=_REPOSITORY_PATTERN)]
+PluginDistribution = Annotated[str, StringConstraints(pattern=_DISTRIBUTION_PATTERN)]
+PluginVersion = Annotated[str, StringConstraints(pattern=_PLUGIN_VERSION_PATTERN)]
+PluginEntryPoint = Annotated[str, StringConstraints(pattern=_ENTRY_POINT_PATTERN)]
+ClickHouseIdentifier = Annotated[str, StringConstraints(pattern=_CLICKHOUSE_IDENTIFIER_PATTERN)]
+AdminApiPath = Annotated[str, StringConstraints(pattern=_ADMIN_API_PATH_PATTERN)]
+GithubApiVersion = Annotated[str, StringConstraints(pattern=_GITHUB_API_VERSION_PATTERN)]
+BoundedText64 = Annotated[str, StringConstraints(pattern=_NO_CONTROL_CHARS_PATTERN, max_length=64)]
+BoundedText128 = Annotated[
+    str, StringConstraints(pattern=_NO_CONTROL_CHARS_PATTERN, max_length=128)
+]
+BoundedText255 = Annotated[
+    str, StringConstraints(pattern=_NO_CONTROL_CHARS_PATTERN, max_length=255)
+]
+BoundedText512 = Annotated[
+    str, StringConstraints(pattern=_NO_CONTROL_CHARS_PATTERN, max_length=512)
+]
+IanaTimezone = Annotated[
+    str, StringConstraints(pattern=_TIMEZONE_PATTERN), AfterValidator(_validate_timezone)
+]
+RelativePathStr = Annotated[
+    str,
+    StringConstraints(pattern=_NO_CONTROL_CHARS_PATTERN),
+    AfterValidator(_validate_relative_path),
+]
+AbsolutePathStr = Annotated[
+    str,
+    StringConstraints(pattern=_NO_CONTROL_CHARS_PATTERN),
+    AfterValidator(_validate_absolute_path),
+]
+ClassSpecificPathStr = Annotated[
+    str,
+    StringConstraints(pattern=_NO_CONTROL_CHARS_PATTERN),
+    AfterValidator(_validate_class_specific_path),
+]
+ConfigDirRelativePathStr = Annotated[str, StringConstraints(pattern=_NO_CONTROL_CHARS_PATTERN)]
+FutureUtcDatetime = Annotated[datetime, AfterValidator(_validate_future_utc_datetime)]
+HttpsUrl = Annotated[Url, UrlConstraints(allowed_schemes=["https"])]
+
+
+class _HasId(Protocol):
+    id: str
+
+
+class StrictModel(BaseModel):
+    """Base model shared by every Milhouse configuration node."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+def require_unique_ids(items: Sequence[_HasId], *, label: str) -> frozenset[str]:
+    ids = [item.id for item in items]
+    _require_unique(ids, label=label)
+    return frozenset(ids)
+
+
+# --- 4.1 project, paths, secrets, identity, plugins, runtime -------------
+
+
+class ProjectConfig(StrictModel):
+    name: Identifier
+    default_target: Identifier
+    timezone: IanaTimezone
+
+
+class PathsConfig(StrictModel):
+    home: ConfigDirRelativePathStr
+    spool: ClassSpecificPathStr
+    reports: ClassSpecificPathStr
+    logs: ClassSpecificPathStr
+    backups: ClassSpecificPathStr
+
+
+class SecretsConfig(StrictModel):
+    env_files: list[ConfigDirRelativePathStr] = Field(default_factory=list)
+
+
+class IdentityConfig(StrictModel):
+    pseudonym_key_path: ClassSpecificPathStr
+
+
+class PluginAllowlistEntry(StrictModel):
+    distribution: PluginDistribution
+    version: PluginVersion
+    group: Literal["milhouse.collectors", "milhouse.notifications", "milhouse.exporters"]
+    entry_point: PluginEntryPoint
+
+
+class PluginsConfig(StrictModel):
+    allow_third_party: bool = False
+    allowed: list[PluginAllowlistEntry] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _check_unique_allowlist(self) -> PluginsConfig:
+        keys = [(entry.distribution, entry.group, entry.entry_point) for entry in self.allowed]
+        _require_unique([str(key) for key in keys], label="plugins.allowed")
+        if not self.allow_third_party and self.allowed:
+            raise ValueError("plugins.allowed requires allow_third_party=true")
+        return self
+
+
+class RuntimeConfig(StrictModel):
+    mode: Literal["full", "spool_only"]
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+    max_batch_records: int = Field(ge=1, le=_COUNT_MAX)
+    max_batch_bytes: int = Field(ge=1, le=_BYTES_MAX)
+
+
+class StorageClickHouseConfig(StrictModel):
+    enabled: bool
+    url_env: EnvVarRef
+    username_env: EnvVarRef
+    password_env: EnvVarRef
+    database: ClickHouseIdentifier
+    connect_timeout_seconds: int = Field(ge=1, le=_SECONDS_MAX)
+
+
+class StorageConfig(StrictModel):
+    clickhouse: StorageClickHouseConfig
+
+
+class PrivacyConfig(StrictModel):
+    strict: bool
+    agent_summaries_enabled: bool = False
+    agent_trace_events_enabled: bool = False
+    trace_excerpts_enabled: Literal[False] = False
+    hash_local_paths: bool = True
+
+
+class RetentionConfig(StrictModel):
+    events_days: int = Field(ge=1, le=_DAYS_MAX)
+    metrics_days: int = Field(ge=1, le=_DAYS_MAX)
+    runs_days: int = Field(ge=1, le=_DAYS_MAX)
+    alerts_days: int = Field(ge=1, le=_DAYS_MAX)
+    feedback_days: int = Field(ge=1, le=_DAYS_MAX)
+    agent_summaries_days: int = Field(ge=1, le=_DAYS_MAX)
+    trace_events_days: int = Field(ge=1, le=_DAYS_MAX)
+    reports_days: int = Field(ge=1, le=_DAYS_MAX)
+    logs_days: int = Field(ge=1, le=_DAYS_MAX)
+
+
+class SchedulerConfig(StrictModel):
+    enabled: bool
+    jitter_seconds: int = Field(ge=0, le=_SECONDS_MAX)
+    shutdown_timeout_seconds: int = Field(ge=1, le=_SECONDS_MAX)
+
+
+class ReportScheduleConfig(StrictModel):
+    enabled: bool
+
+
+class ReportsConfig(StrictModel):
+    daily: ReportScheduleConfig
+    weekly: ReportScheduleConfig
+
+
+class MCPConfig(StrictModel):
+    enabled: bool
+    transport: Literal["stdio"]
+    allow_writes: bool = False
+    default_limit: int = Field(ge=1, le=_COUNT_MAX)
+    maximum_limit: int = Field(ge=1, le=_COUNT_MAX)
+    maximum_window_days: int = Field(ge=1, le=_DAYS_MAX)
+
+    @model_validator(mode="after")
+    def _check_limit_order(self) -> MCPConfig:
+        if self.default_limit > self.maximum_limit:
+            raise ValueError("mcp.default_limit must not exceed mcp.maximum_limit")
+        return self
+
+
+class PostmortemConfig(StrictModel):
+    auto_on_doh_marker: bool
+    default_window_hours: int = Field(ge=1, le=720)
+    scan_project_docs: bool
+
+
+# --- 4.12 ingestion receiver ------------------------------------------------
+
+
+class _ReceiverSourceBase(StrictModel):
+    id: Identifier
+    target: Identifier
+    secret_env: EnvVarRef
+    previous_secret_env: EnvVarRef | None = None
+    previous_secret_expires_at: FutureUtcDatetime | None = None
+
+    @model_validator(mode="after")
+    def _check_previous_secret_pair(self) -> _ReceiverSourceBase:
+        has_env = self.previous_secret_env is not None
+        has_deadline = self.previous_secret_expires_at is not None
+        if has_env != has_deadline:
+            raise ValueError(
+                "previous_secret_env and previous_secret_expires_at must both be set or both absent"
+            )
+        if has_env and self.previous_secret_env == self.secret_env:
+            raise ValueError("previous_secret_env must differ from secret_env")
+        return self
+
+
+class HmacIngestSource(_ReceiverSourceBase):
+    type: Literal["hmac_v1"]
+    allowed_paths: list[
+        Literal[
+            "/v1/ingest/events",
+            "/v1/ingest/backend-errors",
+            "/v1/ingest/browser-errors",
+        ]
+    ] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _check_unique_paths(self) -> HmacIngestSource:
+        _require_unique(self.allowed_paths, label="allowed_paths")
+        return self
+
+
+class GithubWebhookSource(_ReceiverSourceBase):
+    type: Literal["github_webhook"]
+    repository: RepositorySlug
+
+
+ReceiverSource = Annotated[HmacIngestSource | GithubWebhookSource, Field(discriminator="type")]
+
+
+class ReceiverConfig(StrictModel):
+    enabled: bool = False
+    bind: IPvAnyAddress
+    port: int = Field(ge=1, le=65535)
+    allow_remote: bool = False
+    max_body_bytes: int = Field(ge=1, le=_BYTES_MAX)
+    requests_per_minute: int = Field(ge=1, le=_COUNT_MAX)
+    clock_skew_seconds: int = Field(ge=1, le=_SECONDS_MAX)
+    sources: list[ReceiverSource] = Field(default_factory=list)
+
+
+# --- targets -----------------------------------------------------------------
+
+
+class TargetConfig(StrictModel):
+    id: Identifier
+    name: Annotated[str, StringConstraints(pattern=_NO_CONTROL_CHARS_PATTERN, max_length=200)]
+    kind: Identifier
+    environment: Identifier
+    base_url: HttpUrl | None = None
+    repo_path: AbsolutePathStr | None = None
+
+
+# --- 4.8 collectors ------------------------------------------------------------
+
+
+class _CollectorBase(StrictModel):
+    id: Identifier
+    target: Identifier
+    request_timeout_seconds: int = Field(ge=1, le=300, default=30)
+
+
+class SiteCanaryCollector(_CollectorBase):
+    type: Literal["site_canary"]
+    url: HttpUrl
+    expected_statuses: list[int] = Field(min_length=1)
+    follow_redirects: bool = False
+    verify_tls: bool = True
+
+    @model_validator(mode="after")
+    def _check_statuses(self) -> SiteCanaryCollector:
+        for status in self.expected_statuses:
+            if not 100 <= status <= 599:
+                raise ValueError("expected_statuses entries must be valid HTTP status codes")
+        _require_unique([str(s) for s in self.expected_statuses], label="expected_statuses")
+        return self
+
+
+class FileOutboxCollector(_CollectorBase):
+    type: Literal["file_outbox"]
+    path: RelativePathStr
+    producer_allowlist: list[Identifier] = Field(default_factory=list)
+    max_line_bytes: int = Field(ge=1, le=_BYTES_MAX, default=65536)
+    max_file_bytes: int = Field(ge=1, le=_BYTES_MAX, default=104857600)
+    ack_filename: BoundedText255 = "outbox-ack.json"
+    rotation_glob: BoundedText255 | None = None
+
+
+class ErrorReportFileCollector(_CollectorBase):
+    type: Literal["error_report_file"]
+    path: ConfigDirRelativePathStr
+    input_schema_version: int = Field(ge=1, le=1000)
+    mode: Literal["json", "jsonl"] = "jsonl"
+    max_record_bytes: int = Field(ge=1, le=_BYTES_MAX, default=65536)
+
+
+class WorkflowFileCollector(_CollectorBase):
+    type: Literal["workflow_file"]
+    path: ConfigDirRelativePathStr
+    input_schema_version: int = Field(ge=1, le=1000)
+    mode: Literal["json", "jsonl"] = "jsonl"
+    workflow_run_type_mapping: dict[Identifier, Identifier] = Field(default_factory=dict)
+
+
+class CloudflareCollector(_CollectorBase):
+    type: Literal["cloudflare"]
+    provider: Identifier
+    zone_account_mapping: dict[Identifier, Identifier] = Field(min_length=1)
+    metric_families: list[Identifier] = Field(min_length=1)
+    late_arrival_overlap_seconds: int = Field(ge=0, le=_SECONDS_MAX, default=0)
+    page_size: int = Field(ge=1, le=1000, default=100)
+    window_seconds: int = Field(ge=1, le=_SECONDS_MAX, default=300)
+
+    @model_validator(mode="after")
+    def _check_unique_families(self) -> CloudflareCollector:
+        _require_unique(self.metric_families, label="metric_families")
+        return self
+
+
+class GithubActionsCollector(_CollectorBase):
+    type: Literal["github_actions"]
+    provider: Identifier
+    repository: RepositorySlug
+    workflow_allowlist: list[BoundedText255] = Field(default_factory=list)
+    environment_allowlist: list[Identifier] = Field(default_factory=list)
+    polling_lookback_seconds: int = Field(ge=1, le=_SECONDS_MAX, default=3600)
+    page_size: int = Field(ge=1, le=1000, default=100)
+    include_deployments: bool = False
+
+
+class GenericAdminApiFieldMapping(StrictModel):
+    source_pointer: BoundedText512
+    record_field: MachineName
+
+
+class GenericAdminApiCollector(_CollectorBase):
+    type: Literal["generic_admin_api"]
+    provider: Identifier
+    base_url: HttpsUrl
+    path: AdminApiPath
+    field_mappings: list[GenericAdminApiFieldMapping] = Field(min_length=1)
+    pagination_pointer: BoundedText512 | None = None
+    max_response_bytes: int = Field(ge=1, le=_BYTES_MAX, default=1048576)
+    max_pages: int = Field(ge=1, le=10000, default=1)
+
+
+class AgentSummaryCollector(_CollectorBase):
+    type: Literal["agent_summary"]
+    path: ConfigDirRelativePathStr
+    input_schema_version: int = Field(ge=1, le=1000)
+    mode: Literal["json", "jsonl"] = "jsonl"
+    target_alias_mapping: dict[Identifier, Identifier] = Field(default_factory=dict)
+
+
+class CodexSessionCollector(_CollectorBase):
+    type: Literal["codex_session"]
+    sessions_root: AbsolutePathStr
+    target_repo_mapping: dict[Identifier, Identifier] = Field(min_length=1)
+    trace_categories: list[Identifier] = Field(default_factory=list)
+
+
+class ClaudeSessionCollector(_CollectorBase):
+    type: Literal["claude_session"]
+    projects_root: AbsolutePathStr
+    target_repo_mapping: dict[Identifier, Identifier] = Field(min_length=1)
+    trace_categories: list[Identifier] = Field(default_factory=list)
+
+
+CollectorConfig = Annotated[
+    SiteCanaryCollector
+    | FileOutboxCollector
+    | ErrorReportFileCollector
+    | WorkflowFileCollector
+    | CloudflareCollector
+    | GithubActionsCollector
+    | GenericAdminApiCollector
+    | AgentSummaryCollector
+    | CodexSessionCollector
+    | ClaudeSessionCollector,
+    Field(discriminator="type"),
+]
+
+_COLLECTOR_PROVIDER_TYPE: dict[str, str] = {
+    "cloudflare": "cloudflare",
+    "github_actions": "github",
+    "generic_admin_api": "generic_http",
+}
+
+
+# --- 4.8 providers -------------------------------------------------------------
+
+
+class _ProviderBase(StrictModel):
+    id: Identifier
+
+
+class CloudflareProvider(_ProviderBase):
+    type: Literal["cloudflare"]
+    account_id_env: EnvVarRef
+    token_env: EnvVarRef
+    workers_token_env: EnvVarRef | None = None
+    api_base_url: HttpsUrl | None = None
+    allowed_accounts: list[Identifier] = Field(default_factory=list)
+    allowed_zones: list[Identifier] = Field(default_factory=list)
+
+
+class GithubProvider(_ProviderBase):
+    type: Literal["github"]
+    api_url: HttpsUrl = Url("https://api.github.com")
+    read_token_env: EnvVarRef
+    repository_allowlist: list[RepositorySlug] = Field(min_length=1)
+    api_version: GithubApiVersion
+    issue_write_token_env: EnvVarRef | None = None
+
+    @model_validator(mode="after")
+    def _check_unique_repositories(self) -> GithubProvider:
+        _require_unique(self.repository_allowlist, label="repository_allowlist")
+        return self
+
+
+class GenericHttpProvider(_ProviderBase):
+    type: Literal["generic_http"]
+    auth_mode: Literal["bearer", "header"]
+    token_env: EnvVarRef
+    header_name: BoundedText128 | None = None
+    header_scheme: BoundedText64 | None = None
+    tls_verify: bool = True
+    host_allowlist: list[BoundedText255] = Field(min_length=1)
+    max_retries: int = Field(ge=0, le=100, default=3)
+    rate_limit_per_minute: int = Field(ge=1, le=_COUNT_MAX, default=60)
+    max_response_bytes: int = Field(ge=1, le=_BYTES_MAX, default=1048576)
+
+    @model_validator(mode="after")
+    def _check_header_mode(self) -> GenericHttpProvider:
+        if self.auth_mode == "header" and self.header_name is None:
+            raise ValueError("header_name is required when auth_mode is 'header'")
+        return self
+
+
+class ClickHouseHostedProvider(_ProviderBase):
+    type: Literal["clickhouse_hosted"]
+    url_env: EnvVarRef
+    username_env: EnvVarRef
+    password_env: EnvVarRef
+    database: ClickHouseIdentifier
+    tls_required: bool = True
+    egress_allowlist: list[Literal["public", "internal", "sensitive"]] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _check_unique_egress(self) -> ClickHouseHostedProvider:
+        _require_unique(self.egress_allowlist, label="egress_allowlist")
+        return self
+
+
+ProviderConfig = Annotated[
+    CloudflareProvider | GithubProvider | GenericHttpProvider | ClickHouseHostedProvider,
+    Field(discriminator="type"),
+]
+
+
+# --- 4.14 notifications --------------------------------------------------------
+
+
+class _NotificationBase(StrictModel):
+    id: Identifier
+    enabled: bool = False
+
+
+def _default_public_classifications() -> list[Literal["public", "internal"]]:
+    return ["public"]
+
+
+class TelegramNotification(_NotificationBase):
+    type: Literal["telegram"]
+    bot_token_env: EnvVarRef
+    chat_id_env: EnvVarRef
+    allowed_classifications: list[Literal["public", "internal"]] = Field(
+        default_factory=_default_public_classifications
+    )
+    urgent_alerts: bool = False
+    weekly_summary: bool = False
+    message_limit: int = Field(ge=1, le=4096, default=4096)
+    retry_max_attempts: int = Field(ge=0, le=100, default=5)
+    retry_backoff_seconds: int = Field(ge=1, le=_SECONDS_MAX, default=30)
+
+    @model_validator(mode="after")
+    def _check_unique_classifications(self) -> TelegramNotification:
+        _require_unique(self.allowed_classifications, label="allowed_classifications")
+        return self
+
+
+class GithubIssuesNotification(_NotificationBase):
+    type: Literal["github_issues"]
+    provider: Identifier
+    repository: RepositorySlug
+    label_allowlist: list[Identifier] = Field(min_length=1)
+    enabled_priorities: list[Literal["P0", "P1", "P2", "P3"]] = Field(min_length=1)
+    enabled_actionabilities: list[
+        Literal["observe", "investigate", "agent_safe", "needs_approval"]
+    ] = Field(min_length=1)
+    allowed_classifications: list[Literal["public", "internal"]] = Field(min_length=1)
+    require_preview: bool = True
+    idempotent_marker_prefix: Annotated[
+        str, StringConstraints(pattern=r"^[a-z][a-z0-9:_-]{0,63}$")
+    ] = "milhouse:"
+
+    @model_validator(mode="after")
+    def _check_unique_lists(self) -> GithubIssuesNotification:
+        _require_unique(self.label_allowlist, label="label_allowlist")
+        _require_unique(self.enabled_priorities, label="enabled_priorities")
+        _require_unique(self.enabled_actionabilities, label="enabled_actionabilities")
+        _require_unique(self.allowed_classifications, label="allowed_classifications")
+        return self
+
+
+NotificationConfig = Annotated[
+    TelegramNotification | GithubIssuesNotification, Field(discriminator="type")
+]
+
+
+# --- 4.6 alert, incident, feedback rules ---------------------------------------
+
+
+class CanaryStateAlertRule(StrictModel):
+    id: Identifier
+    type: Literal["canary_state"]
+    collector: Identifier
+    consecutive_failures: int = Field(ge=1, le=100)
+    consecutive_successes: int = Field(ge=1, le=100)
+    cooldown_seconds: int = Field(ge=0, le=_SECONDS_MAX)
+
+
+AlertRuleConfig = CanaryStateAlertRule
+
+
+class IncidentRuleConfig(StrictModel):
+    id: Identifier
+    target: Identifier
+    alert_rule_ids: list[Identifier] = Field(min_length=1)
+    group_dimensions: list[DimensionKey] = Field(default_factory=list)
+    correlation_horizon_seconds: int = Field(ge=1, le=_SECONDS_MAX)
+    quiet_window_seconds: int = Field(ge=0, le=_SECONDS_MAX)
+
+    @model_validator(mode="after")
+    def _check_unique_lists(self) -> IncidentRuleConfig:
+        _require_unique(self.alert_rule_ids, label="alert_rule_ids")
+        _require_unique(self.group_dimensions, label="group_dimensions")
+        return self
+
+
+class FeedbackRuleConfig(StrictModel):
+    id: Identifier
+    type: Literal["recurrence"]
+    target: Identifier
+    record_names: list[MachineName] = Field(min_length=1)
+    minimum_occurrences: int = Field(ge=1, le=10000)
+    window_seconds: int = Field(ge=1, le=31536000)
+    priority: Literal["P0", "P1", "P2", "P3"]
+    actionability: Literal["observe", "investigate", "agent_safe", "needs_approval"]
+
+    @model_validator(mode="after")
+    def _check_unique_record_names(self) -> FeedbackRuleConfig:
+        _require_unique(self.record_names, label="record_names")
+        return self
+
+
+# --- 4.13 jobs -------------------------------------------------------------------
+
+_WEEKDAYS = (
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+)
+
+
+class _JobBase(StrictModel):
+    id: Identifier
+    enabled: bool
+    schedule: Literal["interval", "daily", "weekly"]
+    interval_seconds: int | None = Field(default=None, ge=1, le=_SECONDS_MAX)
+    weekday: Literal[_WEEKDAYS] | None = None  # type: ignore[valid-type]
+    local_time: LocalTime | None = None
+    timeout_seconds: int = Field(ge=1, le=_SECONDS_MAX)
+    missed_run_policy: Literal["skip", "run_once"] = "run_once"
+
+    @model_validator(mode="after")
+    def _check_schedule_fields(self) -> _JobBase:
+        if self.schedule == "interval":
+            if self.interval_seconds is None:
+                raise ValueError("interval_seconds is required when schedule is 'interval'")
+            if self.weekday is not None or self.local_time is not None:
+                raise ValueError("weekday and local_time are invalid when schedule is 'interval'")
+        elif self.schedule == "daily":
+            if self.local_time is None:
+                raise ValueError("local_time is required when schedule is 'daily'")
+            if self.interval_seconds is not None or self.weekday is not None:
+                raise ValueError(
+                    "interval_seconds and weekday are invalid when schedule is 'daily'"
+                )
+        else:
+            if self.local_time is None or self.weekday is None:
+                raise ValueError("weekday and local_time are required when schedule is 'weekly'")
+            if self.interval_seconds is not None:
+                raise ValueError("interval_seconds is invalid when schedule is 'weekly'")
+        return self
+
+
+class SpoolReplayJob(_JobBase):
+    type: Literal["spool_replay"]
+
+
+class CollectorJob(_JobBase):
+    type: Literal["collector"]
+    collector: Identifier
+
+
+class FeedbackCurationJob(_JobBase):
+    type: Literal["feedback_curation"]
+
+
+class FeedbackVerificationJob(_JobBase):
+    type: Literal["feedback_verification"]
+
+
+class NotificationRetryJob(_JobBase):
+    type: Literal["notification_retry"]
+
+
+class RetentionApplyJob(_JobBase):
+    type: Literal["retention_apply"]
+
+
+class DailyReportJob(_JobBase):
+    type: Literal["daily_report"]
+
+
+class WeeklyReportJob(_JobBase):
+    type: Literal["weekly_report"]
+
+
+class BackupVerificationJob(_JobBase):
+    type: Literal["backup_verification"]
+
+
+JobConfig = Annotated[
+    SpoolReplayJob
+    | CollectorJob
+    | FeedbackCurationJob
+    | FeedbackVerificationJob
+    | NotificationRetryJob
+    | RetentionApplyJob
+    | DailyReportJob
+    | WeeklyReportJob
+    | BackupVerificationJob,
+    Field(discriminator="type"),
+]
+
+
+# --- root configuration ----------------------------------------------------------
+
+
+def _validate_config_version(value: int) -> int:
+    if value != CONFIG_VERSION:
+        raise ValueError(f"config_version must equal {CONFIG_VERSION}")
+    return value
+
+
+ConfigVersion = Annotated[int, AfterValidator(_validate_config_version)]
+
+
+class MilhouseConfig(StrictModel):
+    config_version: ConfigVersion
+    project: ProjectConfig
+    paths: PathsConfig
+    secrets: SecretsConfig = Field(default_factory=SecretsConfig)
+    identity: IdentityConfig
+    plugins: PluginsConfig = Field(default_factory=PluginsConfig)
+    runtime: RuntimeConfig
+    storage: StorageConfig
+    privacy: PrivacyConfig
+    retention: RetentionConfig
+    scheduler: SchedulerConfig
+    reports: ReportsConfig
+    jobs: list[JobConfig] = Field(default_factory=list)
+    mcp: MCPConfig
+    postmortem: PostmortemConfig
+    receiver: ReceiverConfig
+    targets: list[TargetConfig] = Field(default_factory=list)
+    collectors: list[CollectorConfig] = Field(default_factory=list)
+    providers: list[ProviderConfig] = Field(default_factory=list)
+    notifications: list[NotificationConfig] = Field(default_factory=list)
+    alert_rules: list[AlertRuleConfig] = Field(default_factory=list)
+    incident_rules: list[IncidentRuleConfig] = Field(default_factory=list)
+    feedback_rules: list[FeedbackRuleConfig] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _check_cross_references(self) -> MilhouseConfig:
+        target_ids = require_unique_ids(self.targets, label="targets")
+        collector_ids = require_unique_ids(self.collectors, label="collectors")
+        require_unique_ids(self.providers, label="providers")
+        require_unique_ids(self.notifications, label="notifications")
+        alert_rule_ids = require_unique_ids(self.alert_rules, label="alert_rules")
+        require_unique_ids(self.incident_rules, label="incident_rules")
+        require_unique_ids(self.feedback_rules, label="feedback_rules")
+        require_unique_ids(self.jobs, label="jobs")
+        require_unique_ids(self.receiver.sources, label="receiver.sources")
+
+        if self.project.default_target not in target_ids:
+            raise ValueError("project.default_target is not a declared target id")
+
+        provider_by_id = {provider.id: provider for provider in self.providers}
+        collector_by_id = {collector.id: collector for collector in self.collectors}
+
+        for collector in self.collectors:
+            if collector.target not in target_ids:
+                raise ValueError("collector target is not a declared target id")
+            provider_id = getattr(collector, "provider", None)
+            if provider_id is not None:
+                provider = provider_by_id.get(provider_id)
+                if provider is None:
+                    raise ValueError("collector provider is not a declared provider id")
+                required_type = _COLLECTOR_PROVIDER_TYPE[collector.type]
+                if provider.type != required_type:
+                    raise ValueError("collector provider has an incompatible provider type")
+            mapped_targets: Iterable[str]
+            if isinstance(collector, AgentSummaryCollector):
+                mapped_targets = collector.target_alias_mapping.values()
+            elif isinstance(collector, (CodexSessionCollector, ClaudeSessionCollector)):
+                mapped_targets = collector.target_repo_mapping.values()
+            else:
+                mapped_targets = ()
+            if any(target_id not in target_ids for target_id in mapped_targets):
+                raise ValueError("collector contains an undeclared mapped target id")
+
+        for source in self.receiver.sources:
+            if source.target not in target_ids:
+                raise ValueError("receiver source target is not a declared target id")
+
+        alert_rule_target: dict[str, str] = {}
+        for rule in self.alert_rules:
+            rule_collector = collector_by_id.get(rule.collector)
+            if rule_collector is None:
+                raise ValueError("alert rule collector is not a declared collector id")
+            if rule_collector.type != "site_canary":
+                raise ValueError("alert rule must reference a site_canary collector")
+            alert_rule_target[rule.id] = rule_collector.target
+
+        for incident_rule in self.incident_rules:
+            if incident_rule.target not in target_ids:
+                raise ValueError("incident rule target is not a declared target id")
+            for alert_rule_id in incident_rule.alert_rule_ids:
+                if alert_rule_id not in alert_rule_ids:
+                    raise ValueError("incident rule references an undeclared alert rule id")
+                if alert_rule_target[alert_rule_id] != incident_rule.target:
+                    raise ValueError(
+                        "incident rule references an alert rule bound to another target"
+                    )
+
+        for feedback_rule in self.feedback_rules:
+            if feedback_rule.target not in target_ids:
+                raise ValueError("feedback rule target is not a declared target id")
+
+        for job in self.jobs:
+            if job.type == "collector" and job.collector not in collector_ids:
+                raise ValueError("collector job is not bound to a declared collector id")
+
+        for notification in self.notifications:
+            if notification.type == "github_issues":
+                provider = provider_by_id.get(notification.provider)
+                if provider is None:
+                    raise ValueError("notification provider is not a declared provider id")
+                if provider.type != "github":
+                    raise ValueError("github issues notification requires a github provider")
+                if notification.repository not in provider.repository_allowlist:
+                    raise ValueError(
+                        "notification repository is not allowlisted by its github provider"
+                    )
+
+        return self
+
+
+__all__ = [
+    "CONFIG_VERSION",
+    "AbsolutePathStr",
+    "AgentSummaryCollector",
+    "AlertRuleConfig",
+    "BackupVerificationJob",
+    "CanaryStateAlertRule",
+    "ClaudeSessionCollector",
+    "ClickHouseHostedProvider",
+    "ClickHouseIdentifier",
+    "CloudflareCollector",
+    "CloudflareProvider",
+    "CodexSessionCollector",
+    "CollectorConfig",
+    "CollectorJob",
+    "DailyReportJob",
+    "DimensionKey",
+    "ErrorReportFileCollector",
+    "FeedbackCurationJob",
+    "FeedbackRuleConfig",
+    "FeedbackVerificationJob",
+    "FileOutboxCollector",
+    "GenericAdminApiCollector",
+    "GenericAdminApiFieldMapping",
+    "GenericHttpProvider",
+    "GithubActionsCollector",
+    "GithubIssuesNotification",
+    "GithubProvider",
+    "GithubWebhookSource",
+    "HmacIngestSource",
+    "Identifier",
+    "IdentityConfig",
+    "IncidentRuleConfig",
+    "JobConfig",
+    "MCPConfig",
+    "MachineName",
+    "MilhouseConfig",
+    "NotificationConfig",
+    "NotificationRetryJob",
+    "PathsConfig",
+    "PluginAllowlistEntry",
+    "PluginsConfig",
+    "PostmortemConfig",
+    "PrivacyConfig",
+    "ProjectConfig",
+    "ProviderConfig",
+    "ReceiverConfig",
+    "ReceiverSource",
+    "RelativePathStr",
+    "ReportScheduleConfig",
+    "ReportsConfig",
+    "RetentionApplyJob",
+    "RetentionConfig",
+    "RuntimeConfig",
+    "SchedulerConfig",
+    "SecretsConfig",
+    "SiteCanaryCollector",
+    "SpoolReplayJob",
+    "StorageClickHouseConfig",
+    "StorageConfig",
+    "StrictModel",
+    "TargetConfig",
+    "TelegramNotification",
+    "WeeklyReportJob",
+    "WorkflowFileCollector",
+    "require_unique_ids",
+]

--- a/src/milhouse/config/schema.py
+++ b/src/milhouse/config/schema.py
@@ -1,0 +1,35 @@
+"""Deterministic Draft 2020-12 JSON Schema export for Milhouse configuration v1."""
+
+from __future__ import annotations
+
+import json
+
+from milhouse.config.models import MilhouseConfig
+
+JSON_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema"
+JSON_SCHEMA_ID = "urn:milhouse:config-schema:v1"
+
+
+def generate_json_schema() -> dict[str, object]:
+    """Return the config v1 JSON Schema as a plain, ordered mapping."""
+
+    schema = MilhouseConfig.model_json_schema(mode="validation")
+    ordered: dict[str, object] = {"$schema": JSON_SCHEMA_DIALECT, "$id": JSON_SCHEMA_ID}
+    ordered.update(schema)
+    return ordered
+
+
+def generate_json_schema_bytes() -> bytes:
+    """Serialize the config v1 JSON Schema as deterministic, sorted, UTF-8 bytes."""
+
+    schema = generate_json_schema()
+    text = json.dumps(schema, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+    return text.encode("utf-8")
+
+
+__all__ = [
+    "JSON_SCHEMA_DIALECT",
+    "JSON_SCHEMA_ID",
+    "generate_json_schema",
+    "generate_json_schema_bytes",
+]

--- a/tests/contract/test_config_examples.py
+++ b/tests/contract/test_config_examples.py
@@ -1,0 +1,152 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from milhouse.config import generate_json_schema_bytes
+from milhouse.config.loader import ConfigError, load_config_file
+from milhouse.config.schema import JSON_SCHEMA_DIALECT
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_PATHS = (
+    Path("config/example.toml"),
+    Path("config/examples/ai-agent-workflows.toml"),
+    Path("config/examples/cloudflare-sites.toml"),
+    Path("config/examples/local-only.toml"),
+)
+
+
+def _env_references(value: object) -> set[str]:
+    references: set[str] = set()
+    if isinstance(value, dict):
+        for key, member in value.items():
+            if key.endswith("_env") and isinstance(member, str):
+                references.add(member)
+            references.update(_env_references(member))
+    elif isinstance(value, list):
+        for member in value:
+            references.update(_env_references(member))
+    return references
+
+
+@pytest.mark.contract
+@pytest.mark.parametrize("relative_path", EXAMPLE_PATHS, ids=str)
+def test_every_checked_in_example_validates(relative_path: Path) -> None:
+    config = load_config_file(REPOSITORY_ROOT / relative_path)
+
+    assert config.config_version == 1
+    assert config.project.default_target in {target.id for target in config.targets}
+
+
+@pytest.mark.contract
+def test_canonical_example_exercises_cross_referenced_sections() -> None:
+    config = load_config_file(REPOSITORY_ROOT / "config/example.toml")
+
+    assert config.collectors[0].id == "example-canary"
+    assert config.receiver.sources[1].repository == "example/example-app"
+    assert config.incident_rules[0].alert_rule_ids == ["example-canary-state"]
+
+
+@pytest.mark.contract
+def test_specialized_examples_exercise_their_intended_collectors() -> None:
+    agent = load_config_file(REPOSITORY_ROOT / "config/examples/ai-agent-workflows.toml")
+    cloudflare = load_config_file(REPOSITORY_ROOT / "config/examples/cloudflare-sites.toml")
+    local = load_config_file(REPOSITORY_ROOT / "config/examples/local-only.toml")
+
+    assert {collector.type for collector in agent.collectors} == {
+        "claude_session",
+        "codex_session",
+        "file_outbox",
+    }
+    assert {collector.type for collector in cloudflare.collectors} == {
+        "cloudflare",
+        "site_canary",
+    }
+    assert local.runtime.mode == "spool_only"
+    assert local.storage.clickhouse.enabled is False
+
+
+@pytest.mark.contract
+def test_example_environment_references_are_declared() -> None:
+    required: set[str] = set()
+    for relative_path in EXAMPLE_PATHS:
+        config = load_config_file(REPOSITORY_ROOT / relative_path)
+        required.update(_env_references(config.model_dump(mode="python")))
+
+    declared = {
+        line.partition("=")[0]
+        for line in (REPOSITORY_ROOT / ".env.example").read_text(encoding="utf-8").splitlines()
+        if line and not line.startswith("#")
+    }
+    assert required <= declared
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "milhouse.toml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _canonical_example_text() -> str:
+    return (REPOSITORY_ROOT / "config/example.toml").read_text(encoding="utf-8")
+
+
+@pytest.mark.contract
+def test_example_with_duplicate_ids_is_rejected(tmp_path: Path) -> None:
+    broken = (
+        _canonical_example_text()
+        + """
+
+[[targets]]
+id = "example-app"
+name = "Duplicate"
+kind = "web_service"
+environment = "production"
+"""
+    )
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(_write(tmp_path, broken))
+
+    assert excinfo.value.code == "config.schema.invalid"
+    assert "duplicate entry" in excinfo.value.message
+
+
+@pytest.mark.contract
+def test_example_with_invalid_cross_reference_is_rejected(tmp_path: Path) -> None:
+    broken = _canonical_example_text().replace(
+        'collector = "example-canary"', 'collector = "no-such-collector"', 1
+    )
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(_write(tmp_path, broken))
+
+    assert excinfo.value.code == "config.schema.invalid"
+    assert "not bound to a declared collector id" in excinfo.value.message
+
+
+def test_json_schema_bytes_are_deterministic_across_calls() -> None:
+    first = generate_json_schema_bytes()
+    second = generate_json_schema_bytes()
+
+    assert first == second
+    assert first.endswith(b"\n")
+    assert hashlib.sha256(first).hexdigest() == (
+        "6c48eb696a701229e3d0338ebf58f65e29f36b558bd298a050c8c3d6c103d304"
+    )
+
+
+def test_json_schema_declares_draft_2020_12() -> None:
+    schema = json.loads(generate_json_schema_bytes())
+
+    assert schema["$schema"] == JSON_SCHEMA_DIALECT
+    assert JSON_SCHEMA_DIALECT == "https://json-schema.org/draft/2020-12/schema"
+
+
+def test_json_schema_is_sorted_and_parses_as_valid_json() -> None:
+    raw = generate_json_schema_bytes()
+    schema = json.loads(raw)
+
+    reserialized = json.dumps(schema, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+    assert reserialized.encode("utf-8") == raw

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,0 +1,440 @@
+import os
+import traceback
+from pathlib import Path
+
+import pytest
+
+import milhouse.config.loader as config_loader
+from milhouse.config.loader import (
+    CONFIG_PATH_ENV_VAR,
+    MAX_CONFIG_BYTES,
+    ConfigError,
+    load_config,
+    load_config_file,
+    resolve_config_path,
+)
+
+_MINIMAL_CONFIG = """
+config_version = 1
+
+[project]
+name = "team"
+default_target = "app"
+timezone = "UTC"
+
+[paths]
+home = "../data"
+spool = "spool"
+reports = "reports"
+logs = "logs"
+backups = "backups"
+
+[secrets]
+env_files = []
+
+[identity]
+pseudonym_key_path = "control/pseudonym.key"
+
+[plugins]
+allow_third_party = false
+
+[runtime]
+mode = "full"
+log_level = "INFO"
+max_batch_records = 500
+max_batch_bytes = 5242880
+
+[storage.clickhouse]
+enabled = true
+url_env = "MILHOUSE_CLICKHOUSE_URL"
+username_env = "MILHOUSE_CLICKHOUSE_USER"
+password_env = "MILHOUSE_CLICKHOUSE_PASSWORD"
+database = "milhouse"
+connect_timeout_seconds = 5
+
+[privacy]
+strict = true
+agent_summaries_enabled = false
+agent_trace_events_enabled = false
+trace_excerpts_enabled = false
+hash_local_paths = true
+
+[retention]
+events_days = 30
+metrics_days = 90
+runs_days = 180
+alerts_days = 365
+feedback_days = 365
+agent_summaries_days = 30
+trace_events_days = 14
+reports_days = 90
+logs_days = 14
+
+[scheduler]
+enabled = true
+jitter_seconds = 5
+shutdown_timeout_seconds = 30
+
+[reports.daily]
+enabled = true
+
+[reports.weekly]
+enabled = true
+
+[mcp]
+enabled = true
+transport = "stdio"
+allow_writes = false
+default_limit = 100
+maximum_limit = 500
+maximum_window_days = 30
+
+[postmortem]
+auto_on_doh_marker = true
+default_window_hours = 24
+scan_project_docs = true
+
+[receiver]
+enabled = false
+bind = "127.0.0.1"
+port = 8787
+allow_remote = false
+max_body_bytes = 262144
+requests_per_minute = 60
+clock_skew_seconds = 300
+
+[[targets]]
+id = "app"
+name = "App"
+kind = "web_service"
+environment = "production"
+"""
+
+
+def _write(path: Path, text: str = _MINIMAL_CONFIG) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_load_config_file_accepts_a_valid_document(tmp_path: Path) -> None:
+    config_path = _write(tmp_path / "milhouse.toml")
+
+    config = load_config_file(config_path)
+
+    assert config.project.name == "team"
+
+
+def test_resolve_config_path_prefers_cli_over_env_and_default(tmp_path: Path) -> None:
+    cli_path = tmp_path / "cli.toml"
+    env_path = tmp_path / "env.toml"
+    default_path = tmp_path / "default.toml"
+
+    resolved = resolve_config_path(
+        str(cli_path),
+        platform_default=default_path,
+        env={CONFIG_PATH_ENV_VAR: str(env_path)},
+    )
+
+    assert resolved == cli_path
+
+
+def test_resolve_config_path_prefers_env_over_default(tmp_path: Path) -> None:
+    env_path = tmp_path / "env.toml"
+    default_path = tmp_path / "default.toml"
+
+    resolved = resolve_config_path(
+        None, platform_default=default_path, env={CONFIG_PATH_ENV_VAR: str(env_path)}
+    )
+
+    assert resolved == env_path
+
+
+def test_resolve_config_path_falls_back_to_platform_default(tmp_path: Path) -> None:
+    default_path = tmp_path / "default.toml"
+
+    resolved = resolve_config_path(None, platform_default=default_path, env={})
+
+    assert resolved == default_path
+
+
+def test_resolve_config_path_ignores_empty_env_value(tmp_path: Path) -> None:
+    default_path = tmp_path / "default.toml"
+
+    resolved = resolve_config_path(
+        None, platform_default=default_path, env={CONFIG_PATH_ENV_VAR: ""}
+    )
+
+    assert resolved == default_path
+
+
+def test_resolve_config_path_rejects_empty_cli_value(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        resolve_config_path("", platform_default=tmp_path / "default.toml", env={})
+
+    assert excinfo.value.code == "config.path.invalid"
+
+
+def test_resolve_config_path_never_searches_the_current_working_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    decoy_cwd = tmp_path / "cwd"
+    decoy_cwd.mkdir()
+    _write(decoy_cwd / "milhouse.toml")
+    monkeypatch.chdir(decoy_cwd)
+
+    default_path = tmp_path / "elsewhere" / "default.toml"
+    resolved = resolve_config_path(None, platform_default=default_path, env={})
+
+    assert resolved == default_path
+    assert resolved != Path("milhouse.toml").resolve()
+
+
+def test_resolve_config_path_uses_process_environment_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_path = _write(tmp_path / "env.toml")
+    monkeypatch.setenv(CONFIG_PATH_ENV_VAR, str(env_path))
+
+    resolved = resolve_config_path(None, platform_default=tmp_path / "default.toml")
+
+    assert resolved == env_path
+
+
+def test_load_config_end_to_end_returns_config_and_resolved_path(tmp_path: Path) -> None:
+    config_path = _write(tmp_path / "milhouse.toml")
+
+    config, resolved_path = load_config(
+        str(config_path), platform_default=tmp_path / "default.toml", env={}
+    )
+
+    assert resolved_path == config_path
+    assert config.project.name == "team"
+
+
+def test_load_config_file_missing_is_a_stable_error(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(tmp_path / "missing.toml")
+
+    assert excinfo.value.code == "config.file.not_found"
+
+
+def test_load_config_file_rejects_symlinks(tmp_path: Path) -> None:
+    target = _write(tmp_path / "real.toml")
+    link = tmp_path / "link.toml"
+    link.symlink_to(target)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(link)
+
+    assert excinfo.value.code == "config.file.not_regular"
+
+
+def test_load_config_file_rejects_symlinks_without_o_nofollow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = _write(tmp_path / "real.toml")
+    link = tmp_path / "link.toml"
+    link.symlink_to(target)
+    monkeypatch.setattr(config_loader.os, "O_NOFOLLOW", 0, raising=False)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(link)
+
+    assert excinfo.value.code == "config.file.not_regular"
+
+
+def test_load_config_file_detects_a_fallback_open_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _write(tmp_path / "milhouse.toml")
+    replacement = _write(tmp_path / "replacement.toml")
+    real_open = os.open
+    monkeypatch.setattr(config_loader.os, "O_NOFOLLOW", 0, raising=False)
+
+    def swapped_open(candidate: str | bytes | os.PathLike[str], flags: int) -> int:
+        os.replace(replacement, path)
+        return real_open(candidate, flags)
+
+    monkeypatch.setattr(config_loader.os, "open", swapped_open)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(path)
+
+    assert excinfo.value.code == "config.file.changed"
+
+
+def test_load_config_file_rejects_directories(tmp_path: Path) -> None:
+    directory = tmp_path / "a-directory.toml"
+    directory.mkdir()
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(directory)
+
+    assert excinfo.value.code == "config.file.not_regular"
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are unavailable")
+def test_load_config_file_rejects_a_fifo_without_blocking(tmp_path: Path) -> None:
+    fifo = tmp_path / "config.fifo"
+    os.mkfifo(fifo)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(fifo)
+
+    assert excinfo.value.code == "config.file.not_regular"
+
+
+def test_load_config_file_rejects_an_invalid_path_without_echoing_it() -> None:
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file("invalid\x00path")
+
+    assert excinfo.value.code == "config.path.invalid"
+    assert "invalid\x00path" not in str(excinfo.value)
+
+
+def test_load_config_file_rejects_empty_files(tmp_path: Path) -> None:
+    empty = _write(tmp_path / "empty.toml", "")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(empty)
+
+    assert excinfo.value.code == "config.file.empty"
+
+
+def test_load_config_file_rejects_oversized_files(tmp_path: Path) -> None:
+    oversized = tmp_path / "big.toml"
+    oversized.write_text("# " + ("x" * (MAX_CONFIG_BYTES + 1)), encoding="utf-8")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(oversized)
+
+    assert excinfo.value.code == "config.file.too_large"
+
+
+def test_load_config_file_enforces_the_read_bound_after_fstat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    oversized = tmp_path / "growing.toml"
+    oversized.write_bytes(b"#" * (MAX_CONFIG_BYTES + 1))
+    real_fstat = os.fstat
+
+    def hidden_size(descriptor: int) -> os.stat_result:
+        values = list(real_fstat(descriptor))
+        values[6] = MAX_CONFIG_BYTES
+        return os.stat_result(values)
+
+    monkeypatch.setattr(config_loader.os, "fstat", hidden_size)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(oversized)
+
+    assert excinfo.value.code == "config.file.too_large"
+
+
+def test_load_config_file_detects_an_in_place_read_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _write(tmp_path / "milhouse.toml")
+    real_fstat = os.fstat
+    initial = path.stat()
+    calls = 0
+
+    def changed_after_read(descriptor: int) -> os.stat_result:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            os.utime(
+                path,
+                ns=(initial.st_atime_ns, initial.st_mtime_ns + 1_000_000_000),
+            )
+        return real_fstat(descriptor)
+
+    monkeypatch.setattr(config_loader.os, "fstat", changed_after_read)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(path)
+
+    assert excinfo.value.code == "config.file.changed"
+
+
+def test_load_config_file_rejects_non_utf8_bytes(tmp_path: Path) -> None:
+    non_utf8 = tmp_path / "non-utf8.toml"
+    non_utf8.write_bytes(b"config_version = 1\nname = \xff\xfe")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(non_utf8)
+
+    assert excinfo.value.code == "config.file.unreadable"
+
+
+def test_load_config_file_rejects_malformed_toml(tmp_path: Path) -> None:
+    malformed = _write(tmp_path / "malformed.toml", "not valid = = toml")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(malformed)
+
+    assert excinfo.value.code == "config.toml.syntax"
+    assert "line" in excinfo.value.message
+
+
+@pytest.mark.parametrize(
+    "version_line",
+    ["config_version = 2", 'config_version = "1"', "config_version = 1.0"],
+)
+def test_load_config_file_rejects_unsupported_versions(tmp_path: Path, version_line: str) -> None:
+    document = _MINIMAL_CONFIG.replace("config_version = 1", version_line, 1)
+    path = _write(tmp_path / "version.toml", document)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(path)
+
+    assert excinfo.value.code == "config.version.unsupported"
+
+
+def test_load_config_file_schema_errors_never_echo_raw_field_values(tmp_path: Path) -> None:
+    secret_looking_value = "sk-not-a-real-secret-0123456789"
+    document = _MINIMAL_CONFIG.replace(
+        "max_batch_records = 500", f'max_batch_records = "{secret_looking_value}"'
+    )
+    path = _write(tmp_path / "coercion.toml", document)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(path)
+
+    assert excinfo.value.code == "config.schema.invalid"
+    assert secret_looking_value not in excinfo.value.message
+    assert secret_looking_value not in str(excinfo.value)
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__suppress_context__ is True
+    assert secret_looking_value not in "".join(traceback.format_exception(excinfo.value))
+
+
+def test_load_config_file_cross_reference_errors_never_echo_raw_ids(tmp_path: Path) -> None:
+    secret_looking_id = "secret_token_0123456789abcdef"
+    document = _MINIMAL_CONFIG.replace(
+        'default_target = "app"', f'default_target = "{secret_looking_id}"'
+    )
+    path = _write(tmp_path / "reference.toml", document)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(path)
+
+    assert excinfo.value.code == "config.schema.invalid"
+    assert secret_looking_id not in str(excinfo.value)
+
+
+def test_load_config_file_reports_unknown_keys(tmp_path: Path) -> None:
+    document = _MINIMAL_CONFIG.replace("[project]", "[project]\nbogus_field = 1")
+    path = _write(tmp_path / "unknown.toml", document)
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_config_file(path)
+
+    assert excinfo.value.code == "config.schema.invalid"
+    assert "project.bogus_field" in excinfo.value.message
+
+
+def test_config_error_string_includes_code_and_message() -> None:
+    error = ConfigError("config.file.not_found", "config file was not found")
+
+    assert str(error) == "config.file.not_found: config file was not found"

--- a/tests/unit/test_config_models.py
+++ b/tests/unit/test_config_models.py
@@ -1,0 +1,546 @@
+import copy
+
+import pytest
+from pydantic import ValidationError
+
+from milhouse.config.models import MilhouseConfig
+
+
+def _base_config(**overrides: object) -> dict[str, object]:
+    config: dict[str, object] = {
+        "config_version": 1,
+        "project": {"name": "team", "default_target": "app", "timezone": "UTC"},
+        "paths": {
+            "home": "../data",
+            "spool": "spool",
+            "reports": "reports",
+            "logs": "logs",
+            "backups": "backups",
+        },
+        "secrets": {"env_files": []},
+        "identity": {"pseudonym_key_path": "control/pseudonym.key"},
+        "plugins": {"allow_third_party": False, "allowed": []},
+        "runtime": {
+            "mode": "full",
+            "log_level": "INFO",
+            "max_batch_records": 500,
+            "max_batch_bytes": 5242880,
+        },
+        "storage": {
+            "clickhouse": {
+                "enabled": True,
+                "url_env": "MILHOUSE_CLICKHOUSE_URL",
+                "username_env": "MILHOUSE_CLICKHOUSE_USER",
+                "password_env": "MILHOUSE_CLICKHOUSE_PASSWORD",
+                "database": "milhouse",
+                "connect_timeout_seconds": 5,
+            }
+        },
+        "privacy": {
+            "strict": True,
+            "agent_summaries_enabled": False,
+            "agent_trace_events_enabled": False,
+            "trace_excerpts_enabled": False,
+            "hash_local_paths": True,
+        },
+        "retention": {
+            "events_days": 30,
+            "metrics_days": 90,
+            "runs_days": 180,
+            "alerts_days": 365,
+            "feedback_days": 365,
+            "agent_summaries_days": 30,
+            "trace_events_days": 14,
+            "reports_days": 90,
+            "logs_days": 14,
+        },
+        "scheduler": {"enabled": True, "jitter_seconds": 5, "shutdown_timeout_seconds": 30},
+        "reports": {"daily": {"enabled": True}, "weekly": {"enabled": True}},
+        "jobs": [],
+        "mcp": {
+            "enabled": True,
+            "transport": "stdio",
+            "allow_writes": False,
+            "default_limit": 100,
+            "maximum_limit": 500,
+            "maximum_window_days": 30,
+        },
+        "postmortem": {
+            "auto_on_doh_marker": True,
+            "default_window_hours": 24,
+            "scan_project_docs": True,
+        },
+        "receiver": {
+            "enabled": False,
+            "bind": "127.0.0.1",
+            "port": 8787,
+            "allow_remote": False,
+            "max_body_bytes": 262144,
+            "requests_per_minute": 60,
+            "clock_skew_seconds": 300,
+            "sources": [],
+        },
+        "targets": [
+            {"id": "app", "name": "App", "kind": "web_service", "environment": "production"}
+        ],
+        "collectors": [],
+        "providers": [],
+        "notifications": [],
+        "alert_rules": [],
+        "incident_rules": [],
+        "feedback_rules": [],
+    }
+    config.update(overrides)
+    return config
+
+
+def _with_section(base: dict[str, object], section: str, **overrides: object) -> dict[str, object]:
+    config = copy.deepcopy(base)
+    section_value = dict(config[section])  # type: ignore[arg-type]
+    section_value.update(overrides)
+    config[section] = section_value
+    return config
+
+
+def _errors(exc: ValidationError) -> str:
+    return "; ".join(f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors())
+
+
+def test_minimal_config_validates() -> None:
+    config = MilhouseConfig.model_validate(_base_config())
+
+    assert config.project.default_target == "app"
+    assert config.targets[0].id == "app"
+
+
+def test_unknown_top_level_key_is_rejected() -> None:
+    document = _base_config(bogus_top_level_key=True)
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_unknown_nested_key_is_rejected() -> None:
+    document = _with_section(_base_config(), "project", bogus_field="oops")
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        MilhouseConfig.model_validate(document)
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value"),
+    [
+        ("runtime", "max_batch_records", "500"),
+        ("runtime", "max_batch_bytes", 5242880.0),
+        ("privacy", "strict", 1),
+        ("scheduler", "enabled", "true"),
+    ],
+)
+def test_native_toml_types_are_not_coerced(section: str, field: str, value: object) -> None:
+    document = _with_section(_base_config(), section, **{field: value})
+
+    with pytest.raises(ValidationError):
+        MilhouseConfig.model_validate(document)
+
+
+def test_trace_excerpts_enabled_true_is_rejected() -> None:
+    document = _with_section(_base_config(), "privacy", trace_excerpts_enabled=True)
+
+    with pytest.raises(ValidationError) as excinfo:
+        MilhouseConfig.model_validate(document)
+    assert "trace_excerpts_enabled" in _errors(excinfo.value)
+
+
+@pytest.mark.parametrize("version", [0, 2, -1, 1.0, "1", True])
+def test_unsupported_config_version_is_rejected(version: object) -> None:
+    document = _base_config(config_version=version)
+
+    with pytest.raises(ValidationError):
+        MilhouseConfig.model_validate(document)
+
+
+def test_duplicate_target_ids_are_rejected() -> None:
+    document = _base_config(
+        targets=[
+            {"id": "app", "name": "App", "kind": "web_service", "environment": "production"},
+            {"id": "app", "name": "App Two", "kind": "web_service", "environment": "staging"},
+        ]
+    )
+
+    with pytest.raises(ValidationError, match="duplicate entry"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_duplicate_job_ids_are_rejected() -> None:
+    job = {
+        "id": "replay",
+        "type": "spool_replay",
+        "enabled": True,
+        "schedule": "interval",
+        "interval_seconds": 60,
+        "timeout_seconds": 30,
+    }
+    document = _base_config(jobs=[job, dict(job)])
+
+    with pytest.raises(ValidationError, match="duplicate entry"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_default_target_must_reference_a_declared_target() -> None:
+    document = _with_section(_base_config(), "project", default_target="missing-app")
+
+    with pytest.raises(ValidationError, match="not a declared target id"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_collector_target_must_reference_a_declared_target() -> None:
+    document = _base_config(
+        collectors=[
+            {
+                "id": "canary",
+                "type": "site_canary",
+                "target": "missing-app",
+                "url": "https://example.com/health",
+                "expected_statuses": [200],
+            }
+        ]
+    )
+
+    with pytest.raises(ValidationError, match="not a declared target id"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_alert_rule_collector_must_be_a_site_canary_collector() -> None:
+    document = _base_config(
+        collectors=[
+            {
+                "id": "outbox",
+                "type": "file_outbox",
+                "target": "app",
+                "path": "feedback-outbox.jsonl",
+            }
+        ],
+        alert_rules=[
+            {
+                "id": "outbox-state",
+                "type": "canary_state",
+                "collector": "outbox",
+                "consecutive_failures": 2,
+                "consecutive_successes": 2,
+                "cooldown_seconds": 300,
+            }
+        ],
+    )
+
+    with pytest.raises(ValidationError, match="must reference a site_canary collector"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_incident_rule_target_must_match_referenced_alert_rule_target() -> None:
+    document = _base_config(
+        targets=[
+            {"id": "app", "name": "App", "kind": "web_service", "environment": "production"},
+            {"id": "other", "name": "Other", "kind": "web_service", "environment": "production"},
+        ],
+        collectors=[
+            {
+                "id": "canary",
+                "type": "site_canary",
+                "target": "app",
+                "url": "https://example.com/health",
+                "expected_statuses": [200],
+            }
+        ],
+        alert_rules=[
+            {
+                "id": "canary-state",
+                "type": "canary_state",
+                "collector": "canary",
+                "consecutive_failures": 2,
+                "consecutive_successes": 2,
+                "cooldown_seconds": 300,
+            }
+        ],
+        incident_rules=[
+            {
+                "id": "mismatch",
+                "target": "other",
+                "alert_rule_ids": ["canary-state"],
+                "group_dimensions": [],
+                "correlation_horizon_seconds": 900,
+                "quiet_window_seconds": 300,
+            }
+        ],
+    )
+
+    with pytest.raises(ValidationError, match="bound to another target"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_collector_job_must_reference_a_declared_collector() -> None:
+    document = _base_config(
+        jobs=[
+            {
+                "id": "collect",
+                "type": "collector",
+                "collector": "missing-collector",
+                "enabled": True,
+                "schedule": "interval",
+                "interval_seconds": 60,
+                "timeout_seconds": 15,
+            }
+        ]
+    )
+
+    with pytest.raises(ValidationError, match="not bound to a declared collector id"):
+        MilhouseConfig.model_validate(document)
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    ["Bad-ID", "bad id", "bad\nid", "bad_ïd", "", "-leading-dash", "a" * 65],
+)
+def test_invalid_identifier_patterns_are_rejected(identifier: str) -> None:
+    document = _with_section(_base_config(), "project", default_target=identifier)
+
+    with pytest.raises(ValidationError):
+        MilhouseConfig.model_validate(document)
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    ["milhouse_url", "MILHOUSE URL", "MILHOUSE\nURL", "1LEADING_DIGIT", "MÜLHOUSE_URL", ""],
+)
+def test_invalid_env_var_patterns_are_rejected(env_name: str) -> None:
+    base = _base_config()
+    clickhouse = dict(base["storage"]["clickhouse"])  # type: ignore[index]
+    clickhouse["url_env"] = env_name
+    document = _with_section(base, "storage", clickhouse=clickhouse)
+
+    with pytest.raises(ValidationError):
+        MilhouseConfig.model_validate(document)
+
+
+@pytest.mark.parametrize(
+    "job",
+    [
+        {
+            "id": "interval-missing-seconds",
+            "type": "spool_replay",
+            "enabled": True,
+            "schedule": "interval",
+            "timeout_seconds": 30,
+        },
+        {
+            "id": "daily-missing-local-time",
+            "type": "spool_replay",
+            "enabled": True,
+            "schedule": "daily",
+            "timeout_seconds": 30,
+        },
+        {
+            "id": "weekly-missing-weekday",
+            "type": "spool_replay",
+            "enabled": True,
+            "schedule": "weekly",
+            "local_time": "08:00",
+            "timeout_seconds": 30,
+        },
+        {
+            "id": "interval-with-weekday",
+            "type": "spool_replay",
+            "enabled": True,
+            "schedule": "interval",
+            "interval_seconds": 60,
+            "weekday": "monday",
+            "timeout_seconds": 30,
+        },
+    ],
+)
+def test_job_schedule_requires_matching_fields(job: dict[str, object]) -> None:
+    document = _base_config(jobs=[job])
+
+    with pytest.raises(ValidationError):
+        MilhouseConfig.model_validate(document)
+
+
+def test_job_schedule_accepts_valid_weekly_shape() -> None:
+    document = _base_config(
+        jobs=[
+            {
+                "id": "weekly-report",
+                "type": "weekly_report",
+                "enabled": True,
+                "schedule": "weekly",
+                "weekday": "monday",
+                "local_time": "08:00",
+                "timeout_seconds": 120,
+            }
+        ]
+    )
+
+    config = MilhouseConfig.model_validate(document)
+    assert config.jobs[0].weekday == "monday"
+
+
+def test_receiver_source_requires_both_or_neither_previous_secret_fields() -> None:
+    document = _base_config(
+        targets=[{"id": "app", "name": "App", "kind": "web_service", "environment": "production"}],
+        receiver={
+            "enabled": True,
+            "bind": "127.0.0.1",
+            "port": 8787,
+            "allow_remote": False,
+            "max_body_bytes": 262144,
+            "requests_per_minute": 60,
+            "clock_skew_seconds": 300,
+            "sources": [
+                {
+                    "id": "backend",
+                    "type": "hmac_v1",
+                    "target": "app",
+                    "secret_env": "MILHOUSE_INGEST_SECRET",
+                    "allowed_paths": ["/v1/ingest/events"],
+                    "previous_secret_env": "MILHOUSE_INGEST_SECRET_OLD",
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(ValidationError, match="must both be set or both absent"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_plugins_allowlist_rejects_duplicate_entries() -> None:
+    entry = {
+        "distribution": "example-plugin",
+        "version": "1.0.0",
+        "group": "milhouse.collectors",
+        "entry_point": "example_plugin.module:Collector",
+    }
+    document = _with_section(
+        _base_config(), "plugins", allow_third_party=True, allowed=[entry, dict(entry)]
+    )
+
+    with pytest.raises(ValidationError, match="duplicate entry"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_plugins_allowlist_requires_third_party_enablement() -> None:
+    entry = {
+        "distribution": "example-plugin",
+        "version": "1.0.0",
+        "group": "milhouse.collectors",
+        "entry_point": "example_plugin.module:Collector",
+    }
+    document = _with_section(_base_config(), "plugins", allowed=[entry])
+
+    with pytest.raises(ValidationError, match="allow_third_party=true"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_agent_collector_mapping_must_reference_a_declared_target() -> None:
+    document = _base_config(
+        collectors=[
+            {
+                "id": "codex-sessions",
+                "type": "codex_session",
+                "target": "app",
+                "sessions_root": "/absolute/path/to/codex/sessions",
+                "target_repo_mapping": {"example-repo": "missing-target"},
+            }
+        ]
+    )
+
+    with pytest.raises(ValidationError, match="undeclared mapped target id"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_github_issue_repository_must_be_provider_allowlisted() -> None:
+    document = _base_config(
+        providers=[
+            {
+                "id": "github-primary",
+                "type": "github",
+                "read_token_env": "MILHOUSE_GITHUB_READ_TOKEN",
+                "repository_allowlist": ["example/allowed"],
+                "api_version": "2022-11-28",
+            }
+        ],
+        notifications=[
+            {
+                "id": "github-issues",
+                "type": "github_issues",
+                "enabled": True,
+                "provider": "github-primary",
+                "repository": "example/not-allowed",
+                "label_allowlist": ["milhouse"],
+                "enabled_priorities": ["P1"],
+                "enabled_actionabilities": ["needs_approval"],
+                "allowed_classifications": ["internal"],
+            }
+        ],
+    )
+
+    with pytest.raises(ValidationError, match="repository is not allowlisted"):
+        MilhouseConfig.model_validate(document)
+
+
+def test_path_fields_reject_control_characters() -> None:
+    document = _with_section(_base_config(), "paths", spool="bad\tpath")
+
+    with pytest.raises(ValidationError):
+        MilhouseConfig.model_validate(document)
+
+
+def test_timezone_validation_returns_a_value_free_error() -> None:
+    document = _with_section(_base_config(), "project", timezone="/not/a/zone")
+
+    with pytest.raises(ValidationError) as excinfo:
+        MilhouseConfig.model_validate(document)
+
+    assert "known IANA zone name" in _errors(excinfo.value)
+    assert "/not/a/zone" not in _errors(excinfo.value)
+
+
+def test_standalone_file_sources_allow_config_directory_relative_paths() -> None:
+    document = _base_config(
+        collectors=[
+            {
+                "id": "errors",
+                "type": "error_report_file",
+                "target": "app",
+                "path": "../inputs/errors.jsonl",
+                "input_schema_version": 1,
+            }
+        ]
+    )
+
+    config = MilhouseConfig.model_validate(document)
+    assert config.collectors[0].path == "../inputs/errors.jsonl"
+
+
+@pytest.mark.parametrize(
+    "record_names",
+    [["Canary.State"], ["canary..state"], ["canary state"], ["<script>alert(1)</script>"]],
+)
+def test_feedback_rule_record_names_reject_unsafe_or_malformed_values(
+    record_names: list[str],
+) -> None:
+    document = _base_config(
+        feedback_rules=[
+            {
+                "id": "recurrence",
+                "type": "recurrence",
+                "target": "app",
+                "record_names": record_names,
+                "minimum_occurrences": 2,
+                "window_seconds": 86400,
+                "priority": "P1",
+                "actionability": "needs_approval",
+            }
+        ]
+    )
+
+    with pytest.raises(ValidationError):
+        MilhouseConfig.model_validate(document)


### PR DESCRIPTION
## Summary
- add strict, recursive Pydantic config v1 models for the canonical W02 sections, first-party collectors/providers/notifiers, jobs, and cross-references
- add explicit CLI/environment/platform-default config path precedence with bounded descriptor-based TOML reads, symlink/swap/change detection, and value-safe stable errors
- add deterministic Draft 2020-12 JSON Schema bytes with a locked SHA-256 vector
- migrate all checked-in config examples and `.env.example` to the canonical v1 contract
- validate real examples, environment references, unknown fields, native-type strictness, duplicate IDs, bad references, path safety, secret-safe errors, loader races, and schema stability

## Validation
- `make quality`
- `make test` (844 passed, 1 skipped on the combined main tree)
- `make test-coverage` (97.19% line, 95.19% branch)
- `make build package-check artifact-smoke`
- `make private-identifier-check secret-scan-self-test secret-scan`
- wheel and sdist include the new `milhouse.config` package and pass artifact smoke tests

## Scope
This is a bounded W02 production foundation and does not claim G02 completion. Runtime-home/path resolution, explicit env-file secret loading, installed plugin version verification, privacy/redaction, pseudonyms, safe rendering, durations, and structured logging remain subsequent W02 slices.