### PR TITLE
feat(cli): expose configuration validation and schema

### DIFF
--- a/src/milhouse/cli/root.py
+++ b/src/milhouse/cli/root.py
@@ -2,9 +2,25 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+
 import click
+from platformdirs import user_config_path
 
 from milhouse import __version__
+from milhouse.config import ConfigError, generate_json_schema_bytes, load_config
+
+
+@dataclass(frozen=True, slots=True)
+class CliState:
+    """Value-safe root options shared by Milhouse command groups."""
+
+    config_path: str | None
+
+
+def _platform_config_file() -> Path:
+    return user_config_path("milhouse", appauthor=False) / "config.toml"
 
 
 @click.group(
@@ -13,5 +29,40 @@ from milhouse import __version__
     no_args_is_help=True,
 )
 @click.version_option(version=__version__, prog_name="milhouse")
-def main() -> None:
+@click.option(
+    "--config",
+    "config_path",
+    metavar="PATH",
+    help="Use this config file before MILHOUSE_CONFIG or the platform default.",
+)
+@click.pass_context
+def main(context: click.Context, config_path: str | None) -> None:
     """Local-first observability and verified feedback loops (pre-alpha)."""
+
+    context.obj = CliState(config_path=config_path)
+
+
+@main.group(name="config")
+def config_group() -> None:
+    """Validate configuration or export its machine schema."""
+
+
+@config_group.command(name="validate")
+@click.pass_obj
+def validate_config_command(state: CliState) -> None:
+    """Validate one config without network access or secret resolution."""
+
+    try:
+        load_config(state.config_path, platform_default=_platform_config_file())
+    except ConfigError as error:
+        raise click.ClickException(str(error)) from None
+    click.echo("configuration is valid")
+
+
+@config_group.command(name="schema")
+def config_schema_command() -> None:
+    """Write the deterministic Draft 2020-12 config schema to stdout."""
+
+    output = click.get_binary_stream("stdout")
+    output.write(generate_json_schema_bytes())
+    output.flush()

--- a/tests/integration/test_cli_config_integration.py
+++ b/tests/integration/test_cli_config_integration.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from milhouse.cli import main
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_every_public_example_validates_through_the_cli() -> None:
+    examples = (
+        REPOSITORY_ROOT / "config/example.toml",
+        REPOSITORY_ROOT / "config/examples/ai-agent-workflows.toml",
+        REPOSITORY_ROOT / "config/examples/cloudflare-sites.toml",
+        REPOSITORY_ROOT / "config/examples/local-only.toml",
+    )
+
+    for example in examples:
+        result = CliRunner().invoke(
+            main,
+            ["--config", str(example), "config", "validate"],
+        )
+        assert result.exit_code == 0, result.output
+        assert result.output == "configuration is valid\n"

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from milhouse.cli import main
+from milhouse.config import generate_json_schema_bytes
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_CONFIG = REPOSITORY_ROOT / "config/example.toml"
+
+
+def test_root_help_exposes_config_commands_and_global_path_option() -> None:
+    result = CliRunner().invoke(main, ["--help"])
+
+    assert result.exit_code == 0
+    assert "--config PATH" in result.output
+    assert "config" in result.output
+
+
+def test_config_schema_writes_the_exact_deterministic_schema_bytes() -> None:
+    result = CliRunner().invoke(main, ["config", "schema"])
+
+    assert result.exit_code == 0
+    assert result.stdout_bytes == generate_json_schema_bytes()
+    assert result.stderr_bytes == b""
+
+
+def test_config_validate_accepts_an_explicit_checked_in_example() -> None:
+    result = CliRunner().invoke(
+        main,
+        ["--config", str(EXAMPLE_CONFIG), "config", "validate"],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "configuration is valid\n"
+
+
+def test_config_validate_uses_milhouse_config_environment_precedence() -> None:
+    result = CliRunner().invoke(
+        main,
+        ["config", "validate"],
+        env={"MILHOUSE_CONFIG": str(EXAMPLE_CONFIG)},
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "configuration is valid\n"
+
+
+def test_config_validate_uses_the_platform_default_without_cwd_search(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    default_root = tmp_path / "platform"
+    default_root.mkdir()
+    default_config = default_root / "config.toml"
+    default_config.write_text(EXAMPLE_CONFIG.read_text(encoding="utf-8"), encoding="utf-8")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / "milhouse.toml").write_text("config_version = 999\n", encoding="utf-8")
+    monkeypatch.chdir(cwd)
+    monkeypatch.setattr(
+        "milhouse.cli.root.user_config_path",
+        lambda *_args, **_kwargs: default_root,
+    )
+
+    result = CliRunner().invoke(main, ["config", "validate"], env={})
+
+    assert result.exit_code == 0
+    assert result.output == "configuration is valid\n"
+
+
+def test_config_validate_failure_is_stable_and_value_safe(tmp_path: Path) -> None:
+    secret_looking_value = "secret_token_0123456789abcdef"
+    broken = EXAMPLE_CONFIG.read_text(encoding="utf-8").replace(
+        "max_batch_records = 500",
+        f'max_batch_records = "{secret_looking_value}"',
+    )
+    config_path = tmp_path / "broken.toml"
+    config_path.write_text(broken, encoding="utf-8")
+
+    result = CliRunner().invoke(
+        main,
+        ["--config", str(config_path), "config", "validate"],
+    )
+
+    assert result.exit_code == 1
+    assert "config.schema.invalid" in result.stderr
+    assert secret_looking_value not in result.output
+    assert secret_looking_value not in result.stderr


### PR DESCRIPTION
## Summary
- add the global `--config PATH` option with the locked CLI/environment/platform-default precedence and no current-working-directory lookup
- add offline `milhouse config validate` with stable, value-safe configuration errors
- add `milhouse config schema` with byte-for-byte deterministic Draft 2020-12 JSON Schema output
- prove the complete public example set through the real Click command surface

## Validation
- `make quality`
- `make test` (851 passed, 1 skipped)
- `make test-coverage` (97.20% line, 95.19% branch)
- `make build package-check artifact-smoke`
- `make audit license-check secret-scan`
- `python3 -I scripts/check_dco.py --range origin/main..HEAD`

## Scope
This is a bounded W02 CLI exposure slice. It does not claim G02 or the full W06 CLI: redacted `config show`, explicit env-file loading, JSON/log-level globals, runtime path resolution, and the remaining privacy/runtime commands stay in their owning slices.