### PR TITLE
feat(privacy): securely create and load pseudonym keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,7 @@
 - Add canonical `STATE_ROOT` resolution with contained runtime children and symlink-escape refusal,
   plus bounded explicit env-file loading with process/CLI/configured precedence, no discovery or
   interpolation, safe source metadata, and non-enumerating secret storage.
+- Add runtime-generation-bound pseudonym-key primitives with staged, fsynced, atomic no-overwrite
+  publication; ACL-free private `0700` parent and `0600` key enforcement; owner/link/identity and
+  published-byte validation; wrong-key detection; value-safe failures; and explicit recovery from
+  uncertain publication commits.

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ test-coverage:
 		--critical 'src/milhouse/core/canonical.py' \
 		--critical 'src/milhouse/domain/identity.py' \
 		--critical 'src/milhouse/domain/records.py' \
+		--critical 'src/milhouse/privacy/keys.py' \
 		--critical 'src/milhouse/privacy/allowlist.py' \
 		--critical 'src/milhouse/privacy/pseudonym.py' \
 		--critical 'src/milhouse/privacy/redact.py' \

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ teams and AI-assisted development workflows.
 > **Status: pre-alpha implementation; no public release.** The W01 package and quality-toolchain
 > foundation has passed G01; W02 domain, configuration, identity, trust, and privacy implementation
 > is in progress. The repository now contains strict configuration/schema validation, deterministic
-> record identity and envelopes, privacy/redaction primitives, and secure runtime path and explicit
-> secret-loading foundations. Durable storage, collection, querying, and the operational runtime are
-> not implemented yet. Do not use this build for production data.
+> record identity and envelopes, privacy/redaction primitives, secure runtime path and explicit
+> secret-loading foundations, and secure pseudonym-key material primitives. Durable storage,
+> collection, querying, initialization, and the operational runtime are not implemented yet. Do not
+> use this build for production data.
 
 The normative scope, contracts, work order, gates, and Definition of Done are in [the authoritative implementation plan](docs/implementation-plan.md). Progress and validation evidence are tracked in [implementation status](docs/implementation-status.md).
 
@@ -49,7 +50,9 @@ python3 -I scripts/run_uv.py run --locked milhouse config schema
 Those commands exercise the pre-alpha CLI and offline configuration surface only. `milhouse init`,
 collectors, storage, feedback, reports, MCP, and services become available in their owning work
 packages. In particular, product initialization is W06 work; contributor setup does not create
-Milhouse configuration or runtime state.
+Milhouse configuration or runtime state. The current key-material module is a lower-level primitive:
+W06 still owns private-directory initialization and stale staging-artifact handling, while W16 owns
+backup, restore, identity-continuity, and rotation workflows.
 
 ## Contributor quickstart
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -12,13 +12,13 @@ status and evidence; it does not amend the plan.
 | Product phase | **Pre-alpha; not released and not ready for production use** |
 | Plan | Version 1.0, approved for implementation by the owner on 2026-07-18 |
 | Target release | Milhouse OSS 1.0 |
-| Working branch | `codex/w02-secure-config` |
-| Git state | This snapshot is based on protected `main` commit `31f3014238696227edaa3435f542284e846f94c3`; every job in post-merge Required CI run `29848332682` passed |
+| Working branch | `codex/w02-pseudonym-key-lifecycle` |
+| Git state | This snapshot is based on protected `main` commit `0d049268f850b75fc071e991f8a3ae7bbe0d97bb`; every job in post-merge Required CI run `29858595039` passed |
 | Public source baseline | `that1guy15/Milhouse-oss@fb81a7faf2c101e8bb3f08ef9120d82c2b20600b` |
 | Private reference baseline | `that1guy15/milhouse@18ee9514ee11413812fde8fe361405b3686e025f` |
 | External mutation authority | Owner authorized build-branch pushes, pull requests, and merges to `main` after required checks on 2026-07-19. Tags, package publication, announcements, live-provider calls, and unrelated external mutation remain separately controlled |
 | Highest passed gate | G01 |
-| Active package | W02 implementation: secure runtime paths and explicit secret loading after the merged domain, config, identity, record, and privacy foundations |
+| Active package | W02 implementation: secure pseudonym-key material lifecycle after the merged domain, config, identity, record, privacy, runtime-path, and secret-loading foundations |
 
 The audited public baseline is the source scaffold. The private baseline is a
 read-only behavior and algorithm donor. Its history, configuration, telemetry,
@@ -74,7 +74,7 @@ evidence. A later regression returns the affected gate to **In progress**.
 |---|---|---|---|---|
 | W00 — authority, governance, ADRs | Owner plan approval | **Passed** | PR #1 merged as signed squash commit `79b9fdca3c567b1de48a3136fbe4ba0dd981926a`; reviewed head tree matched protected `main`; post-merge `test` and `gitleaks` passed | E01 and E02 complete for G00; third-party PVR delivery remains E01/E05 at G17 |
 | W01 — package and quality toolchain | G00 | **Passed** | [G01 evidence](gate-evidence/G01.md): exact candidate and remediation trees passed local gates, 18-check hosted PR runs, three independent reviews, signed protected merges, exact-tree equality, post-merge required CI, and corrected default-branch updater execution at commit `333c051ea1018a624715b98bf5dad7c885bdeca5` | G01 accepted by engineering on 2026-07-19 under the owner-authorized solo-maintainer path; aggregate `required-ci` and protection controls remain active |
-| W02 — domain, config, identity, privacy | G01 | **In progress** | Merged PRs #8-#13 provide deterministic bytes/IDs, strict config/schema/CLI foundations, canonical record envelopes, keyed pseudonyms, safe URL/path/evidence handling, layered redaction, and nested allowlists. This candidate adds secure runtime-path and explicit secret-source loading; key lifecycle, durations/logging, and complete G02 adversarial evidence remain required before `Passed` | None beyond review |
+| W02 — domain, config, identity, privacy | G01 | **In progress** | Merged PRs #8-#14 provide deterministic bytes/IDs, strict config/schema/CLI foundations, canonical record envelopes, keyed pseudonyms, safe URL/path/evidence handling, layered redaction, nested allowlists, secure runtime paths, and explicit secret loading. This candidate adds runtime-generation binding, staged and fsynced atomic no-overwrite key publication, ACL-aware owner-only validation, exact published-byte verification, and explicit commit-uncertain recovery. W06 still owns initialization and stale staging-artifact orchestration; W16 owns backup, restore, identity continuity, and rotation. Durations, structured logging/errors, common egress enforcement, plugin validation, cross-platform identity evidence, and the final G02 adversarial corpus remain required before `Passed` | None beyond review |
 | W03 — SQLite, spool, replay, retention | G02 | Pending | Every durable-write kill point; concurrency; corruption recovery; replay of 10,000 records twice; permissions; privacy-expiry behavior | Access to a supported local filesystem/host if not available to engineering |
 | W04 — ClickHouse and recovery | G02; G04b also requires G03 | Pending | G04a auth/migrations/checksums; G04b idempotent delivery, 24-hour simulated outage drain, and verified native restore | Docker-capable supported host if not available to engineering |
 | W05 — runtime/canary vertical slice | G03 and G04 | Pending | Full canary-to-query slice; ClickHouse outage behavior; exact-once logical drain; alert transition cases | None beyond review |

--- a/src/milhouse/config/filesystem.py
+++ b/src/milhouse/config/filesystem.py
@@ -1,23 +1,54 @@
-"""Descriptor-relative, no-follow primitives for selected configuration files."""
+"""Descriptor-relative, no-follow primitives for selected runtime files."""
 
 from __future__ import annotations
 
+import ctypes
 import errno
+import hmac
 import os
+import secrets
 import stat
+import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+from typing import Any
 
 
 class SecureFileErrorKind(StrEnum):
     """Value-safe failure categories translated by each configuration surface."""
 
+    ACCESS_CONTROL_UNSAFE = "access_control_unsafe"
+    ALREADY_EXISTS = "already_exists"
+    CHANGED = "changed"
+    CLEANUP_FAILED = "cleanup_failed"
+    COMMIT_UNCERTAIN = "commit_uncertain"
     INVALID = "invalid"
     NOT_FOUND = "not_found"
     NOT_REGULAR = "not_regular"
+    PARENT_UNSAFE = "parent_unsafe"
+    PERMISSION_FAILED = "permission_failed"
     SECURITY_UNSUPPORTED = "security_unsupported"
+    SYNC_FAILED = "sync_failed"
     UNREADABLE = "unreadable"
+    WRITE_FAILED = "write_failed"
+
+
+_STAGED_FILE_PREFIX = ".milhouse-stage-"
+_STAGED_FILE_ATTEMPTS = 16
+_MACOS_ACL_TYPE_EXTENDED = 0x00000100
+_LINUX_ACL_XATTR_NAMES = (
+    b"system.posix_acl_access",
+    b"system.posix_acl_default",
+)
+
+
+class _BeforePublishFailure(BaseException):
+    """Carry a caller-owned failure through exact staged-file cleanup."""
+
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
 
 
 class SecureFileError(Exception):
@@ -115,25 +146,502 @@ def _open_directory_chain(path: Path, *, nofollow: int) -> tuple[int, str]:
 
     directory_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
     directory_flags |= getattr(os, "O_DIRECTORY", 0) | nofollow
-    directory_descriptor = os.open(parts[0], directory_flags)
+    directory_descriptor: int | None = None
     try:
+        directory_descriptor = os.open(parts[0], directory_flags)
         for component in parts[1:-1]:
-            next_descriptor = os.open(component, directory_flags, dir_fd=directory_descriptor)
+            next_descriptor: int | None = None
             try:
+                next_descriptor = os.open(component, directory_flags, dir_fd=directory_descriptor)
                 if not stat.S_ISDIR(os.fstat(next_descriptor).st_mode):
                     raise OSError(errno.ENOTDIR, "path component is not a directory")
             except BaseException:
-                os.close(next_descriptor)
+                if next_descriptor is not None:
+                    try:
+                        os.close(next_descriptor)
+                    except OSError:
+                        pass
                 raise
-            os.close(directory_descriptor)
+            previous_descriptor = directory_descriptor
             directory_descriptor = next_descriptor
-        return directory_descriptor, parts[-1]
+            next_descriptor = None
+            try:
+                os.close(previous_descriptor)
+            except OSError:
+                current_descriptor = directory_descriptor
+                directory_descriptor = None
+                try:
+                    os.close(current_descriptor)
+                except OSError:
+                    pass
+                raise SecureFileError(SecureFileErrorKind.UNREADABLE) from None
+        result = directory_descriptor
+        directory_descriptor = None
+        return result, parts[-1]
     except BaseException:
-        os.close(directory_descriptor)
+        if directory_descriptor is not None:
+            try:
+                os.close(directory_descriptor)
+            except OSError:
+                pass
         raise
 
 
-def open_regular_file_no_follow(path: str | Path) -> OpenedRegularFile:
+def _exclusive_rename_primitive() -> tuple[Any, int]:
+    """Return the supported kernel primitive for an atomic no-overwrite rename."""
+
+    if sys.platform == "darwin":
+        function_name = "renameatx_np"
+        flag = 0x00000004  # RENAME_EXCL
+    elif sys.platform.startswith("linux"):
+        function_name = "renameat2"
+        flag = 0x00000001  # RENAME_NOREPLACE
+    else:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+    try:
+        library = ctypes.CDLL(None, use_errno=True)
+        function: Any = getattr(library, function_name)
+        function.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_uint,
+        ]
+        function.restype = ctypes.c_int
+    except Exception:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED) from None
+    return function, flag
+
+
+def _rename_no_replace(
+    directory_descriptor: int,
+    staged_leaf: str,
+    final_leaf: str,
+    *,
+    primitive: Any,
+    flag: int,
+) -> None:
+    """Atomically publish one staged leaf only when the destination is absent."""
+
+    ctypes.set_errno(0)
+    try:
+        result = primitive(
+            directory_descriptor,
+            os.fsencode(staged_leaf),
+            directory_descriptor,
+            os.fsencode(final_leaf),
+            flag,
+        )
+    except Exception:
+        raise SecureFileError(SecureFileErrorKind.COMMIT_UNCERTAIN) from None
+    if result == 0:
+        return
+    error_number = ctypes.get_errno()
+    if error_number in {errno.EEXIST, errno.ENOTEMPTY}:
+        raise SecureFileError(SecureFileErrorKind.ALREADY_EXISTS)
+    if error_number == errno.EIO:
+        raise SecureFileError(SecureFileErrorKind.COMMIT_UNCERTAIN)
+    if error_number in {errno.ENOSYS, errno.ENOTSUP, errno.EOPNOTSUPP, errno.EINVAL}:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+    raise SecureFileError(SecureFileErrorKind.WRITE_FAILED)
+
+
+def _macos_descriptor_has_extended_acl(descriptor: int) -> bool:
+    """Inspect a descriptor for a macOS NFSv4-style extended ACL."""
+
+    try:
+        library = ctypes.CDLL(None, use_errno=True)
+        get_acl: Any = library.acl_get_fd_np
+        get_acl.argtypes = [ctypes.c_int, ctypes.c_int]
+        get_acl.restype = ctypes.c_void_p
+        free_acl: Any = library.acl_free
+        free_acl.argtypes = [ctypes.c_void_p]
+        free_acl.restype = ctypes.c_int
+    except Exception:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED) from None
+
+    try:
+        ctypes.set_errno(0)
+        acl = get_acl(descriptor, _MACOS_ACL_TYPE_EXTENDED)
+    except Exception:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED) from None
+    if not acl:
+        no_acl_errors = {errno.ENOENT}
+        enoattr = getattr(errno, "ENOATTR", None)
+        if enoattr is not None:
+            no_acl_errors.add(enoattr)
+        if ctypes.get_errno() in no_acl_errors:
+            return False
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+    try:
+        return True
+    finally:
+        try:
+            free_acl(acl)
+        except Exception:
+            raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED) from None
+
+
+def _linux_descriptor_has_extended_acl(descriptor: int) -> bool:
+    """Inspect a descriptor for Linux POSIX access or inheritable default ACLs."""
+
+    try:
+        library = ctypes.CDLL(None, use_errno=True)
+        get_xattr: Any = library.fgetxattr
+        get_xattr.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+        ]
+        get_xattr.restype = ctypes.c_ssize_t
+    except Exception:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED) from None
+
+    no_data_errors = {getattr(errno, "ENODATA", -1)}
+    enoattr = getattr(errno, "ENOATTR", None)
+    if enoattr is not None:
+        no_data_errors.add(enoattr)
+    for attribute_name in _LINUX_ACL_XATTR_NAMES:
+        try:
+            ctypes.set_errno(0)
+            size = get_xattr(descriptor, attribute_name, None, 0)
+        except Exception:
+            raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED) from None
+        if size >= 0:
+            return True
+        if ctypes.get_errno() not in no_data_errors:
+            raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+    return False
+
+
+def _descriptor_has_extended_acl(descriptor: int) -> bool:
+    if sys.platform == "darwin":
+        return _macos_descriptor_has_extended_acl(descriptor)
+    elif sys.platform.startswith("linux"):
+        return _linux_descriptor_has_extended_acl(descriptor)
+    raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+
+
+def _require_no_extended_acl(descriptor: int) -> None:
+    """Fail closed when mode bits are supplemented by an extended ACL."""
+
+    if _descriptor_has_extended_acl(descriptor):
+        raise SecureFileError(SecureFileErrorKind.ACCESS_CONTROL_UNSAFE)
+
+
+def _require_private_parent(descriptor: int, metadata: os.stat_result) -> None:
+    """Require the key namespace to be owned and accessible only by the current user."""
+
+    effective_user_id = getattr(os, "geteuid", None)
+    if effective_user_id is None:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+    try:
+        owner = effective_user_id()
+    except OSError:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED) from None
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != owner
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise SecureFileError(SecureFileErrorKind.PARENT_UNSAFE)
+    try:
+        _require_no_extended_acl(descriptor)
+    except SecureFileError as error:
+        if error.kind is SecureFileErrorKind.ACCESS_CONTROL_UNSAFE:
+            raise SecureFileError(SecureFileErrorKind.PARENT_UNSAFE) from None
+        raise
+
+
+def _validate_created_metadata(
+    metadata: os.stat_result,
+    *,
+    content_size: int,
+    mode: int,
+) -> None:
+    effective_user_id = getattr(os, "geteuid", None)
+    if effective_user_id is None:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+    try:
+        owner = effective_user_id()
+    except OSError:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED) from None
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_size != content_size
+        or stat.S_IMODE(metadata.st_mode) != mode
+        or metadata.st_uid != owner
+        or metadata.st_nlink != 1
+    ):
+        raise SecureFileError(SecureFileErrorKind.CHANGED)
+
+
+def _sanitize_staged_descriptor(descriptor: int) -> None:
+    """Remove logical content from the exact staged inode without unlinking a mutable name."""
+
+    try:
+        os.ftruncate(descriptor, 0)
+        os.fsync(descriptor)
+    except OSError:
+        raise SecureFileError(SecureFileErrorKind.CLEANUP_FAILED) from None
+
+
+def _descriptor_content_matches(descriptor: int, expected: bytes) -> bool:
+    """Read back one bounded descriptor value and compare it without content-dependent timing."""
+
+    chunks: list[bytes] = []
+    offset = 0
+    remaining = len(expected) + 1
+    try:
+        while remaining:
+            chunk = os.pread(descriptor, remaining, offset)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            offset += len(chunk)
+            remaining -= len(chunk)
+    except Exception:
+        raise SecureFileError(SecureFileErrorKind.UNREADABLE) from None
+    return hmac.compare_digest(b"".join(chunks), expected)
+
+
+def create_regular_file_no_follow(
+    path: str | Path,
+    content: bytes,
+    *,
+    mode: int,
+    before_publish: Callable[[], None] | None = None,
+    require_private_parent: bool = False,
+) -> FileSelection:
+    """Stage, fsync, and atomically publish one regular file without overwriting a name.
+
+    The parent directory must already exist.  Before publication, failures sanitize the exact open
+    staging inode and never unlink a path that could have been replaced.  A process interruption can
+    leave an owner-only staging artifact, but the final path is either absent or a complete file.
+    Failures after the atomic publication are reported as commit-uncertain for explicit recovery.
+    """
+
+    normalized = lexical_absolute_path(path)
+    if type(content) is not bytes or not content:
+        raise SecureFileError(SecureFileErrorKind.INVALID)
+    if type(mode) is not int or not 0 < mode <= 0o777:
+        raise SecureFileError(SecureFileErrorKind.INVALID)
+    if before_publish is not None and not callable(before_publish):
+        raise SecureFileError(SecureFileErrorKind.INVALID)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow == 0:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+    primitive, rename_flag = _exclusive_rename_primitive()
+
+    file_flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | nofollow
+    directory_descriptor: int | None = None
+    descriptor: int | None = None
+    staged = False
+    published = False
+    publication_uncertain = False
+    failure: BaseException | None = None
+    result: FileSelection | None = None
+    leaf = ""
+    staged_leaf = ""
+    try:
+        directory_descriptor, leaf = _open_directory_chain(normalized, nofollow=nofollow)
+        parent_metadata = os.fstat(directory_descriptor)
+        if require_private_parent:
+            _require_private_parent(directory_descriptor, parent_metadata)
+        try:
+            os.stat(leaf, dir_fd=directory_descriptor, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise SecureFileError(SecureFileErrorKind.ALREADY_EXISTS)
+
+        for _attempt in range(_STAGED_FILE_ATTEMPTS):
+            try:
+                staged_token = secrets.token_hex(16)
+            except Exception:
+                raise SecureFileError(SecureFileErrorKind.WRITE_FAILED) from None
+            if (
+                type(staged_token) is not str
+                or len(staged_token) != 32
+                or any(character not in "0123456789abcdef" for character in staged_token)
+            ):
+                raise SecureFileError(SecureFileErrorKind.WRITE_FAILED)
+            staged_leaf = f"{_STAGED_FILE_PREFIX}{staged_token}"
+            try:
+                descriptor = os.open(
+                    staged_leaf,
+                    file_flags,
+                    mode,
+                    dir_fd=directory_descriptor,
+                )
+            except FileExistsError:
+                continue
+            staged = True
+            break
+        if descriptor is None:
+            raise SecureFileError(SecureFileErrorKind.WRITE_FAILED)
+
+        initial_metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(initial_metadata.st_mode):
+            raise SecureFileError(SecureFileErrorKind.NOT_REGULAR)
+        try:
+            os.fchmod(descriptor, mode)
+        except OSError:
+            raise SecureFileError(SecureFileErrorKind.PERMISSION_FAILED) from None
+        if require_private_parent:
+            _require_no_extended_acl(descriptor)
+
+        offset = 0
+        while offset < len(content):
+            try:
+                written = os.write(descriptor, content[offset:])
+            except OSError:
+                raise SecureFileError(SecureFileErrorKind.WRITE_FAILED) from None
+            if written <= 0:
+                raise SecureFileError(SecureFileErrorKind.WRITE_FAILED)
+            offset += written
+
+        try:
+            os.fsync(descriptor)
+        except OSError:
+            raise SecureFileError(SecureFileErrorKind.SYNC_FAILED) from None
+
+        final_metadata = os.fstat(descriptor)
+        _validate_created_metadata(final_metadata, content_size=len(content), mode=mode)
+        if not _descriptor_content_matches(descriptor, content):
+            raise SecureFileError(SecureFileErrorKind.CHANGED)
+        if require_private_parent:
+            _require_no_extended_acl(descriptor)
+        if before_publish is not None:
+            try:
+                before_publish()
+            except BaseException as error:
+                raise _BeforePublishFailure(error) from None
+        publication_uncertain = True
+        try:
+            _rename_no_replace(
+                directory_descriptor,
+                staged_leaf,
+                leaf,
+                primitive=primitive,
+                flag=rename_flag,
+            )
+        except SecureFileError as error:
+            if error.kind is not SecureFileErrorKind.COMMIT_UNCERTAIN:
+                publication_uncertain = False
+            raise
+        published = True
+        publication_uncertain = False
+        try:
+            os.fsync(directory_descriptor)
+        except OSError:
+            raise SecureFileError(SecureFileErrorKind.COMMIT_UNCERTAIN) from None
+
+        published_metadata = os.fstat(descriptor)
+        _validate_created_metadata(published_metadata, content_size=len(content), mode=mode)
+        try:
+            current = inspect_regular_file_no_follow(
+                normalized,
+                require_private_parent=require_private_parent,
+            )
+        except SecureFileError:
+            raise SecureFileError(SecureFileErrorKind.COMMIT_UNCERTAIN) from None
+        if current.parent_identity != FileIdentity.from_stat(
+            parent_metadata
+        ) or current.snapshot != FileSnapshot.from_stat(published_metadata):
+            raise SecureFileError(SecureFileErrorKind.COMMIT_UNCERTAIN)
+        if not _descriptor_content_matches(descriptor, content):
+            raise SecureFileError(SecureFileErrorKind.COMMIT_UNCERTAIN)
+        verified_metadata = os.fstat(descriptor)
+        _validate_created_metadata(verified_metadata, content_size=len(content), mode=mode)
+        if FileSnapshot.from_stat(verified_metadata) != current.snapshot:
+            raise SecureFileError(SecureFileErrorKind.COMMIT_UNCERTAIN)
+        result = current
+    except _BeforePublishFailure as wrapper:
+        failure = wrapper.error
+    except SecureFileError as error:
+        failure = (
+            SecureFileError(SecureFileErrorKind.COMMIT_UNCERTAIN)
+            if published or publication_uncertain
+            else error
+        )
+    except FileNotFoundError:
+        kind = (
+            SecureFileErrorKind.COMMIT_UNCERTAIN
+            if published or publication_uncertain
+            else SecureFileErrorKind.NOT_FOUND
+        )
+        failure = SecureFileError(kind)
+    except ValueError:
+        kind = (
+            SecureFileErrorKind.COMMIT_UNCERTAIN
+            if published or publication_uncertain
+            else SecureFileErrorKind.INVALID
+        )
+        failure = SecureFileError(kind)
+    except OSError as exc:
+        if published or publication_uncertain:
+            kind = SecureFileErrorKind.COMMIT_UNCERTAIN
+        else:
+            kind = (
+                SecureFileErrorKind.NOT_REGULAR
+                if exc.errno in {errno.ELOOP, errno.ENOTDIR}
+                else SecureFileErrorKind.UNREADABLE
+            )
+        failure = SecureFileError(kind)
+    except Exception:
+        kind = (
+            SecureFileErrorKind.COMMIT_UNCERTAIN
+            if published or publication_uncertain
+            else SecureFileErrorKind.UNREADABLE
+        )
+        failure = SecureFileError(kind)
+    except BaseException as error:
+        failure = error
+    finally:
+        if descriptor is not None:
+            if staged and not published and not publication_uncertain:
+                try:
+                    _sanitize_staged_descriptor(descriptor)
+                except SecureFileError as cleanup_error:
+                    failure = cleanup_error
+            closing_descriptor = descriptor
+            descriptor = None
+            try:
+                os.close(closing_descriptor)
+            except OSError:
+                failure = SecureFileError(
+                    SecureFileErrorKind.COMMIT_UNCERTAIN
+                    if published or publication_uncertain
+                    else SecureFileErrorKind.CLEANUP_FAILED
+                )
+        if directory_descriptor is not None:
+            closing_directory = directory_descriptor
+            directory_descriptor = None
+            try:
+                os.close(closing_directory)
+            except OSError:
+                if failure is None:
+                    failure = SecureFileError(
+                        SecureFileErrorKind.COMMIT_UNCERTAIN
+                        if published or publication_uncertain
+                        else SecureFileErrorKind.UNREADABLE
+                    )
+
+    if failure is None and result is not None:
+        return result
+    if failure is None:  # pragma: no cover - defensive invariant
+        failure = SecureFileError(SecureFileErrorKind.UNREADABLE)
+    raise failure
+
+
+def open_regular_file_no_follow(
+    path: str | Path,
+    *,
+    require_private_parent: bool = False,
+) -> OpenedRegularFile:
     """Open an explicit regular file without following any parent or leaf symlink."""
 
     normalized = lexical_absolute_path(path)
@@ -144,44 +652,130 @@ def open_regular_file_no_follow(path: str | Path) -> OpenedRegularFile:
     file_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0) | nofollow
     directory_descriptor: int | None = None
     descriptor: int | None = None
+    selection: FileSelection | None = None
+    failure: BaseException | None = None
     try:
         directory_descriptor, leaf = _open_directory_chain(normalized, nofollow=nofollow)
         parent_metadata = os.fstat(directory_descriptor)
+        if require_private_parent:
+            _require_private_parent(directory_descriptor, parent_metadata)
         descriptor = os.open(leaf, file_flags, dir_fd=directory_descriptor)
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise SecureFileError(SecureFileErrorKind.NOT_REGULAR)
-        result = OpenedRegularFile(
-            descriptor=descriptor,
-            selection=FileSelection(
-                path=normalized,
-                parent_identity=FileIdentity.from_stat(parent_metadata),
-                snapshot=FileSnapshot.from_stat(metadata),
-            ),
+        if require_private_parent:
+            _require_no_extended_acl(descriptor)
+        selection = FileSelection(
+            path=normalized,
+            parent_identity=FileIdentity.from_stat(parent_metadata),
+            snapshot=FileSnapshot.from_stat(metadata),
         )
-        descriptor = None
-        return result
     except FileNotFoundError:
-        raise SecureFileError(SecureFileErrorKind.NOT_FOUND) from None
-    except SecureFileError:
-        raise
+        failure = SecureFileError(SecureFileErrorKind.NOT_FOUND)
+    except SecureFileError as error:
+        failure = error
     except ValueError:
-        raise SecureFileError(SecureFileErrorKind.INVALID) from None
+        failure = SecureFileError(SecureFileErrorKind.INVALID)
     except OSError as exc:
-        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
-            raise SecureFileError(SecureFileErrorKind.NOT_REGULAR) from None
-        raise SecureFileError(SecureFileErrorKind.UNREADABLE) from None
+        kind = (
+            SecureFileErrorKind.NOT_REGULAR
+            if exc.errno in {errno.ELOOP, errno.ENOTDIR}
+            else SecureFileErrorKind.UNREADABLE
+        )
+        failure = SecureFileError(kind)
+    except Exception:
+        failure = SecureFileError(SecureFileErrorKind.UNREADABLE)
+    except BaseException as error:
+        failure = error
     finally:
-        if descriptor is not None:
-            os.close(descriptor)
         if directory_descriptor is not None:
-            os.close(directory_descriptor)
+            closing_directory = directory_descriptor
+            directory_descriptor = None
+            try:
+                os.close(closing_directory)
+            except OSError:
+                if failure is None:
+                    failure = SecureFileError(SecureFileErrorKind.UNREADABLE)
+        if failure is not None and descriptor is not None:
+            closing_descriptor = descriptor
+            descriptor = None
+            try:
+                os.close(closing_descriptor)
+            except OSError:
+                pass
+
+    if failure is not None:
+        raise failure
+    if descriptor is None or selection is None:  # pragma: no cover - defensive invariant
+        raise SecureFileError(SecureFileErrorKind.UNREADABLE)
+    return OpenedRegularFile(descriptor=descriptor, selection=selection)
 
 
-def inspect_regular_file_no_follow(path: str | Path) -> FileSelection:
+def sync_parent_directory_no_follow(
+    path: str | Path,
+    *,
+    require_private_parent: bool = False,
+) -> FileIdentity:
+    """Durably synchronize the securely opened parent directory for one explicit path."""
+
+    normalized = lexical_absolute_path(path)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow == 0:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+
+    directory_descriptor: int | None = None
+    failure: SecureFileError | None = None
+    identity: FileIdentity | None = None
+    try:
+        directory_descriptor, _leaf = _open_directory_chain(normalized, nofollow=nofollow)
+        metadata = os.fstat(directory_descriptor)
+        if require_private_parent:
+            _require_private_parent(directory_descriptor, metadata)
+        os.fsync(directory_descriptor)
+        identity = FileIdentity.from_stat(metadata)
+    except FileNotFoundError:
+        failure = SecureFileError(SecureFileErrorKind.NOT_FOUND)
+    except SecureFileError as error:
+        failure = error
+    except ValueError:
+        failure = SecureFileError(SecureFileErrorKind.INVALID)
+    except OSError as exc:
+        kind = (
+            SecureFileErrorKind.NOT_REGULAR
+            if exc.errno in {errno.ELOOP, errno.ENOTDIR}
+            else SecureFileErrorKind.SYNC_FAILED
+        )
+        failure = SecureFileError(kind)
+    except Exception:
+        failure = SecureFileError(SecureFileErrorKind.SYNC_FAILED)
+    finally:
+        if directory_descriptor is not None:
+            closing_directory = directory_descriptor
+            directory_descriptor = None
+            try:
+                os.close(closing_directory)
+            except OSError:
+                if failure is None:
+                    failure = SecureFileError(SecureFileErrorKind.UNREADABLE)
+
+    if failure is not None:
+        raise failure
+    if identity is None:  # pragma: no cover - defensive invariant
+        raise SecureFileError(SecureFileErrorKind.UNREADABLE)
+    return identity
+
+
+def inspect_regular_file_no_follow(
+    path: str | Path,
+    *,
+    require_private_parent: bool = False,
+) -> FileSelection:
     """Capture a secure file selection and close its descriptor before returning."""
 
-    opened = open_regular_file_no_follow(path)
+    opened = open_regular_file_no_follow(
+        path,
+        require_private_parent=require_private_parent,
+    )
     try:
         os.close(opened.descriptor)
     except OSError:
@@ -196,7 +790,9 @@ __all__ = [
     "OpenedRegularFile",
     "SecureFileError",
     "SecureFileErrorKind",
+    "create_regular_file_no_follow",
     "inspect_regular_file_no_follow",
     "lexical_absolute_path",
     "open_regular_file_no_follow",
+    "sync_parent_directory_no_follow",
 ]

--- a/src/milhouse/config/paths.py
+++ b/src/milhouse/config/paths.py
@@ -24,8 +24,8 @@ MILHOUSE_HOME_ENV_VAR = "MILHOUSE_HOME"
 
 
 @dataclass(frozen=True, slots=True, repr=False)
-class RuntimePaths:
-    """Immutable canonical paths whose representation never exposes local path text."""
+class _RuntimePathGeneration:
+    """Private snapshot proving that one set of paths came from a single resolution."""
 
     config_file: Path
     config_dir: Path
@@ -39,9 +39,61 @@ class RuntimePaths:
     configured_env_files: tuple[Path, ...]
 
     def __repr__(self) -> str:
+        return "RuntimePathGeneration(bound=True)"
+
+    __str__ = __repr__
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class RuntimePaths:
+    """Immutable canonical paths whose representation never exposes local path text."""
+
+    config_file: Path
+    config_dir: Path
+    config_selection: ConfigFileSelection
+    state_root: Path
+    spool: Path
+    reports: Path
+    logs: Path
+    backups: Path
+    pseudonym_key: Path
+    configured_env_files: tuple[Path, ...]
+    _generation: _RuntimePathGeneration
+
+    def __repr__(self) -> str:
         return f"RuntimePaths(resolved=True, configured_env_files={len(self.configured_env_files)})"
 
     __str__ = __repr__
+
+
+def verify_runtime_path_generation(paths: RuntimePaths) -> RuntimePaths:
+    """Refuse runtime-path fields changed after their authoritative resolution."""
+
+    if not isinstance(paths, RuntimePaths) or not isinstance(
+        paths._generation, _RuntimePathGeneration
+    ):
+        raise _path_error(
+            "config.paths.generation_mismatch",
+            "runtime paths do not match their resolved generation",
+        )
+    current = _RuntimePathGeneration(
+        config_file=paths.config_file,
+        config_dir=paths.config_dir,
+        config_selection=paths.config_selection,
+        state_root=paths.state_root,
+        spool=paths.spool,
+        reports=paths.reports,
+        logs=paths.logs,
+        backups=paths.backups,
+        pseudonym_key=paths.pseudonym_key,
+        configured_env_files=paths.configured_env_files,
+    )
+    if current != paths._generation:
+        raise _path_error(
+            "config.paths.generation_mismatch",
+            "runtime paths do not match their resolved generation",
+        )
+    return paths
 
 
 def _path_error(code: str, message: str) -> ConfigError:
@@ -230,7 +282,7 @@ def resolve_runtime_paths(
     )
     verify_config_generation(config, config_selection)
 
-    return RuntimePaths(
+    generation = _RuntimePathGeneration(
         config_file=config_file,
         config_dir=config_dir,
         config_selection=config_selection,
@@ -242,6 +294,19 @@ def resolve_runtime_paths(
         pseudonym_key=pseudonym_key,
         configured_env_files=configured_env_files,
     )
+    return RuntimePaths(
+        config_file=config_file,
+        config_dir=config_dir,
+        config_selection=config_selection,
+        state_root=state_root,
+        spool=spool,
+        reports=reports,
+        logs=logs,
+        backups=backups,
+        pseudonym_key=pseudonym_key,
+        configured_env_files=configured_env_files,
+        _generation=generation,
+    )
 
 
 __all__ = [
@@ -249,4 +314,5 @@ __all__ = [
     "RuntimePaths",
     "resolve_config_source_path",
     "resolve_runtime_paths",
+    "verify_runtime_path_generation",
 ]

--- a/src/milhouse/privacy/__init__.py
+++ b/src/milhouse/privacy/__init__.py
@@ -6,21 +6,38 @@ from milhouse.privacy.allowlist import (
     FieldRule,
     apply_field_allowlist,
 )
-from milhouse.privacy.pseudonym import PrivacyError, Pseudonymizer
+from milhouse.privacy.keys import (
+    PSEUDONYM_KEY_MODE,
+    PseudonymKeyCommitUncertain,
+    create_pseudonym_key,
+    load_pseudonym_key,
+    recover_pseudonym_key_creation,
+)
+from milhouse.privacy.pseudonym import (
+    PSEUDONYM_KEY_BYTES,
+    PrivacyError,
+    Pseudonymizer,
+)
 from milhouse.privacy.redact import LayeredRedactor, RedactionResult
 from milhouse.privacy.render import render_untrusted_evidence
 from milhouse.privacy.sanitize import SanitizedUrl, sanitize_local_path, sanitize_url
 
 __all__ = [
+    "PSEUDONYM_KEY_BYTES",
+    "PSEUDONYM_KEY_MODE",
     "AllowedFields",
     "FieldAllowlist",
     "FieldRule",
     "LayeredRedactor",
     "PrivacyError",
+    "PseudonymKeyCommitUncertain",
     "Pseudonymizer",
     "RedactionResult",
     "SanitizedUrl",
     "apply_field_allowlist",
+    "create_pseudonym_key",
+    "load_pseudonym_key",
+    "recover_pseudonym_key_creation",
     "render_untrusted_evidence",
     "sanitize_local_path",
     "sanitize_url",

--- a/src/milhouse/privacy/keys.py
+++ b/src/milhouse/privacy/keys.py
@@ -1,0 +1,499 @@
+"""Secure creation and loading of installation-local pseudonym key material."""
+
+from __future__ import annotations
+
+import hmac
+import os
+import re
+import secrets
+import stat
+from collections.abc import Callable
+from pathlib import Path
+
+from milhouse.config.filesystem import (
+    FileSelection,
+    SecureFileError,
+    SecureFileErrorKind,
+    create_regular_file_no_follow,
+    inspect_regular_file_no_follow,
+    open_regular_file_no_follow,
+    sync_parent_directory_no_follow,
+)
+from milhouse.config.loader import verify_config_generation
+from milhouse.config.models import MilhouseConfig
+from milhouse.config.paths import RuntimePaths, verify_runtime_path_generation
+from milhouse.privacy.pseudonym import (
+    PSEUDONYM_KEY_BYTES,
+    PrivacyError,
+    Pseudonymizer,
+    validate_pseudonym_epoch,
+)
+
+PSEUDONYM_KEY_MODE = 0o600
+
+_KEY_ID_PATTERN = re.compile(r"^mh_pk1_[0-9a-f]{16}$")
+
+
+class PseudonymKeyCommitUncertain(PrivacyError):
+    """A published key needs explicit identity-checked durability recovery."""
+
+    __slots__ = ("__key_id",)
+
+    def __init__(self, key_id: str) -> None:
+        super().__init__(
+            "MH_PRIVACY_KEY_COMMIT_UNCERTAIN",
+            "pseudonym key publication requires explicit recovery",
+        )
+        self.__key_id = key_id
+
+    @property
+    def key_id(self) -> str:
+        """Return the non-secret key ID required by the recovery operation."""
+
+        return self.__key_id
+
+    def __repr__(self) -> str:
+        return "PseudonymKeyCommitUncertain(recovery_required=True)"
+
+
+def _key_error(code: str, message: str) -> PrivacyError:
+    return PrivacyError(code, message)
+
+
+def _bound_key_path(config: MilhouseConfig, paths: RuntimePaths) -> Path:
+    """Return the key path only when it matches one securely loaded runtime generation."""
+
+    if getattr(os, "O_NOFOLLOW", 0) == 0:
+        raise _key_error(
+            "MH_PRIVACY_KEY_SECURITY_UNSUPPORTED",
+            "safe pseudonym key filesystem operations are unavailable",
+        )
+    if not isinstance(config, MilhouseConfig) or not isinstance(paths, RuntimePaths):
+        raise _key_error(
+            "MH_PRIVACY_KEY_BINDING",
+            "pseudonym key access requires validated runtime paths",
+        )
+    try:
+        selection = verify_config_generation(config, paths.config_selection)
+    except Exception:
+        raise _key_error(
+            "MH_PRIVACY_KEY_CONFIG",
+            "validated configuration changed before pseudonym key access",
+        ) from None
+
+    try:
+        state_root = Path(os.path.normpath(os.fspath(paths.state_root)))
+        key_path = Path(os.path.normpath(os.fspath(paths.pseudonym_key)))
+        config_file = Path(os.path.normpath(os.fspath(paths.config_file)))
+        config_dir = Path(os.path.normpath(os.fspath(paths.config_dir)))
+    except (OSError, TypeError, ValueError):
+        raise _key_error(
+            "MH_PRIVACY_KEY_BINDING",
+            "pseudonym key runtime paths are invalid",
+        ) from None
+
+    if (
+        not state_root.is_absolute()
+        or state_root == Path(state_root.anchor)
+        or not key_path.is_absolute()
+        or config_file != selection.path
+        or config_dir != config_file.parent
+    ):
+        raise _key_error(
+            "MH_PRIVACY_KEY_BINDING",
+            "pseudonym key runtime paths do not match the selected configuration",
+        )
+    try:
+        relative_key = key_path.relative_to(state_root)
+    except ValueError:
+        raise _key_error(
+            "MH_PRIVACY_KEY_ESCAPE",
+            "pseudonym key must remain beneath STATE_ROOT",
+        ) from None
+    if not relative_key.parts:
+        raise _key_error(
+            "MH_PRIVACY_KEY_ESCAPE",
+            "pseudonym key must remain beneath STATE_ROOT",
+        )
+
+    configured = Path(config.identity.pseudonym_key_path)
+    expected = configured if configured.is_absolute() else state_root / configured
+    expected = Path(os.path.normpath(os.fspath(expected)))
+    try:
+        expected.relative_to(state_root)
+    except ValueError:
+        raise _key_error(
+            "MH_PRIVACY_KEY_ESCAPE",
+            "configured pseudonym key must remain beneath STATE_ROOT",
+        ) from None
+    if key_path != expected:
+        raise _key_error(
+            "MH_PRIVACY_KEY_BINDING",
+            "pseudonym key path does not match the selected configuration",
+        )
+
+    try:
+        verify_runtime_path_generation(paths)
+    except Exception:
+        raise _key_error(
+            "MH_PRIVACY_KEY_BINDING",
+            "runtime paths changed after their validated resolution",
+        ) from None
+    try:
+        verify_config_generation(config, selection)
+    except Exception:
+        raise _key_error(
+            "MH_PRIVACY_KEY_CONFIG",
+            "validated configuration changed before pseudonym key access",
+        ) from None
+    return key_path
+
+
+def _create_error(error: SecureFileError, *, key_id: str) -> PrivacyError:
+    if error.kind is SecureFileErrorKind.ACCESS_CONTROL_UNSAFE:
+        return _key_error(
+            "MH_PRIVACY_KEY_ACL",
+            "pseudonym key must not have extended access controls",
+        )
+    if error.kind is SecureFileErrorKind.ALREADY_EXISTS:
+        return _key_error(
+            "MH_PRIVACY_KEY_EXISTS",
+            "pseudonym key already exists and will not be overwritten",
+        )
+    if error.kind is SecureFileErrorKind.NOT_FOUND:
+        return _key_error(
+            "MH_PRIVACY_KEY_PARENT_MISSING",
+            "pseudonym key parent directory does not exist",
+        )
+    if error.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED:
+        return _key_error(
+            "MH_PRIVACY_KEY_SECURITY_UNSUPPORTED",
+            "safe pseudonym key creation is unavailable",
+        )
+    if error.kind is SecureFileErrorKind.PARENT_UNSAFE:
+        return _key_error(
+            "MH_PRIVACY_KEY_PARENT_UNSAFE",
+            "pseudonym key parent directory must be owner-only",
+        )
+    if error.kind is SecureFileErrorKind.COMMIT_UNCERTAIN:
+        return PseudonymKeyCommitUncertain(key_id)
+    if error.kind is SecureFileErrorKind.CLEANUP_FAILED:
+        return _key_error(
+            "MH_PRIVACY_KEY_CLEANUP",
+            "failed pseudonym key creation could not be safely cleaned up",
+        )
+    if error.kind is SecureFileErrorKind.PERMISSION_FAILED:
+        return _key_error(
+            "MH_PRIVACY_KEY_PERMISSION",
+            "pseudonym key permissions could not be restricted",
+        )
+    if error.kind is SecureFileErrorKind.SYNC_FAILED:
+        return _key_error(
+            "MH_PRIVACY_KEY_SYNC",
+            "pseudonym key could not be durably synchronized",
+        )
+    if error.kind is SecureFileErrorKind.WRITE_FAILED:
+        return _key_error(
+            "MH_PRIVACY_KEY_WRITE",
+            "pseudonym key could not be completely written",
+        )
+    if error.kind is SecureFileErrorKind.CHANGED:
+        return _key_error(
+            "MH_PRIVACY_KEY_CHANGED",
+            "pseudonym key path changed during creation",
+        )
+    return _key_error(
+        "MH_PRIVACY_KEY_CREATE",
+        "pseudonym key could not be safely created",
+    )
+
+
+def _read_error(error: SecureFileError) -> PrivacyError:
+    if error.kind is SecureFileErrorKind.ACCESS_CONTROL_UNSAFE:
+        return _key_error(
+            "MH_PRIVACY_KEY_ACL",
+            "pseudonym key must not have extended access controls",
+        )
+    if error.kind is SecureFileErrorKind.NOT_FOUND:
+        return _key_error("MH_PRIVACY_KEY_NOT_FOUND", "pseudonym key was not found")
+    if error.kind is SecureFileErrorKind.NOT_REGULAR:
+        return _key_error(
+            "MH_PRIVACY_KEY_TYPE",
+            "pseudonym key must be a regular non-symlink file",
+        )
+    if error.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED:
+        return _key_error(
+            "MH_PRIVACY_KEY_SECURITY_UNSUPPORTED",
+            "safe pseudonym key loading is unavailable",
+        )
+    if error.kind is SecureFileErrorKind.PARENT_UNSAFE:
+        return _key_error(
+            "MH_PRIVACY_KEY_PARENT_UNSAFE",
+            "pseudonym key parent directory must be owner-only",
+        )
+    return _key_error("MH_PRIVACY_KEY_READ", "pseudonym key could not be safely read")
+
+
+def _metadata_coordinates(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        stat.S_IMODE(metadata.st_mode),
+        metadata.st_uid,
+        metadata.st_nlink,
+    )
+
+
+def _validate_key_metadata(metadata: os.stat_result) -> None:
+    if not stat.S_ISREG(metadata.st_mode):
+        raise _key_error(
+            "MH_PRIVACY_KEY_TYPE",
+            "pseudonym key must be a regular non-symlink file",
+        )
+    if metadata.st_size != PSEUDONYM_KEY_BYTES:
+        raise _key_error(
+            "MH_PRIVACY_KEY_SIZE",
+            f"pseudonym key must contain exactly {PSEUDONYM_KEY_BYTES} bytes",
+        )
+    if stat.S_IMODE(metadata.st_mode) != PSEUDONYM_KEY_MODE:
+        raise _key_error(
+            "MH_PRIVACY_KEY_MODE",
+            "pseudonym key must have owner-only read and write permissions",
+        )
+    effective_user_id = getattr(os, "geteuid", None)
+    if effective_user_id is None:
+        raise _key_error(
+            "MH_PRIVACY_KEY_SECURITY_UNSUPPORTED",
+            "pseudonym key ownership checks are unavailable",
+        )
+    if metadata.st_uid != effective_user_id():
+        raise _key_error(
+            "MH_PRIVACY_KEY_OWNER",
+            "pseudonym key must be owned by the current user",
+        )
+    if metadata.st_nlink != 1:
+        raise _key_error(
+            "MH_PRIVACY_KEY_LINKS",
+            "pseudonym key must have exactly one filesystem link",
+        )
+
+
+def _read_key_material(path: Path) -> bytes:
+    try:
+        opened = open_regular_file_no_follow(path, require_private_parent=True)
+    except SecureFileError as error:
+        raise _read_error(error) from None
+
+    descriptor = opened.descriptor
+    failure: PrivacyError | None = None
+    raw = b""
+    after_read: os.stat_result | None = None
+    try:
+        before_read = os.fstat(descriptor)
+        _validate_key_metadata(before_read)
+        chunks: list[bytes] = []
+        remaining = PSEUDONYM_KEY_BYTES + 1
+        while remaining:
+            chunk = os.read(descriptor, remaining)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+        after_read = os.fstat(descriptor)
+        _validate_key_metadata(after_read)
+        if _metadata_coordinates(before_read) != _metadata_coordinates(after_read):
+            raise _key_error(
+                "MH_PRIVACY_KEY_CHANGED",
+                "pseudonym key changed while it was being read",
+            )
+    except PrivacyError as error:
+        failure = error
+    except (OSError, ValueError):
+        failure = _key_error("MH_PRIVACY_KEY_READ", "pseudonym key could not be safely read")
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError:
+            failure = _key_error(
+                "MH_PRIVACY_KEY_READ",
+                "pseudonym key could not be safely read",
+            )
+
+    if failure is not None:
+        raise failure from None
+    if len(raw) != PSEUDONYM_KEY_BYTES or after_read is None:
+        raise _key_error(
+            "MH_PRIVACY_KEY_SIZE",
+            f"pseudonym key must contain exactly {PSEUDONYM_KEY_BYTES} bytes",
+        )
+
+    try:
+        current = inspect_regular_file_no_follow(path, require_private_parent=True)
+    except SecureFileError:
+        raise _key_error(
+            "MH_PRIVACY_KEY_CHANGED",
+            "pseudonym key path changed while it was being read",
+        ) from None
+    expected_selection = FileSelection(
+        path=opened.path,
+        parent_identity=opened.parent_identity,
+        snapshot=opened.snapshot,
+    )
+    if current != expected_selection:
+        raise _key_error(
+            "MH_PRIVACY_KEY_CHANGED",
+            "pseudonym key path changed while it was being read",
+        )
+    return raw
+
+
+def create_pseudonym_key(
+    config: MilhouseConfig,
+    paths: RuntimePaths,
+    *,
+    epoch: int = 1,
+    random_bytes: Callable[[int], bytes] = secrets.token_bytes,
+) -> Pseudonymizer:
+    """Create one new key without overwriting any existing path."""
+
+    validate_pseudonym_epoch(epoch)
+    try:
+        key = random_bytes(PSEUDONYM_KEY_BYTES)
+    except Exception:
+        raise _key_error(
+            "MH_PRIVACY_KEY_RANDOM",
+            "pseudonym key entropy generation failed",
+        ) from None
+    if type(key) is not bytes or len(key) != PSEUDONYM_KEY_BYTES:
+        raise _key_error(
+            "MH_PRIVACY_KEY_RANDOM",
+            "pseudonym key entropy generation returned an invalid result",
+        )
+    pseudonymizer = Pseudonymizer(key, epoch=epoch)
+    key_path = _bound_key_path(config, paths)
+
+    def verify_before_publish() -> None:
+        if _bound_key_path(config, paths) != key_path:
+            raise _key_error(
+                "MH_PRIVACY_KEY_BINDING",
+                "runtime paths changed before pseudonym key publication",
+            )
+
+    try:
+        create_regular_file_no_follow(
+            key_path,
+            key,
+            mode=PSEUDONYM_KEY_MODE,
+            before_publish=verify_before_publish,
+            require_private_parent=True,
+        )
+    except SecureFileError as error:
+        raise _create_error(error, key_id=pseudonymizer.key_id) from None
+    except PrivacyError:
+        raise
+    except Exception:
+        raise _key_error(
+            "MH_PRIVACY_KEY_CREATE",
+            "pseudonym key could not be safely created",
+        ) from None
+    return pseudonymizer
+
+
+def load_pseudonym_key(
+    config: MilhouseConfig,
+    paths: RuntimePaths,
+    *,
+    epoch: int = 1,
+    expected_key_id: str | None = None,
+) -> Pseudonymizer:
+    """Load one unchanged owner-only key and optionally verify its non-secret key ID."""
+
+    validate_pseudonym_epoch(epoch)
+    if expected_key_id is not None and (
+        type(expected_key_id) is not str or _KEY_ID_PATTERN.fullmatch(expected_key_id) is None
+    ):
+        raise _key_error(
+            "MH_PRIVACY_KEY_ID",
+            "expected pseudonym key ID is invalid",
+        )
+    key_path = _bound_key_path(config, paths)
+    try:
+        key = _read_key_material(key_path)
+    except PrivacyError:
+        raise
+    except Exception:
+        raise _key_error(
+            "MH_PRIVACY_KEY_READ",
+            "pseudonym key could not be safely read",
+        ) from None
+    try:
+        verify_config_generation(config, paths.config_selection)
+    except Exception:
+        raise _key_error(
+            "MH_PRIVACY_KEY_CONFIG",
+            "validated configuration changed during pseudonym key loading",
+        ) from None
+    pseudonymizer = Pseudonymizer(key, epoch=epoch)
+    if expected_key_id is not None and not hmac.compare_digest(
+        pseudonymizer.key_id,
+        expected_key_id,
+    ):
+        raise _key_error(
+            "MH_PRIVACY_KEY_ID_MISMATCH",
+            "pseudonym key does not match the expected key ID",
+        )
+    return pseudonymizer
+
+
+def recover_pseudonym_key_creation(
+    config: MilhouseConfig,
+    paths: RuntimePaths,
+    *,
+    expected_key_id: str,
+    epoch: int = 1,
+) -> Pseudonymizer:
+    """Verify and durably adopt a key after commit-uncertain creation."""
+
+    key_path = _bound_key_path(config, paths)
+    load_pseudonym_key(
+        config,
+        paths,
+        epoch=epoch,
+        expected_key_id=expected_key_id,
+    )
+    try:
+        sync_parent_directory_no_follow(key_path, require_private_parent=True)
+    except SecureFileError as error:
+        if error.kind is SecureFileErrorKind.PARENT_UNSAFE:
+            raise _key_error(
+                "MH_PRIVACY_KEY_PARENT_UNSAFE",
+                "pseudonym key parent directory must be owner-only",
+            ) from None
+        raise _key_error(
+            "MH_PRIVACY_KEY_RECOVERY",
+            "pseudonym key publication could not be durably recovered",
+        ) from None
+    except Exception:
+        raise _key_error(
+            "MH_PRIVACY_KEY_RECOVERY",
+            "pseudonym key publication could not be durably recovered",
+        ) from None
+    return load_pseudonym_key(
+        config,
+        paths,
+        epoch=epoch,
+        expected_key_id=expected_key_id,
+    )
+
+
+__all__ = [
+    "PSEUDONYM_KEY_MODE",
+    "PseudonymKeyCommitUncertain",
+    "create_pseudonym_key",
+    "load_pseudonym_key",
+    "recover_pseudonym_key_creation",
+]

--- a/src/milhouse/privacy/pseudonym.py
+++ b/src/milhouse/privacy/pseudonym.py
@@ -53,6 +53,14 @@ def _validate_kind(kind: str) -> bytes:
     return encoded
 
 
+def validate_pseudonym_epoch(epoch: int) -> int:
+    """Return one valid persisted pseudonym epoch without coercing booleans or strings."""
+
+    if type(epoch) is not int or not 1 <= epoch <= 2_147_483_647:
+        raise PrivacyError("MH_PRIVACY_EPOCH", "pseudonym epoch is invalid")
+    return epoch
+
+
 class Pseudonymizer:
     """Derive deterministic, domain-separated tokens without exposing the key or value."""
 
@@ -64,10 +72,8 @@ class Pseudonymizer:
                 "MH_PRIVACY_KEY_LENGTH",
                 f"pseudonym key must contain exactly {PSEUDONYM_KEY_BYTES} bytes",
             )
-        if type(epoch) is not int or not 1 <= epoch <= 2_147_483_647:
-            raise PrivacyError("MH_PRIVACY_EPOCH", "pseudonym epoch is invalid")
         self.__key = bytes(key)
-        self.__epoch = epoch
+        self.__epoch = validate_pseudonym_epoch(epoch)
 
     def __repr__(self) -> str:
         return f"Pseudonymizer(epoch={self.epoch})"
@@ -99,3 +105,13 @@ class Pseudonymizer:
 
         digest = self._digest(_FINGERPRINT_DOMAIN, kind, value)
         return f"mh_fp1_e{self.epoch}_{kind}_{_base32(digest)}"
+
+
+__all__ = [
+    "MAX_PSEUDONYM_INPUT_BYTES",
+    "MAX_PSEUDONYM_KIND_BYTES",
+    "PSEUDONYM_KEY_BYTES",
+    "PrivacyError",
+    "Pseudonymizer",
+    "validate_pseudonym_epoch",
+]

--- a/tests/property/test_pseudonym_key_properties.py
+++ b/tests/property/test_pseudonym_key_properties.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from pathlib import Path
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from milhouse.config import load_config, resolve_runtime_paths
+from milhouse.privacy import create_pseudonym_key, load_pseudonym_key
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_CONFIG = REPOSITORY_ROOT / "config/examples/local-only.toml"
+
+
+@settings(max_examples=40, deadline=None)
+@given(key=st.binary(min_size=32, max_size=32), epoch=st.integers(min_value=1, max_value=10_000))
+def test_every_exact_key_round_trips_without_public_material(
+    key: bytes,
+    epoch: int,
+) -> None:
+    temporary_root = Path(tempfile.gettempdir()).resolve()
+    with tempfile.TemporaryDirectory(
+        prefix="milhouse-key-property-",
+        dir=temporary_root,
+    ) as directory:
+        tmp_path = Path(directory)
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        config_file = config_dir / "milhouse.toml"
+        config_file.write_text(
+            EXAMPLE_CONFIG.read_text(encoding="utf-8").replace(
+                'home = "../../data/local-only"',
+                'home = "../state"',
+            ),
+            encoding="utf-8",
+        )
+        config, selection = load_config(config_file, platform_default=config_file, env={})
+        paths = resolve_runtime_paths(
+            config,
+            config_path=selection,
+            platform_data_root=tmp_path / "platform",
+            env={},
+        )
+        paths.pseudonym_key.parent.mkdir(parents=True, mode=0o700)
+
+        created = create_pseudonym_key(
+            config,
+            paths,
+            epoch=epoch,
+            random_bytes=lambda size: key,
+        )
+        loaded = load_pseudonym_key(
+            config,
+            paths,
+            epoch=epoch,
+            expected_key_id=created.key_id,
+        )
+
+        assert re.fullmatch(r"mh_pk1_[0-9a-f]{16}", created.key_id)
+        assert created.key_id == loaded.key_id
+        assert repr(created) == f"Pseudonymizer(epoch={epoch})"
+        assert key.hex() not in repr(created)
+        assert os.fspath(paths.pseudonym_key) not in repr(created)

--- a/tests/security/test_makefile_safety.py
+++ b/tests/security/test_makefile_safety.py
@@ -16,6 +16,7 @@ CRITICAL_COVERAGE_FILES = {
     "src/milhouse/core/canonical.py",
     "src/milhouse/domain/identity.py",
     "src/milhouse/domain/records.py",
+    "src/milhouse/privacy/keys.py",
     "src/milhouse/privacy/allowlist.py",
     "src/milhouse/privacy/pseudonym.py",
     "src/milhouse/privacy/redact.py",

--- a/tests/security/test_pseudonym_key_boundary.py
+++ b/tests/security/test_pseudonym_key_boundary.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+import stat
+import subprocess
+import sys
+import threading
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+import milhouse.config.filesystem as secure_filesystem
+import milhouse.privacy.keys as privacy_keys
+from milhouse.config import load_config, resolve_runtime_paths
+from milhouse.config.models import MilhouseConfig
+from milhouse.config.paths import RuntimePaths
+from milhouse.privacy import (
+    PrivacyError,
+    PseudonymKeyCommitUncertain,
+    create_pseudonym_key,
+    load_pseudonym_key,
+    recover_pseudonym_key_creation,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_CONFIG = REPOSITORY_ROOT / "config/examples/local-only.toml"
+
+
+def _runtime(tmp_path: Path) -> tuple[MilhouseConfig, RuntimePaths]:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    config_file = config_dir / "milhouse.toml"
+    config_file.write_text(
+        EXAMPLE_CONFIG.read_text(encoding="utf-8").replace(
+            'home = "../../data/local-only"',
+            'home = "../state"',
+        ),
+        encoding="utf-8",
+    )
+    config, selection = load_config(config_file, platform_default=config_file, env={})
+    paths = resolve_runtime_paths(
+        config,
+        config_path=selection,
+        platform_data_root=tmp_path / "platform",
+        env={},
+    )
+    paths.pseudonym_key.parent.mkdir(parents=True, mode=0o700)
+    return config, paths
+
+
+def test_concurrent_exclusive_creation_has_one_winner_and_never_overwrites(
+    tmp_path: Path,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    barrier = threading.Barrier(2)
+    candidates = (b"A" * 32, b"B" * 32)
+
+    def attempt(candidate: bytes) -> tuple[str, str]:
+        def synchronized_entropy(size: int) -> bytes:
+            barrier.wait(timeout=5)
+            return candidate
+
+        try:
+            created = create_pseudonym_key(
+                config,
+                paths,
+                random_bytes=synchronized_entropy,
+            )
+        except PrivacyError as error:
+            return "error", error.code
+        return "created", created.key_id
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = tuple(executor.map(attempt, candidates))
+
+    created = [value for outcome, value in results if outcome == "created"]
+    failures = [value for outcome, value in results if outcome == "error"]
+    assert len(created) == 1
+    assert failures == ["MH_PRIVACY_KEY_EXISTS"]
+    assert paths.pseudonym_key.read_bytes() in candidates
+    assert load_pseudonym_key(config, paths, expected_key_id=created[0]).key_id == created[0]
+
+
+def test_key_failures_suppress_secret_path_and_nested_os_details(
+    tmp_path: Path,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    synthetic_key = os.urandom(32)
+    private_path_text = os.fspath(paths.pseudonym_key)
+    nested_detail = f"{private_path_text}:{synthetic_key.hex()}:synthetic-os-detail"
+
+    def fail_entropy(size: int) -> bytes:
+        raise OSError(nested_detail)
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths, random_bytes=fail_entropy)
+
+    rendered = "".join(traceback.format_exception(captured.value))
+    assert captured.value.code == "MH_PRIVACY_KEY_RANDOM"
+    assert captured.value.__cause__ is None
+    assert captured.value.__suppress_context__ is True
+    assert private_path_text not in rendered
+    assert synthetic_key.hex() not in rendered
+    assert "synthetic-os-detail" not in rendered
+
+
+def test_symlinked_key_never_reads_the_target_material(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    target_key = os.urandom(32)
+    target = tmp_path / "synthetic-target.key"
+    target.write_bytes(target_key)
+    target.chmod(0o600)
+    paths.pseudonym_key.symlink_to(target)
+
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    rendered = "".join(traceback.format_exception(captured.value))
+    assert captured.value.code == "MH_PRIVACY_KEY_TYPE"
+    assert target_key.hex() not in rendered
+    assert os.fspath(target) not in rendered
+    assert os.fspath(paths.pseudonym_key) not in rendered
+
+
+def test_wrong_key_continuity_check_discloses_only_a_stable_code(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    synthetic_key = os.urandom(32)
+    create_pseudonym_key(config, paths, random_bytes=lambda size: synthetic_key)
+
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(
+            config,
+            paths,
+            expected_key_id="mh_pk1_0000000000000000",
+        )
+
+    rendered = "".join(traceback.format_exception(captured.value))
+    assert captured.value.code == "MH_PRIVACY_KEY_ID_MISMATCH"
+    assert synthetic_key.hex() not in rendered
+    assert os.fspath(paths.pseudonym_key) not in rendered
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS extended ACL regression")
+def test_macos_extended_acl_cannot_bypass_owner_only_mode_bits(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    parent = paths.pseudonym_key.parent
+    subprocess.run(
+        [
+            "chmod",
+            "+a",
+            "everyone allow read,execute,file_inherit",
+            os.fspath(parent),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert stat.S_IMODE(parent.stat().st_mode) == 0o700
+
+    with pytest.raises(PrivacyError) as unsafe_parent:
+        create_pseudonym_key(config, paths)
+    assert unsafe_parent.value.code == "MH_PRIVACY_KEY_PARENT_UNSAFE"
+    assert not paths.pseudonym_key.exists()
+
+    paths.pseudonym_key.write_bytes(b"A" * 32)
+    paths.pseudonym_key.chmod(0o600)
+    subprocess.run(
+        ["chmod", "-N", os.fspath(parent)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    acl_listing = subprocess.run(
+        ["ls", "-le", os.fspath(paths.pseudonym_key)],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert stat.S_IMODE(parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(paths.pseudonym_key.stat().st_mode) == 0o600
+    assert "everyone" in acl_listing
+
+    with pytest.raises(PrivacyError) as unsafe_key:
+        load_pseudonym_key(config, paths)
+    assert unsafe_key.value.code == "MH_PRIVACY_KEY_ACL"
+
+
+def test_post_publish_same_inode_overwrite_cannot_report_false_key_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    created_key = b"A" * 32
+    replacement_key = b"B" * 32
+    real_rename = secure_filesystem._rename_no_replace
+
+    def rename_then_overwrite(
+        directory_descriptor: int,
+        staged_leaf: str,
+        final_leaf: str,
+        *,
+        primitive: object,
+        flag: int,
+    ) -> None:
+        real_rename(
+            directory_descriptor,
+            staged_leaf,
+            final_leaf,
+            primitive=primitive,
+            flag=flag,
+        )
+        descriptor = os.open(final_leaf, os.O_WRONLY, dir_fd=directory_descriptor)
+        try:
+            assert os.pwrite(descriptor, replacement_key, 0) == len(replacement_key)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    monkeypatch.setattr(secure_filesystem, "_rename_no_replace", rename_then_overwrite)
+    with pytest.raises(PseudonymKeyCommitUncertain) as captured:
+        create_pseudonym_key(
+            config,
+            paths,
+            random_bytes=lambda size: created_key,
+        )
+
+    loaded = load_pseudonym_key(config, paths)
+    assert captured.value.key_id != loaded.key_id
+    assert paths.pseudonym_key.read_bytes() == replacement_key
+
+
+def test_rename_eio_after_namespace_change_preserves_recoverable_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    key = b"E" * 32
+
+    def rename_then_report_eio(
+        source_directory: int,
+        source: bytes,
+        destination_directory: int,
+        destination: bytes,
+        _flag: int,
+    ) -> int:
+        os.rename(
+            source,
+            destination,
+            src_dir_fd=source_directory,
+            dst_dir_fd=destination_directory,
+        )
+        ctypes.set_errno(errno.EIO)
+        return -1
+
+    monkeypatch.setattr(
+        secure_filesystem,
+        "_exclusive_rename_primitive",
+        lambda: (rename_then_report_eio, 1),
+    )
+    with pytest.raises(PseudonymKeyCommitUncertain) as captured:
+        create_pseudonym_key(config, paths, random_bytes=lambda size: key)
+
+    assert paths.pseudonym_key.read_bytes() == key
+    recovered = recover_pseudonym_key_creation(
+        config,
+        paths,
+        expected_key_id=captured.value.key_id,
+    )
+    assert recovered.key_id == captured.value.key_id
+
+
+def test_publication_cancellation_cannot_sanitize_an_already_renamed_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    key = b"K" * 32
+
+    def rename_then_cancel(
+        source_directory: int,
+        source: bytes,
+        destination_directory: int,
+        destination: bytes,
+        _flag: int,
+    ) -> int:
+        os.rename(
+            source,
+            destination,
+            src_dir_fd=source_directory,
+            dst_dir_fd=destination_directory,
+        )
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        secure_filesystem,
+        "_exclusive_rename_primitive",
+        lambda: (rename_then_cancel, 1),
+    )
+    with pytest.raises(KeyboardInterrupt):
+        create_pseudonym_key(config, paths, random_bytes=lambda size: key)
+
+    assert paths.pseudonym_key.read_bytes() == key
+    assert load_pseudonym_key(config, paths).key_id
+
+
+def test_process_exit_before_atomic_publication_never_leaves_a_partial_final_key(
+    tmp_path: Path,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    interrupted_key = b"I" * 32
+    replacement_key = b"R" * 32
+    child = os.fork()
+    if child == 0:  # pragma: no branch - child exits at the injected boundary
+        real_bound = privacy_keys._bound_key_path
+        calls = 0
+
+        def exit_during_prepublication(config_value, paths_value):
+            nonlocal calls
+            result = real_bound(config_value, paths_value)
+            calls += 1
+            if calls == 2:
+                os._exit(23)
+            return result
+
+        privacy_keys._bound_key_path = exit_during_prepublication
+        create_pseudonym_key(
+            config,
+            paths,
+            random_bytes=lambda size: interrupted_key,
+        )
+        os._exit(99)
+
+    waited, status = os.waitpid(child, 0)
+    assert waited == child
+    assert os.waitstatus_to_exitcode(status) == 23
+    assert not paths.pseudonym_key.exists()
+
+    created = create_pseudonym_key(
+        config,
+        paths,
+        random_bytes=lambda size: replacement_key,
+    )
+    assert paths.pseudonym_key.read_bytes() == replacement_key
+    assert created.key_id == load_pseudonym_key(config, paths).key_id

--- a/tests/unit/test_config_filesystem.py
+++ b/tests/unit/test_config_filesystem.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import errno
 import os
+import stat
 from pathlib import Path
 
 import pytest
 
 import milhouse.config.filesystem as config_filesystem
 from milhouse.config.filesystem import (
+    FileIdentity,
+    FileSelection,
     SecureFileError,
     SecureFileErrorKind,
+    create_regular_file_no_follow,
     inspect_regular_file_no_follow,
     lexical_absolute_path,
     open_regular_file_no_follow,
@@ -64,7 +69,11 @@ def test_inspection_translates_descriptor_close_failure(
     def fail_close(_descriptor: int) -> None:
         raise OSError
 
-    monkeypatch.setattr(config_filesystem, "open_regular_file_no_follow", lambda _path: opened)
+    monkeypatch.setattr(
+        config_filesystem,
+        "open_regular_file_no_follow",
+        lambda _path, **_kwargs: opened,
+    )
     monkeypatch.setattr(config_filesystem.os, "close", fail_close)
 
     try:
@@ -74,3 +83,987 @@ def test_inspection_translates_descriptor_close_failure(
         real_close(opened.descriptor)
 
     assert excinfo.value.kind is SecureFileErrorKind.UNREADABLE
+
+
+@pytest.mark.parametrize(
+    ("content", "mode"),
+    [
+        (b"", 0o600),
+        (bytearray(b"value"), 0o600),
+        (b"value", 0),
+        (b"value", True),
+        (b"value", 0o1000),
+    ],
+)
+def test_exclusive_create_rejects_invalid_content_or_mode(
+    tmp_path: Path,
+    content: object,
+    mode: object,
+) -> None:
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(  # type: ignore[arg-type]
+            tmp_path / "runtime.bin",
+            content,
+            mode=mode,
+        )
+
+    assert excinfo.value.kind is SecureFileErrorKind.INVALID
+
+
+def test_exclusive_create_and_open_fail_without_nofollow_support(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config_filesystem.os, "O_NOFOLLOW", 0)
+
+    with pytest.raises(SecureFileError) as create_error:
+        create_regular_file_no_follow(tmp_path / "runtime.bin", b"value", mode=0o600)
+    with pytest.raises(SecureFileError) as open_error:
+        open_regular_file_no_follow(tmp_path / "runtime.bin")
+
+    assert create_error.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+    assert open_error.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+
+def test_exclusive_create_rejects_noncallable_before_publish(tmp_path: Path) -> None:
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(
+            tmp_path / "runtime.bin",
+            b"value",
+            mode=0o600,
+            before_publish=object(),  # type: ignore[arg-type]
+        )
+
+    assert excinfo.value.kind is SecureFileErrorKind.INVALID
+
+
+def test_exclusive_rename_platform_selection_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeFunction:
+        argtypes: object = None
+        restype: object = None
+
+        def __call__(self, *args: object) -> int:
+            return 0
+
+    class LinuxLibrary:
+        renameat2 = FakeFunction()
+
+    monkeypatch.setattr(config_filesystem.sys, "platform", "linux")
+    monkeypatch.setattr(
+        config_filesystem.ctypes,
+        "CDLL",
+        lambda *args, **kwargs: LinuxLibrary(),
+    )
+    _primitive, flag = config_filesystem._exclusive_rename_primitive()
+    assert flag == 1
+
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: object())
+    with pytest.raises(SecureFileError) as missing_symbol:
+        config_filesystem._exclusive_rename_primitive()
+    assert missing_symbol.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+    monkeypatch.setattr(config_filesystem.sys, "platform", "unsupported")
+    with pytest.raises(SecureFileError) as unsupported:
+        config_filesystem._exclusive_rename_primitive()
+    assert unsupported.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+
+class _FakeCFunction:
+    def __init__(self, result: object) -> None:
+        self.argtypes: object = None
+        self.restype: object = None
+        self._result = result
+
+    def __call__(self, *args: object) -> object:
+        if isinstance(self._result, BaseException):
+            raise self._result
+        if callable(self._result):
+            return self._result(*args)
+        return self._result
+
+
+def test_macos_acl_probe_fails_closed_on_an_unexpected_query_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_acl_query(*args: object) -> None:
+        config_filesystem.ctypes.set_errno(errno.EIO)
+        return None
+
+    class MacLibrary:
+        acl_get_fd_np = _FakeCFunction(fail_acl_query)
+        acl_free = _FakeCFunction(0)
+
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: MacLibrary())
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._macos_descriptor_has_extended_acl(3)
+
+    assert excinfo.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+
+@pytest.mark.parametrize("no_acl_error", [errno.ENOENT, 9876])
+def test_macos_acl_probe_accepts_only_documented_absent_acl_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    no_acl_error: int,
+) -> None:
+    if no_acl_error != errno.ENOENT:
+        monkeypatch.setattr(config_filesystem.errno, "ENOATTR", no_acl_error, raising=False)
+
+    def no_acl(*args: object) -> None:
+        config_filesystem.ctypes.set_errno(no_acl_error)
+        return None
+
+    class MacLibrary:
+        acl_get_fd_np = _FakeCFunction(no_acl)
+        acl_free = _FakeCFunction(0)
+
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: MacLibrary())
+
+    assert config_filesystem._macos_descriptor_has_extended_acl(3) is False
+
+
+def test_macos_acl_probe_fails_closed_when_functions_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: object())
+
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._macos_descriptor_has_extended_acl(3)
+
+    assert excinfo.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+
+def test_macos_acl_probe_translates_unexpected_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MacLibrary:
+        acl_get_fd_np = _FakeCFunction(RuntimeError("private-acl-query-detail"))
+        acl_free = _FakeCFunction(0)
+
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: MacLibrary())
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._macos_descriptor_has_extended_acl(3)
+
+    assert excinfo.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+    assert "private-acl-query-detail" not in str(excinfo.value)
+
+
+def test_macos_acl_probe_translates_acl_free_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MacLibrary:
+        acl_get_fd_np = _FakeCFunction(1)
+        acl_free = _FakeCFunction(RuntimeError("private-acl-free-detail"))
+
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: MacLibrary())
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._macos_descriptor_has_extended_acl(3)
+
+    assert excinfo.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+    assert "private-acl-free-detail" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("responses", "expected"),
+    [
+        ((0,), True),
+        ((-1, 0), True),
+        ((-1, -1), False),
+    ],
+)
+def test_linux_acl_probe_detects_access_and_default_acl_xattrs(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: tuple[int, ...],
+    expected: bool,
+) -> None:
+    pending = list(responses)
+
+    def query_acl(*args: object) -> int:
+        result = pending.pop(0)
+        if result < 0:
+            config_filesystem.ctypes.set_errno(errno.ENODATA)
+        return result
+
+    class LinuxLibrary:
+        fgetxattr = _FakeCFunction(query_acl)
+
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: LinuxLibrary())
+
+    assert config_filesystem._linux_descriptor_has_extended_acl(3) is expected
+    assert not pending
+
+
+def test_linux_acl_probe_fails_closed_on_an_unexpected_query_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_acl_query(*args: object) -> int:
+        config_filesystem.ctypes.set_errno(errno.EIO)
+        return -1
+
+    class LinuxLibrary:
+        fgetxattr = _FakeCFunction(fail_acl_query)
+
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: LinuxLibrary())
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._linux_descriptor_has_extended_acl(3)
+
+    assert excinfo.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+
+def test_linux_acl_probe_fails_closed_when_functions_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: object())
+
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._linux_descriptor_has_extended_acl(3)
+
+    assert excinfo.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+
+def test_linux_acl_probe_translates_unexpected_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class LinuxLibrary:
+        fgetxattr = _FakeCFunction(RuntimeError("private-xattr-detail"))
+
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: LinuxLibrary())
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._linux_descriptor_has_extended_acl(3)
+
+    assert excinfo.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+    assert "private-xattr-detail" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("platform", "helper_name"),
+    [
+        ("darwin", "_macos_descriptor_has_extended_acl"),
+        ("linux", "_linux_descriptor_has_extended_acl"),
+    ],
+)
+def test_acl_dispatcher_selects_supported_platform(
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+    helper_name: str,
+) -> None:
+    calls: list[int] = []
+    monkeypatch.setattr(config_filesystem.sys, "platform", platform)
+    monkeypatch.setattr(
+        config_filesystem,
+        helper_name,
+        lambda descriptor: calls.append(descriptor) or False,
+    )
+
+    assert config_filesystem._descriptor_has_extended_acl(3) is False
+    assert calls == [3]
+
+
+def test_acl_dispatcher_rejects_unsupported_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config_filesystem.sys, "platform", "unsupported")
+
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._descriptor_has_extended_acl(3)
+
+    assert excinfo.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+
+@pytest.mark.parametrize(
+    ("error_number", "kind"),
+    [
+        (errno.EEXIST, SecureFileErrorKind.ALREADY_EXISTS),
+        (errno.ENOSYS, SecureFileErrorKind.SECURITY_UNSUPPORTED),
+        (errno.EIO, SecureFileErrorKind.COMMIT_UNCERTAIN),
+        (errno.ENOSPC, SecureFileErrorKind.WRITE_FAILED),
+    ],
+)
+def test_exclusive_rename_errors_are_stable(
+    error_number: int,
+    kind: SecureFileErrorKind,
+) -> None:
+    def fail_rename(*args: object) -> int:
+        config_filesystem.ctypes.set_errno(error_number)
+        return -1
+
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._rename_no_replace(
+            1,
+            "stage",
+            "final",
+            primitive=fail_rename,
+            flag=1,
+        )
+
+    assert excinfo.value.kind is kind
+
+
+def test_exclusive_rename_translates_unexpected_primitive_failure() -> None:
+    def fail_rename(*args: object) -> int:
+        raise RuntimeError("private-rename-detail")
+
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._rename_no_replace(
+            1,
+            "stage",
+            "final",
+            primitive=fail_rename,
+            flag=1,
+        )
+
+    assert excinfo.value.kind is SecureFileErrorKind.COMMIT_UNCERTAIN
+    assert "private-rename-detail" not in str(excinfo.value)
+
+
+def test_created_metadata_validation_fails_without_owner_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    path.write_bytes(b"value")
+    path.chmod(0o600)
+    monkeypatch.setattr(config_filesystem.os, "geteuid", None)
+
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem._validate_created_metadata(
+            path.stat(),
+            content_size=5,
+            mode=0o600,
+        )
+
+    assert excinfo.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+
+def test_staging_name_collision_bound_fails_without_publishing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    token = "c" * 32
+    staged = tmp_path / f"{config_filesystem._STAGED_FILE_PREFIX}{token}"
+    staged.write_bytes(b"existing-stage")
+    monkeypatch.setattr(config_filesystem.secrets, "token_hex", lambda _size: token)
+
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"value", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.WRITE_FAILED
+    assert not path.exists()
+    assert staged.read_bytes() == b"existing-stage"
+
+
+def test_exclusive_create_handles_successful_short_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    real_write = config_filesystem.os.write
+
+    def short_write(descriptor: int, value: bytes) -> int:
+        return real_write(descriptor, value[:2])
+
+    monkeypatch.setattr(config_filesystem.os, "write", short_write)
+    selected = create_regular_file_no_follow(path, b"runtime-value", mode=0o600)
+
+    assert selected.path == path
+    assert path.read_bytes() == b"runtime-value"
+
+
+def test_descriptor_content_readback_handles_short_reads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    expected = b"runtime-value"
+    path.write_bytes(expected)
+    descriptor = os.open(path, os.O_RDONLY)
+    real_pread = config_filesystem.os.pread
+
+    def short_pread(selected: int, size: int, offset: int) -> bytes:
+        return real_pread(selected, min(size, 2), offset)
+
+    monkeypatch.setattr(config_filesystem.os, "pread", short_pread)
+    try:
+        assert config_filesystem._descriptor_content_matches(descriptor, expected)
+    finally:
+        os.close(descriptor)
+
+
+def test_descriptor_content_readback_failure_is_value_safe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    path.write_bytes(b"value")
+    descriptor = os.open(path, os.O_RDONLY)
+
+    def fail_pread(selected: int, size: int, offset: int) -> bytes:
+        raise RuntimeError("private-pread-detail")
+
+    monkeypatch.setattr(config_filesystem.os, "pread", fail_pread)
+    try:
+        with pytest.raises(SecureFileError) as excinfo:
+            config_filesystem._descriptor_content_matches(descriptor, b"value")
+    finally:
+        os.close(descriptor)
+
+    assert excinfo.value.kind is SecureFileErrorKind.UNREADABLE
+    assert "private-pread-detail" not in str(excinfo.value)
+
+
+def test_zero_byte_write_is_a_failure_and_is_cleaned_up(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    monkeypatch.setattr(config_filesystem.os, "write", lambda descriptor, value: 0)
+
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"runtime-value", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.WRITE_FAILED
+    assert not path.exists()
+
+
+@pytest.mark.parametrize(
+    ("error", "kind"),
+    [
+        (ValueError("private-detail"), SecureFileErrorKind.INVALID),
+        (OSError(errno.ELOOP, "private-detail"), SecureFileErrorKind.NOT_REGULAR),
+        (OSError(errno.EACCES, "private-detail"), SecureFileErrorKind.UNREADABLE),
+    ],
+)
+def test_exclusive_create_translates_parent_open_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: BaseException,
+    kind: SecureFileErrorKind,
+) -> None:
+    def fail_parent(path: Path, *, nofollow: int) -> tuple[int, str]:
+        raise error
+
+    monkeypatch.setattr(config_filesystem, "_open_directory_chain", fail_parent)
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(tmp_path / "runtime.bin", b"value", mode=0o600)
+
+    assert excinfo.value.kind is kind
+    assert "private-detail" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("error", "kind"),
+    [
+        (ValueError("private-detail"), SecureFileErrorKind.INVALID),
+        (OSError(errno.ELOOP, "private-detail"), SecureFileErrorKind.NOT_REGULAR),
+        (OSError(errno.EACCES, "private-detail"), SecureFileErrorKind.UNREADABLE),
+    ],
+)
+def test_open_translates_parent_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: BaseException,
+    kind: SecureFileErrorKind,
+) -> None:
+    def fail_parent(path: Path, *, nofollow: int) -> tuple[int, str]:
+        raise error
+
+    monkeypatch.setattr(config_filesystem, "_open_directory_chain", fail_parent)
+    with pytest.raises(SecureFileError) as excinfo:
+        open_regular_file_no_follow(tmp_path / "runtime.bin")
+
+    assert excinfo.value.kind is kind
+    assert "private-detail" not in str(excinfo.value)
+
+
+def test_open_closes_leaf_descriptor_before_propagating_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    path.write_bytes(b"value")
+    real_open = config_filesystem.os.open
+    real_fstat = config_filesystem.os.fstat
+    leaf_descriptor: int | None = None
+    cancelled = False
+
+    def capture_leaf_open(
+        selected_path: str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal leaf_descriptor
+        descriptor = real_open(selected_path, flags, mode, dir_fd=dir_fd)
+        if selected_path == path.name and dir_fd is not None:
+            leaf_descriptor = descriptor
+        return descriptor
+
+    def cancel_leaf_stat(descriptor: int) -> os.stat_result:
+        nonlocal cancelled
+        if descriptor == leaf_descriptor and not cancelled:
+            cancelled = True
+            raise KeyboardInterrupt
+        return real_fstat(descriptor)
+
+    monkeypatch.setattr(config_filesystem.os, "open", capture_leaf_open)
+    monkeypatch.setattr(config_filesystem.os, "fstat", cancel_leaf_stat)
+    with pytest.raises(KeyboardInterrupt):
+        open_regular_file_no_follow(path)
+
+    assert leaf_descriptor is not None
+    with pytest.raises(OSError):
+        real_fstat(leaf_descriptor)
+
+
+def test_failed_stage_sanitizes_exact_descriptor_without_unlinking_swapped_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    staged = tmp_path / f"{config_filesystem._STAGED_FILE_PREFIX}{'a' * 32}"
+    moved = tmp_path / "moved-stage"
+    replacement = b"replacement-must-survive"
+
+    monkeypatch.setattr(config_filesystem.secrets, "token_hex", lambda _size: "a" * 32)
+
+    def swap_then_fail(descriptor: int, value: bytes) -> int:
+        staged.rename(moved)
+        staged.write_bytes(replacement)
+        raise OSError("private-write-detail")
+
+    monkeypatch.setattr(config_filesystem.os, "write", swap_then_fail)
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"sensitive-stage", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.WRITE_FAILED
+    assert not path.exists()
+    assert staged.read_bytes() == replacement
+    assert moved.read_bytes() == b""
+
+
+def test_post_publish_selection_mismatch_is_commit_uncertain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    real_inspect = config_filesystem.inspect_regular_file_no_follow
+
+    def mismatched_selection(
+        selected_path: Path, *, require_private_parent: bool = False
+    ) -> FileSelection:
+        selected = real_inspect(
+            selected_path,
+            require_private_parent=require_private_parent,
+        )
+        return FileSelection(
+            path=selected.path,
+            parent_identity=FileIdentity(
+                device=selected.parent_identity.device,
+                inode=selected.parent_identity.inode + 1,
+            ),
+            snapshot=selected.snapshot,
+        )
+
+    monkeypatch.setattr(
+        config_filesystem,
+        "inspect_regular_file_no_follow",
+        mismatched_selection,
+    )
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"value", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.COMMIT_UNCERTAIN
+    assert path.read_bytes() == b"value"
+
+
+def test_parent_descriptor_close_failure_is_not_reported_as_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    real_open_chain = config_filesystem._open_directory_chain
+    real_close = config_filesystem.os.close
+    parent_descriptor: int | None = None
+
+    def capture_parent(selected_path: Path, *, nofollow: int) -> tuple[int, str]:
+        nonlocal parent_descriptor
+        descriptor, leaf = real_open_chain(selected_path, nofollow=nofollow)
+        if parent_descriptor is None:
+            parent_descriptor = descriptor
+        return descriptor, leaf
+
+    def fail_parent_close(descriptor: int) -> None:
+        real_close(descriptor)
+        if descriptor == parent_descriptor:
+            raise OSError("private-close-detail")
+
+    monkeypatch.setattr(config_filesystem, "_open_directory_chain", capture_parent)
+    monkeypatch.setattr(config_filesystem.os, "close", fail_parent_close)
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"value", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.COMMIT_UNCERTAIN
+    assert path.read_bytes() == b"value"
+
+
+def test_directory_walk_rejects_file_component_without_o_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    component = tmp_path / "not-a-directory"
+    component.write_bytes(b"value")
+    monkeypatch.setattr(config_filesystem.os, "O_DIRECTORY", 0)
+
+    with pytest.raises(SecureFileError) as excinfo:
+        open_regular_file_no_follow(component / "runtime.bin")
+
+    assert excinfo.value.kind is SecureFileErrorKind.NOT_REGULAR
+
+
+def test_directory_walk_close_failure_does_not_leak_the_next_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "one" / "two" / "runtime.bin"
+    path.parent.mkdir(parents=True)
+    real_open = config_filesystem.os.open
+    real_close = config_filesystem.os.close
+    opened_descriptors: list[int] = []
+    failed_once = False
+
+    def capture_open(*args: object, **kwargs: object) -> int:
+        descriptor = real_open(*args, **kwargs)  # type: ignore[arg-type]
+        opened_descriptors.append(descriptor)
+        return descriptor
+
+    def close_then_fail_once(descriptor: int) -> None:
+        nonlocal failed_once
+        real_close(descriptor)
+        if not failed_once:
+            failed_once = True
+            raise OSError("private-intermediate-close-detail")
+
+    monkeypatch.setattr(config_filesystem.os, "open", capture_open)
+    monkeypatch.setattr(config_filesystem.os, "close", close_then_fail_once)
+    with pytest.raises(SecureFileError) as excinfo:
+        open_regular_file_no_follow(path)
+
+    assert excinfo.value.kind is SecureFileErrorKind.UNREADABLE
+    assert "private-intermediate-close-detail" not in str(excinfo.value)
+    assert len(opened_descriptors) == 2
+    for descriptor in opened_descriptors:
+        with pytest.raises(OSError):
+            os.fstat(descriptor)
+
+
+def test_exclusive_create_rejects_nonregular_opened_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    real_fstat = config_filesystem.os.fstat
+    changed = False
+
+    def report_fifo_once(descriptor: int) -> os.stat_result:
+        nonlocal changed
+        metadata = real_fstat(descriptor)
+        if not changed and stat.S_ISREG(metadata.st_mode) and metadata.st_size == 0:
+            changed = True
+            values = list(metadata)
+            values[0] = stat.S_IFIFO | 0o600
+            return os.stat_result(values)
+        return metadata
+
+    monkeypatch.setattr(config_filesystem.os, "fstat", report_fifo_once)
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"value", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.NOT_REGULAR
+    assert not path.exists()
+
+
+def test_exclusive_create_rejects_changed_final_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    real_fstat = config_filesystem.os.fstat
+
+    def report_wrong_final_size(descriptor: int) -> os.stat_result:
+        metadata = real_fstat(descriptor)
+        if stat.S_ISREG(metadata.st_mode) and metadata.st_size == len(b"value"):
+            values = list(metadata)
+            values[6] = metadata.st_size + 1
+            return os.stat_result(values)
+        return metadata
+
+    monkeypatch.setattr(config_filesystem.os, "fstat", report_wrong_final_size)
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"value", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.CHANGED
+    assert not path.exists()
+
+
+def test_created_file_close_failure_is_cleaned_up(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    real_open = config_filesystem.os.open
+    real_close = config_filesystem.os.close
+    created_descriptor: int | None = None
+
+    def capture_created_open(
+        selected_path: str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal created_descriptor
+        descriptor = real_open(selected_path, flags, mode, dir_fd=dir_fd)
+        if flags & os.O_CREAT:
+            created_descriptor = descriptor
+        return descriptor
+
+    def fail_created_close(descriptor: int) -> None:
+        real_close(descriptor)
+        if descriptor == created_descriptor:
+            raise OSError("private-close-detail")
+
+    monkeypatch.setattr(config_filesystem.os, "open", capture_created_open)
+    monkeypatch.setattr(config_filesystem.os, "close", fail_created_close)
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"value", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.COMMIT_UNCERTAIN
+    assert path.read_bytes() == b"value"
+
+
+def test_cleanup_preserves_primary_error_when_descriptor_close_also_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    real_open = config_filesystem.os.open
+    real_close = config_filesystem.os.close
+    created_descriptor: int | None = None
+
+    def capture_created_open(
+        selected_path: str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal created_descriptor
+        descriptor = real_open(selected_path, flags, mode, dir_fd=dir_fd)
+        if flags & os.O_CREAT:
+            created_descriptor = descriptor
+        return descriptor
+
+    def fail_write(descriptor: int, value: bytes) -> int:
+        raise OSError("private-write-detail")
+
+    def fail_created_close(descriptor: int) -> None:
+        real_close(descriptor)
+        if descriptor == created_descriptor:
+            raise OSError("private-close-detail")
+
+    monkeypatch.setattr(config_filesystem.os, "open", capture_created_open)
+    monkeypatch.setattr(config_filesystem.os, "write", fail_write)
+    monkeypatch.setattr(config_filesystem.os, "close", fail_created_close)
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"value", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.CLEANUP_FAILED
+    assert not path.exists()
+
+
+def test_cleanup_failure_survives_a_parent_close_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    real_chain = config_filesystem._open_directory_chain
+    real_write = config_filesystem.os.write
+    real_close = config_filesystem.os.close
+    parent_descriptor: int | None = None
+    write_calls = 0
+
+    def capture_parent(selected_path: Path, *, nofollow: int) -> tuple[int, str]:
+        nonlocal parent_descriptor
+        descriptor, leaf = real_chain(selected_path, nofollow=nofollow)
+        parent_descriptor = descriptor
+        return descriptor, leaf
+
+    def fail_after_partial_write(descriptor: int, value: bytes) -> int:
+        nonlocal write_calls
+        write_calls += 1
+        if write_calls == 1:
+            return real_write(descriptor, value[:2])
+        raise OSError("private-write-detail")
+
+    def fail_truncate(descriptor: int, length: int) -> None:
+        raise OSError("private-cleanup-detail")
+
+    def fail_parent_close(descriptor: int) -> None:
+        real_close(descriptor)
+        if descriptor == parent_descriptor:
+            raise OSError("private-parent-close-detail")
+
+    monkeypatch.setattr(config_filesystem, "_open_directory_chain", capture_parent)
+    monkeypatch.setattr(config_filesystem.os, "write", fail_after_partial_write)
+    monkeypatch.setattr(config_filesystem.os, "ftruncate", fail_truncate)
+    monkeypatch.setattr(config_filesystem.os, "close", fail_parent_close)
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"value", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.CLEANUP_FAILED
+    assert not path.exists()
+
+
+def test_post_publish_os_failure_is_commit_uncertain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    real_open = config_filesystem.os.open
+    real_fstat = config_filesystem.os.fstat
+    real_rename = config_filesystem._rename_no_replace
+    created_descriptor: int | None = None
+    published = False
+
+    def capture_created_open(
+        selected_path: str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal created_descriptor
+        descriptor = real_open(selected_path, flags, mode, dir_fd=dir_fd)
+        if flags & os.O_CREAT:
+            created_descriptor = descriptor
+        return descriptor
+
+    def publish(
+        directory_descriptor: int,
+        staged_leaf: str,
+        final_leaf: str,
+        *,
+        primitive: object,
+        flag: int,
+    ) -> None:
+        nonlocal published
+        real_rename(
+            directory_descriptor,
+            staged_leaf,
+            final_leaf,
+            primitive=primitive,
+            flag=flag,
+        )
+        published = True
+
+    def fail_post_publish_fstat(descriptor: int) -> os.stat_result:
+        if published and descriptor == created_descriptor:
+            raise OSError("private-post-publish-detail")
+        return real_fstat(descriptor)
+
+    monkeypatch.setattr(config_filesystem.os, "open", capture_created_open)
+    monkeypatch.setattr(config_filesystem.os, "fstat", fail_post_publish_fstat)
+    monkeypatch.setattr(config_filesystem, "_rename_no_replace", publish)
+    with pytest.raises(SecureFileError) as excinfo:
+        create_regular_file_no_follow(path, b"value", mode=0o600)
+
+    assert excinfo.value.kind is SecureFileErrorKind.COMMIT_UNCERTAIN
+    assert path.read_bytes() == b"value"
+    assert "private-post-publish-detail" not in str(excinfo.value)
+
+
+def test_open_preserves_primary_failure_when_parent_close_also_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "missing.bin"
+    real_chain = config_filesystem._open_directory_chain
+    real_close = config_filesystem.os.close
+    parent_descriptor: int | None = None
+
+    def capture_parent(selected_path: Path, *, nofollow: int) -> tuple[int, str]:
+        nonlocal parent_descriptor
+        parent_descriptor, leaf = real_chain(selected_path, nofollow=nofollow)
+        return parent_descriptor, leaf
+
+    def fail_parent_close(descriptor: int) -> None:
+        real_close(descriptor)
+        if descriptor == parent_descriptor:
+            raise OSError("private-parent-close-detail")
+
+    monkeypatch.setattr(config_filesystem, "_open_directory_chain", capture_parent)
+    monkeypatch.setattr(config_filesystem.os, "close", fail_parent_close)
+    with pytest.raises(SecureFileError) as excinfo:
+        open_regular_file_no_follow(path)
+
+    assert excinfo.value.kind is SecureFileErrorKind.NOT_FOUND
+    assert "private-parent-close-detail" not in str(excinfo.value)
+
+
+def test_parent_sync_success_and_failure_boundaries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    identity = config_filesystem.sync_parent_directory_no_follow(path)
+    assert identity == FileIdentity.from_stat(tmp_path.stat())
+
+    monkeypatch.setattr(config_filesystem.os, "O_NOFOLLOW", 0)
+    with pytest.raises(SecureFileError) as unsupported:
+        config_filesystem.sync_parent_directory_no_follow(path)
+    assert unsupported.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+    monkeypatch.undo()
+    missing = tmp_path / "missing" / "runtime.bin"
+    with pytest.raises(SecureFileError) as not_found:
+        config_filesystem.sync_parent_directory_no_follow(missing)
+    assert not_found.value.kind is SecureFileErrorKind.NOT_FOUND
+
+
+@pytest.mark.parametrize("sync_fails", [False, True])
+def test_parent_sync_close_failure_is_stable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    sync_fails: bool,
+) -> None:
+    path = tmp_path / "runtime.bin"
+    real_chain = config_filesystem._open_directory_chain
+    real_close = config_filesystem.os.close
+    real_fsync = config_filesystem.os.fsync
+    parent_descriptor: int | None = None
+
+    def capture_parent(selected_path: Path, *, nofollow: int) -> tuple[int, str]:
+        nonlocal parent_descriptor
+        parent_descriptor, leaf = real_chain(selected_path, nofollow=nofollow)
+        return parent_descriptor, leaf
+
+    def fail_sync(descriptor: int) -> None:
+        if sync_fails and descriptor == parent_descriptor:
+            raise OSError("private-sync-detail")
+        real_fsync(descriptor)
+
+    def fail_parent_close(descriptor: int) -> None:
+        real_close(descriptor)
+        if descriptor == parent_descriptor:
+            raise OSError("private-close-detail")
+
+    monkeypatch.setattr(config_filesystem, "_open_directory_chain", capture_parent)
+    monkeypatch.setattr(config_filesystem.os, "fsync", fail_sync)
+    monkeypatch.setattr(config_filesystem.os, "close", fail_parent_close)
+    with pytest.raises(SecureFileError) as excinfo:
+        config_filesystem.sync_parent_directory_no_follow(path)
+
+    expected = SecureFileErrorKind.SYNC_FAILED if sync_fails else SecureFileErrorKind.UNREADABLE
+    assert excinfo.value.kind is expected
+    assert "private" not in str(excinfo.value)

--- a/tests/unit/test_config_filesystem.py
+++ b/tests/unit/test_config_filesystem.py
@@ -150,6 +150,18 @@ def test_exclusive_rename_platform_selection_fails_closed(
     class LinuxLibrary:
         renameat2 = FakeFunction()
 
+    class MacLibrary:
+        renameatx_np = FakeFunction()
+
+    monkeypatch.setattr(config_filesystem.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        config_filesystem.ctypes,
+        "CDLL",
+        lambda *args, **kwargs: MacLibrary(),
+    )
+    _primitive, flag = config_filesystem._exclusive_rename_primitive()
+    assert flag == 4
+
     monkeypatch.setattr(config_filesystem.sys, "platform", "linux")
     monkeypatch.setattr(
         config_filesystem.ctypes,
@@ -292,6 +304,24 @@ def test_linux_acl_probe_detects_access_and_default_acl_xattrs(
 
     assert config_filesystem._linux_descriptor_has_extended_acl(3) is expected
     assert not pending
+
+
+def test_linux_acl_probe_accepts_the_platform_enoattr_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    enoattr = 9876
+    monkeypatch.setattr(config_filesystem.errno, "ENOATTR", enoattr, raising=False)
+
+    def no_acl(*args: object) -> int:
+        config_filesystem.ctypes.set_errno(enoattr)
+        return -1
+
+    class LinuxLibrary:
+        fgetxattr = _FakeCFunction(no_acl)
+
+    monkeypatch.setattr(config_filesystem.ctypes, "CDLL", lambda *args, **kwargs: LinuxLibrary())
+
+    assert config_filesystem._linux_descriptor_has_extended_acl(3) is False
 
 
 def test_linux_acl_probe_fails_closed_on_an_unexpected_query_error(

--- a/tests/unit/test_privacy_keys.py
+++ b/tests/unit/test_privacy_keys.py
@@ -1,0 +1,1041 @@
+from __future__ import annotations
+
+import os
+import stat
+import traceback
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import milhouse.config.filesystem as secure_filesystem
+import milhouse.privacy.keys as privacy_keys
+from milhouse.config import ConfigError, load_config, resolve_runtime_paths
+from milhouse.config.filesystem import (
+    OpenedRegularFile,
+    SecureFileError,
+    SecureFileErrorKind,
+    inspect_regular_file_no_follow,
+)
+from milhouse.config.loader import ConfigFileSelection, validated_config_digest
+from milhouse.config.models import MilhouseConfig
+from milhouse.config.paths import RuntimePaths
+from milhouse.privacy import (
+    PSEUDONYM_KEY_BYTES,
+    PSEUDONYM_KEY_MODE,
+    PrivacyError,
+    PseudonymKeyCommitUncertain,
+    create_pseudonym_key,
+    load_pseudonym_key,
+    recover_pseudonym_key_creation,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_CONFIG = REPOSITORY_ROOT / "config/examples/local-only.toml"
+
+
+def _runtime(tmp_path: Path) -> tuple[MilhouseConfig, RuntimePaths]:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    config_file = config_dir / "milhouse.toml"
+    config_file.write_text(
+        EXAMPLE_CONFIG.read_text(encoding="utf-8").replace(
+            'home = "../../data/local-only"',
+            'home = "../state"',
+        ),
+        encoding="utf-8",
+    )
+    config, selection = load_config(
+        config_file,
+        platform_default=config_file,
+        env={},
+    )
+    paths = resolve_runtime_paths(
+        config,
+        config_path=selection,
+        platform_data_root=tmp_path / "platform",
+        env={},
+    )
+    paths.pseudonym_key.parent.mkdir(parents=True, mode=0o700)
+    return config, paths
+
+
+def _write_key(paths: RuntimePaths, value: bytes, *, mode: int = PSEUDONYM_KEY_MODE) -> None:
+    paths.pseudonym_key.write_bytes(value)
+    paths.pseudonym_key.chmod(mode)
+
+
+def test_create_and_load_key_round_trip_with_restrictive_mode(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    key = bytes(range(PSEUDONYM_KEY_BYTES))
+
+    created = create_pseudonym_key(config, paths, epoch=3, random_bytes=lambda size: key)
+    loaded = load_pseudonym_key(
+        config,
+        paths,
+        epoch=3,
+        expected_key_id=created.key_id,
+    )
+
+    metadata = paths.pseudonym_key.stat()
+    assert metadata.st_size == PSEUDONYM_KEY_BYTES
+    assert stat.S_IMODE(metadata.st_mode) == PSEUDONYM_KEY_MODE
+    assert metadata.st_nlink == 1
+    assert paths.pseudonym_key.read_bytes() == key
+    assert created.key_id == loaded.key_id
+    assert created.pseudonymize("email", "synthetic@example.test") == loaded.pseudonymize(
+        "email", "synthetic@example.test"
+    )
+    assert repr(created) == "Pseudonymizer(epoch=3)"
+    assert os.fspath(paths.pseudonym_key) not in repr(created)
+    assert key.hex() not in repr(created)
+
+
+def test_create_never_overwrites_an_existing_key(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    original = b"A" * PSEUDONYM_KEY_BYTES
+    replacement = b"B" * PSEUDONYM_KEY_BYTES
+    create_pseudonym_key(config, paths, random_bytes=lambda size: original)
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths, random_bytes=lambda size: replacement)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_EXISTS"
+    assert paths.pseudonym_key.read_bytes() == original
+
+
+@pytest.mark.parametrize(
+    ("value", "mode", "code"),
+    [
+        (b"S" * (PSEUDONYM_KEY_BYTES - 1), PSEUDONYM_KEY_MODE, "MH_PRIVACY_KEY_SIZE"),
+        (b"L" * (PSEUDONYM_KEY_BYTES + 1), PSEUDONYM_KEY_MODE, "MH_PRIVACY_KEY_SIZE"),
+        (b"M" * PSEUDONYM_KEY_BYTES, 0o644, "MH_PRIVACY_KEY_MODE"),
+        (b"R" * PSEUDONYM_KEY_BYTES, 0o400, "MH_PRIVACY_KEY_MODE"),
+    ],
+)
+def test_load_rejects_wrong_size_or_mode_without_rendering_material(
+    tmp_path: Path,
+    value: bytes,
+    mode: int,
+    code: str,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    _write_key(paths, value, mode=mode)
+
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    assert captured.value.code == code
+    assert value.hex() not in str(captured.value)
+    assert os.fspath(paths.pseudonym_key) not in str(captured.value)
+
+
+def test_load_rejects_missing_key_and_missing_create_parent(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+
+    with pytest.raises(PrivacyError) as missing:
+        load_pseudonym_key(config, paths)
+    assert missing.value.code == "MH_PRIVACY_KEY_NOT_FOUND"
+
+    paths.pseudonym_key.parent.rmdir()
+    with pytest.raises(PrivacyError) as missing_parent:
+        create_pseudonym_key(config, paths)
+    assert missing_parent.value.code == "MH_PRIVACY_KEY_PARENT_MISSING"
+
+
+@pytest.mark.parametrize("operation", ["create", "load"])
+def test_key_operations_reject_non_private_parent(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    if operation == "load":
+        _write_key(paths, b"P" * PSEUDONYM_KEY_BYTES)
+    paths.pseudonym_key.parent.chmod(0o750)
+
+    with pytest.raises(PrivacyError) as captured:
+        if operation == "create":
+            create_pseudonym_key(config, paths)
+        else:
+            load_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_PARENT_UNSAFE"
+
+
+def test_load_rejects_wrong_owner_and_hard_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, paths = _runtime(tmp_path)
+    _write_key(paths, b"O" * PSEUDONYM_KEY_BYTES)
+    current_user = os.geteuid()
+    monkeypatch.setattr(privacy_keys.os, "geteuid", lambda: current_user + 1)
+
+    with pytest.raises(PrivacyError) as wrong_owner:
+        privacy_keys._validate_key_metadata(paths.pseudonym_key.stat())
+    assert wrong_owner.value.code == "MH_PRIVACY_KEY_OWNER"
+
+    monkeypatch.setattr(privacy_keys.os, "geteuid", lambda: current_user)
+    os.link(paths.pseudonym_key, paths.pseudonym_key.with_suffix(".linked"))
+    with pytest.raises(PrivacyError) as linked:
+        load_pseudonym_key(config, paths)
+    assert linked.value.code == "MH_PRIVACY_KEY_LINKS"
+
+
+def test_expected_key_id_is_validated_and_compared_without_key_material(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    key = b"I" * PSEUDONYM_KEY_BYTES
+    created = create_pseudonym_key(config, paths, random_bytes=lambda size: key)
+
+    with pytest.raises(PrivacyError) as malformed:
+        load_pseudonym_key(config, paths, expected_key_id="not-a-key-id")
+    assert malformed.value.code == "MH_PRIVACY_KEY_ID"
+
+    different_id = "mh_pk1_0000000000000000"
+    assert different_id != created.key_id
+    with pytest.raises(PrivacyError) as mismatch:
+        load_pseudonym_key(config, paths, expected_key_id=different_id)
+    assert mismatch.value.code == "MH_PRIVACY_KEY_ID_MISMATCH"
+    assert key.hex() not in str(mismatch.value)
+
+
+@pytest.mark.parametrize("leaf_kind", ["symlink", "directory", "fifo"])
+def test_key_leaf_must_be_a_regular_non_symlink_file(tmp_path: Path, leaf_kind: str) -> None:
+    config, paths = _runtime(tmp_path)
+    if leaf_kind == "symlink":
+        target = tmp_path / "synthetic-target"
+        target.write_bytes(b"T" * PSEUDONYM_KEY_BYTES)
+        target.chmod(PSEUDONYM_KEY_MODE)
+        paths.pseudonym_key.symlink_to(target)
+    elif leaf_kind == "directory":
+        paths.pseudonym_key.mkdir()
+    else:
+        os.mkfifo(paths.pseudonym_key, PSEUDONYM_KEY_MODE)
+
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_TYPE"
+
+
+def test_key_parent_symlink_is_refused(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    real_parent = paths.pseudonym_key.parent.with_name("real-control")
+    paths.pseudonym_key.parent.rename(real_parent)
+    paths.pseudonym_key.parent.symlink_to(real_parent, target_is_directory=True)
+    _write_key(replace(paths, pseudonym_key=real_parent / paths.pseudonym_key.name), b"P" * 32)
+
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_TYPE"
+
+
+def test_runtime_key_path_must_match_config_and_remain_beneath_state_root(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    outside = replace(paths, pseudonym_key=tmp_path / "outside.key")
+    alternate = replace(paths, pseudonym_key=paths.state_root / "other.key")
+
+    with pytest.raises(PrivacyError) as escaped:
+        create_pseudonym_key(config, outside)
+    assert escaped.value.code == "MH_PRIVACY_KEY_ESCAPE"
+
+    with pytest.raises(PrivacyError) as mismatched:
+        create_pseudonym_key(config, alternate)
+    assert mismatched.value.code == "MH_PRIVACY_KEY_BINDING"
+    assert not outside.pseudonym_key.exists()
+    assert not alternate.pseudonym_key.exists()
+
+
+def test_self_consistent_forged_absolute_root_fails_runtime_generation_binding(
+    tmp_path: Path,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    forged_root = tmp_path / "forged-state"
+    forged_key = forged_root / config.identity.pseudonym_key_path
+    forged_key.parent.mkdir(parents=True, mode=0o700)
+    forged_paths = replace(
+        paths,
+        state_root=forged_root,
+        pseudonym_key=forged_key,
+    )
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, forged_paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_BINDING"
+    assert not forged_key.exists()
+    assert not paths.pseudonym_key.exists()
+
+
+def test_key_operations_are_independent_of_current_working_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    monkeypatch.chdir(decoy)
+
+    created = create_pseudonym_key(
+        config,
+        paths,
+        random_bytes=lambda size: b"C" * size,
+    )
+    loaded = load_pseudonym_key(config, paths, expected_key_id=created.key_id)
+
+    assert created.key_id == loaded.key_id
+    assert not (decoy / "control/pseudonym.key").exists()
+
+
+def test_missing_nofollow_support_fails_closed_before_creation_or_loading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    monkeypatch.setattr(secure_filesystem.os, "O_NOFOLLOW", 0)
+
+    with pytest.raises(PrivacyError) as create_error:
+        create_pseudonym_key(config, paths)
+    assert create_error.value.code == "MH_PRIVACY_KEY_SECURITY_UNSUPPORTED"
+    assert not paths.pseudonym_key.exists()
+
+    paths.pseudonym_key.write_bytes(b"N" * PSEUDONYM_KEY_BYTES)
+    paths.pseudonym_key.chmod(PSEUDONYM_KEY_MODE)
+    with pytest.raises(PrivacyError) as load_error:
+        load_pseudonym_key(config, paths)
+    assert load_error.value.code == "MH_PRIVACY_KEY_SECURITY_UNSUPPORTED"
+
+
+@pytest.mark.parametrize("result", [b"short", b"X" * 33, bytearray(b"X" * 32), "text"])
+def test_entropy_source_must_return_exact_bytes(tmp_path: Path, result: object) -> None:
+    config, paths = _runtime(tmp_path)
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths, random_bytes=lambda size: result)  # type: ignore[arg-type,return-value]
+
+    assert captured.value.code == "MH_PRIVACY_KEY_RANDOM"
+    assert not paths.pseudonym_key.exists()
+
+
+def test_entropy_source_failure_is_value_safe(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+
+    def fail_entropy(size: int) -> bytes:
+        raise RuntimeError("synthetic-private-random-detail")
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths, random_bytes=fail_entropy)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_RANDOM"
+    assert "synthetic-private-random-detail" not in str(captured.value)
+    assert not paths.pseudonym_key.exists()
+
+
+def test_staging_name_entropy_failure_is_value_safe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+
+    def fail_stage_name(size: int) -> str:
+        raise RuntimeError("synthetic-private-stage-name-detail")
+
+    monkeypatch.setattr(secure_filesystem.secrets, "token_hex", fail_stage_name)
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths, random_bytes=lambda size: b"S" * size)
+
+    rendered = "".join(traceback.format_exception(captured.value))
+    assert captured.value.code == "MH_PRIVACY_KEY_WRITE"
+    assert "synthetic-private-stage-name-detail" not in rendered
+    assert os.fspath(paths.pseudonym_key) not in rendered
+    assert not paths.pseudonym_key.exists()
+
+
+@pytest.mark.parametrize("token", [object(), "../outside-stage", "g" * 32, "a" * 31])
+def test_staging_name_entropy_must_be_exact_lowercase_hex(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    token: object,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    monkeypatch.setattr(secure_filesystem.secrets, "token_hex", lambda size: token)
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_WRITE"
+    assert not paths.pseudonym_key.exists()
+    assert not (tmp_path / "outside-stage").exists()
+
+
+def test_partial_write_failure_removes_only_the_new_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    real_write = secure_filesystem.os.write
+    calls = 0
+
+    def fail_after_short_write(descriptor: int, value: bytes) -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return real_write(descriptor, value[:7])
+        raise OSError("synthetic-private-write-detail")
+
+    monkeypatch.setattr(secure_filesystem.os, "write", fail_after_short_write)
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths, random_bytes=lambda size: b"W" * size)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_WRITE"
+    assert "synthetic-private-write-detail" not in str(captured.value)
+    assert not paths.pseudonym_key.exists()
+
+
+def test_permission_failure_cleans_up_new_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+
+    def fail_chmod(descriptor: int, mode: int) -> None:
+        raise OSError("synthetic-private-chmod-detail")
+
+    monkeypatch.setattr(secure_filesystem.os, "fchmod", fail_chmod)
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_PERMISSION"
+    assert not paths.pseudonym_key.exists()
+
+
+def test_file_sync_failure_sanitizes_stage_without_publishing_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    real_fsync = secure_filesystem.os.fsync
+    calls = 0
+
+    def fail_selected_sync(descriptor: int) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("synthetic-private-sync-detail")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(secure_filesystem.os, "fsync", fail_selected_sync)
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_SYNC"
+    assert not paths.pseudonym_key.exists()
+
+
+def test_parent_sync_failure_returns_identity_checked_recovery_handle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    real_fsync = secure_filesystem.os.fsync
+    calls = 0
+
+    def fail_parent_sync_once(descriptor: int) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("synthetic-private-sync-detail")
+        real_fsync(descriptor)
+
+    monkeypatch.setattr(secure_filesystem.os, "fsync", fail_parent_sync_once)
+    with pytest.raises(PseudonymKeyCommitUncertain) as captured:
+        create_pseudonym_key(config, paths, random_bytes=lambda size: b"D" * size)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_COMMIT_UNCERTAIN"
+    assert repr(captured.value) == "PseudonymKeyCommitUncertain(recovery_required=True)"
+    assert paths.pseudonym_key.read_bytes() == b"D" * PSEUDONYM_KEY_BYTES
+
+    monkeypatch.undo()
+    recovered = recover_pseudonym_key_creation(
+        config,
+        paths,
+        expected_key_id=captured.value.key_id,
+    )
+    assert recovered.key_id == captured.value.key_id
+
+
+def test_cleanup_failure_is_explicit_and_does_not_render_material(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    key = b"Q" * PSEUDONYM_KEY_BYTES
+
+    def fail_write(descriptor: int, value: bytes) -> int:
+        raise OSError("synthetic-private-write-detail")
+
+    def fail_truncate(descriptor: int, length: int) -> None:
+        raise OSError("synthetic-private-cleanup-detail")
+
+    monkeypatch.setattr(secure_filesystem.os, "write", fail_write)
+    monkeypatch.setattr(secure_filesystem.os, "ftruncate", fail_truncate)
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths, random_bytes=lambda size: key)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_CLEANUP"
+    rendered = "".join(traceback.format_exception(captured.value))
+    assert key.hex() not in rendered
+    assert os.fspath(paths.pseudonym_key) not in rendered
+    assert "synthetic-private" not in rendered
+
+
+def test_load_detects_leaf_replacement_after_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    _write_key(paths, b"A" * PSEUDONYM_KEY_BYTES)
+    replacement = tmp_path / "replacement.key"
+    replacement.write_bytes(b"B" * PSEUDONYM_KEY_BYTES)
+    replacement.chmod(PSEUDONYM_KEY_MODE)
+    real_inspect = privacy_keys.inspect_regular_file_no_follow
+
+    def replace_then_inspect(path: str | Path, **kwargs: object):
+        paths.pseudonym_key.unlink()
+        replacement.rename(paths.pseudonym_key)
+        return real_inspect(path, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(privacy_keys, "inspect_regular_file_no_follow", replace_then_inspect)
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_CHANGED"
+
+
+def test_load_detects_parent_replacement_after_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    _write_key(paths, b"A" * PSEUDONYM_KEY_BYTES)
+    original_parent = paths.pseudonym_key.parent
+    moved_parent = original_parent.with_name("old-control")
+    real_inspect = privacy_keys.inspect_regular_file_no_follow
+
+    def replace_parent_then_inspect(path: str | Path, **kwargs: object):
+        original_parent.rename(moved_parent)
+        original_parent.mkdir(mode=0o700)
+        _write_key(
+            replace(paths, pseudonym_key=original_parent / paths.pseudonym_key.name), b"A" * 32
+        )
+        return real_inspect(path, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        privacy_keys,
+        "inspect_regular_file_no_follow",
+        replace_parent_then_inspect,
+    )
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_CHANGED"
+
+
+def test_create_reports_commit_uncertain_without_deleting_moved_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    original_parent = paths.pseudonym_key.parent
+    moved_parent = original_parent.with_name("old-control")
+    real_inspect = secure_filesystem.inspect_regular_file_no_follow
+
+    def replace_parent_then_inspect(path: str | Path, **kwargs: object):
+        original_parent.rename(moved_parent)
+        original_parent.mkdir(mode=0o700)
+        return real_inspect(path, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        secure_filesystem,
+        "inspect_regular_file_no_follow",
+        replace_parent_then_inspect,
+    )
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_COMMIT_UNCERTAIN"
+    assert (moved_parent / paths.pseudonym_key.name).stat().st_size == PSEUDONYM_KEY_BYTES
+    assert not paths.pseudonym_key.exists()
+
+
+@pytest.mark.parametrize("invalid", [object(), None, "runtime-paths"])
+def test_key_operations_require_validated_config_and_runtime_types(
+    tmp_path: Path,
+    invalid: object,
+) -> None:
+    config, paths = _runtime(tmp_path)
+
+    with pytest.raises(PrivacyError) as invalid_config:
+        create_pseudonym_key(invalid, paths)  # type: ignore[arg-type]
+    with pytest.raises(PrivacyError) as invalid_paths:
+        create_pseudonym_key(config, invalid)  # type: ignore[arg-type]
+
+    assert invalid_config.value.code == "MH_PRIVACY_KEY_BINDING"
+    assert invalid_paths.value.code == "MH_PRIVACY_KEY_BINDING"
+
+
+def test_key_operations_reject_changed_config_generation(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    paths.config_file.write_text(
+        paths.config_file.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_CONFIG"
+    assert not paths.pseudonym_key.exists()
+
+
+def test_key_operations_reject_malformed_runtime_path_values(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    malformed = replace(paths, state_root=object())  # type: ignore[arg-type]
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, malformed)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_BINDING"
+
+
+@pytest.mark.parametrize(
+    "forged",
+    [
+        {"state_root": Path("relative-state")},
+        {"config_file": Path("relative-config.toml")},
+        {"config_dir": Path("relative-config")},
+    ],
+)
+def test_key_operations_reject_internally_inconsistent_runtime_paths(
+    tmp_path: Path,
+    forged: dict[str, Path],
+) -> None:
+    config, paths = _runtime(tmp_path)
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, replace(paths, **forged))  # type: ignore[arg-type]
+
+    assert captured.value.code == "MH_PRIVACY_KEY_BINDING"
+
+
+def test_state_root_itself_cannot_be_the_key_path(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, replace(paths, pseudonym_key=paths.state_root))
+
+    assert captured.value.code == "MH_PRIVACY_KEY_ESCAPE"
+
+
+def test_forged_configured_key_escape_is_rejected(tmp_path: Path) -> None:
+    config, paths = _runtime(tmp_path)
+    forged_identity = config.identity.model_copy(update={"pseudonym_key_path": "../outside.key"})
+    forged_config = config.model_copy(update={"identity": forged_identity})
+    selected = inspect_regular_file_no_follow(paths.config_file)
+    forged_selection = ConfigFileSelection(
+        path=selected.path,
+        parent_identity=selected.parent_identity,
+        snapshot=selected.snapshot,
+        config_digest=validated_config_digest(forged_config),
+    )
+    forged_paths = replace(
+        paths,
+        config_selection=forged_selection,
+        pseudonym_key=paths.state_root / "safe.key",
+    )
+
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(forged_config, forged_paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_ESCAPE"
+
+
+def test_runtime_binding_rechecks_generation_before_return(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    calls = 0
+    real_verify = privacy_keys.verify_config_generation
+
+    def fail_second_verify(config_value: MilhouseConfig, selection: ConfigFileSelection):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise ConfigError("config.file.changed", "synthetic safe failure")
+        return real_verify(config_value, selection)
+
+    monkeypatch.setattr(privacy_keys, "verify_config_generation", fail_second_verify)
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_CONFIG"
+    assert not paths.pseudonym_key.exists()
+
+
+@pytest.mark.parametrize(
+    ("kind", "code"),
+    [
+        (SecureFileErrorKind.SECURITY_UNSUPPORTED, "MH_PRIVACY_KEY_SECURITY_UNSUPPORTED"),
+        (SecureFileErrorKind.CHANGED, "MH_PRIVACY_KEY_CHANGED"),
+        (SecureFileErrorKind.INVALID, "MH_PRIVACY_KEY_CREATE"),
+    ],
+)
+def test_create_translates_remaining_secure_file_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    kind: SecureFileErrorKind,
+    code: str,
+) -> None:
+    config, paths = _runtime(tmp_path)
+
+    def fail_create(path: Path, content: bytes, **kwargs: object):
+        raise SecureFileError(kind)
+
+    monkeypatch.setattr(privacy_keys, "create_regular_file_no_follow", fail_create)
+    with pytest.raises(PrivacyError) as captured:
+        create_pseudonym_key(config, paths)
+
+    assert captured.value.code == code
+
+
+@pytest.mark.parametrize("operation", ["create", "load", "recover"])
+def test_key_boundaries_translate_unexpected_runtime_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    created = create_pseudonym_key(config, paths) if operation == "recover" else None
+
+    def fail_unexpected(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("synthetic-private-unexpected-detail")
+
+    if operation == "create":
+        monkeypatch.setattr(privacy_keys, "create_regular_file_no_follow", fail_unexpected)
+        expected_code = "MH_PRIVACY_KEY_CREATE"
+    elif operation == "load":
+        monkeypatch.setattr(privacy_keys, "_read_key_material", fail_unexpected)
+        expected_code = "MH_PRIVACY_KEY_READ"
+    else:
+        assert created is not None
+        monkeypatch.setattr(privacy_keys, "sync_parent_directory_no_follow", fail_unexpected)
+        expected_code = "MH_PRIVACY_KEY_RECOVERY"
+
+    with pytest.raises(PrivacyError) as captured:
+        if operation == "create":
+            create_pseudonym_key(config, paths)
+        elif operation == "load":
+            load_pseudonym_key(config, paths)
+        else:
+            assert created is not None
+            recover_pseudonym_key_creation(
+                config,
+                paths,
+                expected_key_id=created.key_id,
+            )
+
+    rendered = "".join(traceback.format_exception(captured.value))
+    assert captured.value.code == expected_code
+    assert "synthetic-private-unexpected-detail" not in rendered
+    assert os.fspath(paths.pseudonym_key) not in rendered
+
+
+@pytest.mark.parametrize(
+    ("kind", "code"),
+    [
+        (SecureFileErrorKind.SECURITY_UNSUPPORTED, "MH_PRIVACY_KEY_SECURITY_UNSUPPORTED"),
+        (SecureFileErrorKind.UNREADABLE, "MH_PRIVACY_KEY_READ"),
+    ],
+)
+def test_load_translates_remaining_secure_file_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    kind: SecureFileErrorKind,
+    code: str,
+) -> None:
+    config, paths = _runtime(tmp_path)
+
+    def fail_open(path: Path, **kwargs: object):
+        raise SecureFileError(kind)
+
+    monkeypatch.setattr(privacy_keys, "open_regular_file_no_follow", fail_open)
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    assert captured.value.code == code
+
+
+def test_metadata_validator_rejects_nonregular_metadata(tmp_path: Path) -> None:
+    with pytest.raises(PrivacyError) as captured:
+        privacy_keys._validate_key_metadata(tmp_path.stat())
+
+    assert captured.value.code == "MH_PRIVACY_KEY_TYPE"
+
+
+def test_load_fails_when_owner_checks_are_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    _write_key(paths, b"U" * PSEUDONYM_KEY_BYTES)
+    monkeypatch.setattr(privacy_keys.os, "geteuid", None)
+
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_SECURITY_UNSUPPORTED"
+
+    with pytest.raises(PrivacyError) as metadata_error:
+        privacy_keys._validate_key_metadata(paths.pseudonym_key.stat())
+    assert metadata_error.value.code == "MH_PRIVACY_KEY_SECURITY_UNSUPPORTED"
+
+
+@pytest.mark.parametrize(
+    ("kind", "code"),
+    [
+        (SecureFileErrorKind.PARENT_UNSAFE, "MH_PRIVACY_KEY_PARENT_UNSAFE"),
+        (SecureFileErrorKind.SYNC_FAILED, "MH_PRIVACY_KEY_RECOVERY"),
+    ],
+)
+def test_commit_recovery_translates_parent_sync_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    kind: SecureFileErrorKind,
+    code: str,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    created = create_pseudonym_key(config, paths)
+
+    def fail_sync(path: Path, **kwargs: object) -> None:
+        raise SecureFileError(kind)
+
+    monkeypatch.setattr(privacy_keys, "sync_parent_directory_no_follow", fail_sync)
+    with pytest.raises(PrivacyError) as captured:
+        recover_pseudonym_key_creation(
+            config,
+            paths,
+            expected_key_id=created.key_id,
+        )
+
+    assert captured.value.code == code
+
+
+def test_load_rejects_more_bytes_than_the_validated_file_size(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    _write_key(paths, b"B" * PSEUDONYM_KEY_BYTES)
+    calls = 0
+
+    def oversized_read(descriptor: int, size: int) -> bytes:
+        nonlocal calls
+        calls += 1
+        return b"Z" * (PSEUDONYM_KEY_BYTES + 1) if calls == 1 else b""
+
+    monkeypatch.setattr(privacy_keys.os, "read", oversized_read)
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_SIZE"
+
+
+def test_load_detects_metadata_change_during_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    _write_key(paths, b"D" * PSEUDONYM_KEY_BYTES)
+    real_coordinates = privacy_keys._metadata_coordinates
+    calls = 0
+
+    def changed_coordinates(metadata: os.stat_result) -> tuple[int, ...]:
+        nonlocal calls
+        calls += 1
+        coordinates = real_coordinates(metadata)
+        return coordinates if calls == 1 else (*coordinates, 1)
+
+    monkeypatch.setattr(privacy_keys, "_metadata_coordinates", changed_coordinates)
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_CHANGED"
+
+
+def test_load_translates_read_and_close_failures_without_os_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    _write_key(paths, b"E" * PSEUDONYM_KEY_BYTES)
+
+    def fail_read(descriptor: int, size: int) -> bytes:
+        raise OSError("synthetic-private-read-detail")
+
+    monkeypatch.setattr(privacy_keys.os, "read", fail_read)
+    with pytest.raises(PrivacyError) as read_error:
+        load_pseudonym_key(config, paths)
+    assert read_error.value.code == "MH_PRIVACY_KEY_READ"
+    assert "synthetic-private" not in str(read_error.value)
+
+    monkeypatch.undo()
+    config, paths = _runtime(tmp_path / "close-case")
+    _write_key(paths, b"E" * PSEUDONYM_KEY_BYTES)
+    selected = inspect_regular_file_no_follow(paths.pseudonym_key)
+    descriptor = os.open(paths.pseudonym_key, os.O_RDONLY)
+    opened = OpenedRegularFile(descriptor=descriptor, selection=selected)
+    real_close = privacy_keys.os.close
+
+    def fail_selected_close(value: int) -> None:
+        real_close(value)
+        if value == descriptor:
+            raise OSError("synthetic-private-close-detail")
+
+    monkeypatch.setattr(
+        privacy_keys,
+        "open_regular_file_no_follow",
+        lambda path, **kwargs: opened,
+    )
+    monkeypatch.setattr(privacy_keys.os, "close", fail_selected_close)
+    with pytest.raises(PrivacyError) as close_error:
+        load_pseudonym_key(config, paths)
+    assert close_error.value.code == "MH_PRIVACY_KEY_READ"
+    assert "synthetic-private" not in str(close_error.value)
+
+
+def test_real_open_parent_close_failure_is_stable_and_closes_key_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    key = b"J" * PSEUDONYM_KEY_BYTES
+    _write_key(paths, key)
+    real_chain = secure_filesystem._open_directory_chain
+    real_open = secure_filesystem.os.open
+    real_close = secure_filesystem.os.close
+    key_parent_descriptor: int | None = None
+    key_descriptor: int | None = None
+
+    def capture_key_parent(path: Path, *, nofollow: int) -> tuple[int, str]:
+        nonlocal key_parent_descriptor
+        descriptor, leaf = real_chain(path, nofollow=nofollow)
+        if path == paths.pseudonym_key:
+            key_parent_descriptor = descriptor
+        return descriptor, leaf
+
+    def capture_key_open(
+        selected_path: str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal key_descriptor
+        descriptor = real_open(selected_path, flags, mode, dir_fd=dir_fd)
+        if dir_fd == key_parent_descriptor and selected_path == paths.pseudonym_key.name:
+            key_descriptor = descriptor
+        return descriptor
+
+    def fail_key_parent_close(descriptor: int) -> None:
+        real_close(descriptor)
+        if descriptor == key_parent_descriptor:
+            raise OSError("synthetic-private-parent-close-detail")
+
+    monkeypatch.setattr(secure_filesystem, "_open_directory_chain", capture_key_parent)
+    monkeypatch.setattr(secure_filesystem.os, "open", capture_key_open)
+    monkeypatch.setattr(secure_filesystem.os, "close", fail_key_parent_close)
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    rendered = "".join(traceback.format_exception(captured.value))
+    assert captured.value.code == "MH_PRIVACY_KEY_READ"
+    assert os.fspath(paths.pseudonym_key) not in rendered
+    assert key.hex() not in rendered
+    assert "synthetic-private-parent-close-detail" not in rendered
+    assert key_descriptor is not None
+    with pytest.raises(OSError):
+        os.fstat(key_descriptor)
+
+
+def test_load_reports_path_disappearance_after_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    _write_key(paths, b"G" * PSEUDONYM_KEY_BYTES)
+
+    def remove_then_fail(path: Path, **kwargs: object):
+        paths.pseudonym_key.unlink()
+        raise SecureFileError(SecureFileErrorKind.NOT_FOUND)
+
+    monkeypatch.setattr(privacy_keys, "inspect_regular_file_no_follow", remove_then_fail)
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_CHANGED"
+
+
+@pytest.mark.parametrize("operation", ["create", "load"])
+def test_key_operations_recheck_generation_after_file_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    config, paths = _runtime(tmp_path)
+    if operation == "load":
+        _write_key(paths, b"V" * PSEUDONYM_KEY_BYTES)
+    calls = 0
+    real_verify = privacy_keys.verify_config_generation
+
+    def fail_third_verify(config_value: MilhouseConfig, selection: ConfigFileSelection):
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise ConfigError("config.file.changed", "synthetic safe failure")
+        return real_verify(config_value, selection)
+
+    monkeypatch.setattr(privacy_keys, "verify_config_generation", fail_third_verify)
+    with pytest.raises(PrivacyError) as captured:
+        if operation == "create":
+            create_pseudonym_key(config, paths)
+        else:
+            load_pseudonym_key(config, paths)
+
+    assert captured.value.code == "MH_PRIVACY_KEY_CONFIG"
+    if operation == "create":
+        assert not paths.pseudonym_key.exists()
+
+
+@pytest.mark.parametrize("invalid", [b"not-text", 42, object()])
+def test_expected_key_id_must_be_text(tmp_path: Path, invalid: object) -> None:
+    config, paths = _runtime(tmp_path)
+
+    with pytest.raises(PrivacyError) as captured:
+        load_pseudonym_key(config, paths, expected_key_id=invalid)  # type: ignore[arg-type]
+
+    assert captured.value.code == "MH_PRIVACY_KEY_ID"
+
+
+@pytest.mark.parametrize("operation", ["create", "load"])
+def test_key_operations_reject_invalid_epochs(tmp_path: Path, operation: str) -> None:
+    config, paths = _runtime(tmp_path)
+
+    with pytest.raises(PrivacyError) as captured:
+        if operation == "create":
+            create_pseudonym_key(config, paths, epoch=0)
+        else:
+            load_pseudonym_key(config, paths, epoch=0)
+
+    assert captured.value.code == "MH_PRIVACY_EPOCH"
+    assert not paths.pseudonym_key.exists()


### PR DESCRIPTION
## Summary

- bind pseudonym-key operations to the exact validated config/runtime-path generation
- stage and fsync complete 32-byte key material before atomic kernel no-overwrite publication on macOS and Linux
- enforce owner-only `0700` parents and `0600` keys, including descriptor-based extended-ACL rejection
- validate owner, link count, inode snapshots, and exact published bytes before returning a key identity
- expose stable value-safe create/load failures plus identity-checked recovery for commit-uncertain publication
- preserve complete secret material across rename `EIO`, cancellation, close, and parent-fsync ambiguity without overwriting an existing key

## Safety and recovery contract

The final key path is either absent or a complete key before publication. Prepublication failures sanitize only the exact open staging inode and never unlink a mutable name. A process exit may leave a protected staging artifact; W06 initialization owns stale-stage orchestration. Any outcome that may have crossed the atomic rename boundary returns `PseudonymKeyCommitUncertain` with a non-secret key ID, and `recover_pseudonym_key_creation` verifies that identity, fsyncs the parent, and verifies it again.

Normal key backup/restore, identity-continuity policy, encrypted recovery-secret envelopes, rotation, and overlap remain W16 work. No CLI initialization, directory creation, SQLite key metadata, backup, restore, or rotation surface is added here. W02/G02 remain in progress.

## Independent review

Two report-only reviews exercised the uncommitted candidate. Their findings drove remediation for exact-inode cleanup, forged runtime paths, post-create ambiguity, descriptor ownership, crash residue, macOS inherited ACLs, published-byte drift, rename `EIO`, and cancellation at the publication boundary. Both reviewers pass the final tree with no remaining P0-P2 defect.

## Local evidence

Exact commit: `f8f55e06f8ed706b29fe50166c5dccbd35e744d3`  
Tree: `cf1ba8ffc1825607e8b89c3045190d9fb6915793`

- `make quality`: passed (lock, format, Ruff, mypy, repository/config/docs/workflow/skill validation)
- `make test-coverage`: 1,284 passed, 1 skipped; 97.95% line / 96.76% branch; all critical-file thresholds passed
- focused key/filesystem/security/property suite: 142 passed
- real macOS atomic no-overwrite, inherited-ACL, process-exit, concurrency, and recovery regressions: passed
- `make secret-scan`: 205 tracked text files plus full tree/history passed
- `make audit`: no known dependency vulnerabilities
- `make license-check`: 135 packages passed policy
- `make build`, `make package-check`, `make artifact-smoke`: wheel/sdist and installed-artifact parity passed
- wheel SHA-256: `29e4e7f22b9b33794035246143b2c6924a360d7d744f4da690432227695858f0`
- sdist SHA-256: `15fb3e02645bad4cc49f9bf9d1b52c18fda8ea4fd1a60edfe83ba352806ad9bd`
- DCO: signed commit and range check passed

Hosted Ubuntu/ext4 execution of the real `renameat2` and Linux POSIX-ACL path is intentionally left to Required CI on this exact commit.

## Provenance

This is a clean-room implementation of the public v1 plan's mandatory privacy/key-lifecycle contract. No private donor source expression, fixture, history, configuration, telemetry, path, or identifier was imported; no donor-ledger row is required for this slice.
