### PR TITLE
docs(journal): publish the Milhouse build story

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/announcements.yml
+++ b/.github/DISCUSSION_TEMPLATE/announcements.yml
@@ -1,0 +1,69 @@
+title: "[Build Journal] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Milhouse build-journal posts explain verified work from protected `main`. They are not
+        release announcements. Do not include credentials, real telemetry, private paths, account
+        identifiers, raw agent content, provider payloads, generated reports, or private incidents.
+  - type: input
+    id: milestone
+    attributes:
+      label: Milestone
+      description: Name the merged work package, gate, or architecture slice covered by this post.
+      placeholder: "W02: deterministic identity and privacy foundations"
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this matters
+      description: Explain the user or engineering problem in plain language before implementation details.
+    validations:
+      required: true
+  - type: textarea
+    id: implemented
+    attributes:
+      label: Implemented and verified
+      description: Describe only behavior present on protected main and link its pull requests and checks.
+    validations:
+      required: true
+  - type: textarea
+    id: architecture
+    attributes:
+      label: Architecture walkthrough
+      description: Explain important boundaries and tradeoffs; label planned components as planned.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Verification evidence
+      description: Link the exact protected commit, Required CI run, tests, and gate evidence used.
+    validations:
+      required: true
+  - type: textarea
+    id: next
+    attributes:
+      label: What comes next
+      description: Describe dependency-ready work without presenting a schedule or unapproved feature as committed.
+    validations:
+      required: true
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: Current boundaries
+      description: State what is not implemented, released, supported, or suitable for production use.
+    validations:
+      required: true
+  - type: checkboxes
+    id: attestation
+    attributes:
+      label: Publication check
+      options:
+        - label: Every implemented claim is supported by merged public evidence linked above.
+          required: true
+        - label: The post contains no private, credential-bearing, raw-agent, or production data.
+          required: true
+        - label: Planned architecture and released functionality are clearly distinguished.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ Closes #
 - [ ] Relevant `milhouse-gate-review` completed and no P0/P1 remains
 - [ ] Reusable learning was compounded, or this change has no reusable learning
 - [ ] Canonical `skills/` and `.agents/skills/` alias parity is retained
+- [ ] Engineering-journal impact is assessed: publish, group into a later milestone, or no post
 
 ## Privacy Check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ select one dependency-ready work package
 -> fix and re-review until no P0/P1 remains
 -> milhouse-compound when an explicitly requested reusable lesson exists
 -> milhouse-oss-maintainer for provenance, status, commit, PR, and authorized merge handling
+-> engineering-journal post for a meaningful merged milestone when public messaging is authorized
 ```
 
 `milhouse-feedback` is a normalized evidence input to assigned application work; it is never
@@ -68,6 +69,9 @@ permission to inspect raw telemetry or feedback sources.
 - Gate review cannot edit or mark a gate passed. Compound can write only the explicitly requested
   sanitized artifact. Merge authority does not imply tag, publication, announcement, or live-provider
   authority.
+- Engineering-journal authority permits only human-readable GitHub Discussion posts grounded in
+  merged public evidence. It does not authorize release claims, availability promises, private
+  material, raw evidence, tags, packages, or other announcements.
 - Treat `/doh` as a neutral postmortem trigger, not a blame shortcut.
 
 ## Validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   sanitized compound learning, and explicit no-vendoring, privacy, egress, and mutation boundaries.
 - Add privacy, threat-model, governance, support, DCO, and implementation-status artifacts.
 - Remove stale duplicate workflow/publication instructions and harden issue/review privacy guidance.
+- Add an evidence-linked GitHub Discussions engineering journal, maintainer announcement form, and
+  inaugural pre-alpha architecture post while keeping release claims separately authorized.
 - Begin the W01 foundation with the `milhouse-observability` distribution, typed `milhouse` import
   package, modular pre-alpha Click entry point, and explicit package-resource manifest.
 - Separate bounded runtime, optional receiver, and development dependencies; add the uv 0.11.29

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Current repository validation:
 These commands validate the current source tree. W01 has passed, but that does not imply that the
 Milhouse runtime or any later work package is complete.
 
+## Watch the build
+
+The maintainer-authored
+[Milhouse engineering journal](https://github.com/that1guy15/Milhouse-oss/discussions/categories/announcements)
+explains meaningful merged architecture and feature milestones in plain language. Posts link the
+exact protected evidence and distinguish implemented behavior from planned work and release
+readiness. See the [journal workflow](docs/engineering-journal.md).
+
 ## Source and privacy boundary
 
 This is a fresh public implementation. The private operational repository is read-only donor material, not the codebase. Reuse is limited to the audited, generalized algorithms listed in [provenance](docs/provenance.md); private history, telemetry, configuration, paths, fixtures, reports, and agent content are prohibited.
@@ -99,6 +107,7 @@ Never attach credentials, real telemetry, raw agent content, private incident da
 - [Architecture](docs/architecture.md)
 - [Contributor setup](docs/setup.md)
 - [Development workflow](docs/development.md)
+- [Engineering journal](docs/engineering-journal.md)
 - [Dependency policy](docs/dependencies.md)
 - [Privacy](PRIVACY.md)
 - [Threat model](docs/threat-model.md)

--- a/docs/agents-and-tools.md
+++ b/docs/agents-and-tools.md
@@ -40,12 +40,17 @@ select one dependency-ready work package
 -> fix and re-review until no P0/P1 remains
 -> milhouse-compound when an explicitly requested reusable lesson exists
 -> milhouse-oss-maintainer for provenance, status, commit, PR, and authorized merge handling
+-> authorized engineering-journal post after a meaningful milestone reaches merged_verified
 ```
 
 Subagents may perform independent read-only work in parallel. Parallel writes require disjoint files
 and hidden state; the primary agent integrates and verifies the combined tree. Review remains
 read-only. Selecting a skill grants no source, GitHub, provider, external-model, tag, publication, or
 messaging authority.
+
+The [engineering journal](engineering-journal.md) is the public, human-readable output of selected
+`merged_verified` milestones. It summarizes only protected public evidence and cannot pass a gate,
+publish a package, claim release readiness, or expose raw/private inputs.
 
 ## Planned agent surfaces
 

--- a/docs/engineering-journal.md
+++ b/docs/engineering-journal.md
@@ -1,0 +1,60 @@
+# Milhouse engineering journal
+
+The Milhouse engineering journal is a maintainer-authored series in the repository's
+[Announcements](https://github.com/that1guy15/Milhouse-oss/discussions/categories/announcements)
+Discussions category. It lets people follow the architecture, tradeoffs, verification evidence,
+and useful mistakes behind the build without mistaking active engineering for a product release.
+
+## Publication contract
+
+Publish after a meaningful architecture or feature slice reaches `merged_verified`. Group small
+pull requests into one coherent milestone post; do not publish empty status updates merely to meet a
+calendar. If several meaningful slices land together, publish a weekly roundup. Release, security,
+incident-response, and availability announcements retain their separate authorization.
+
+Each post must distinguish these claim classes:
+
+- **Implemented and verified** — present on protected `main`, with exact pull-request and hosted-check
+  links.
+- **Architecture decision** — accepted and binding, but not necessarily implemented.
+- **In progress** — actively being built and not yet accepted by its gate.
+- **Planned** — dependency-bound future work, not a shipping or schedule commitment.
+- **Not available** — an explicit pre-alpha, support, production-data, or release boundary.
+
+Human explanation leads. Commit hashes and check runs support the story instead of replacing it.
+Every post should answer: what problem are we solving, what changed, how does it fit the system, how
+was it verified, what did we learn, what remains unavailable, and what is next?
+
+## Workflow
+
+1. Select only merged public evidence. Never inspect or quote private donor material, raw agent
+   sessions, provider data, production telemetry, generated reports, or private incidents.
+2. Draft a Markdown source under `docs/engineering-journal/` using the structure below. A feature PR
+   may carry its own post, or a focused documentation PR may group several merged slices.
+3. Run documentation, privacy, identifier, and secret checks. Review every capability statement
+   against the exact protected commit and current implementation status.
+4. Merge the source through the normal DCO, review, and Required CI path.
+5. Publish the human-readable body in the maintainer-only `Announcements` category using the
+   checked-in `announcements.yml` form. Link the source file and exact protected evidence.
+6. If a factual correction is needed, preserve transparency: add a dated correction to the post and
+   its checked-in source rather than silently changing the historical claim.
+
+Publishing a journal post does not change a work-package state, pass a gate, authorize a release,
+or prove that an unimplemented component works.
+
+## Post structure
+
+```text
+Title
+Pre-alpha status note
+Why this matters
+Implemented and verified
+Architecture walkthrough
+Verification evidence
+What we learned
+What is not available
+What comes next
+```
+
+The canonical source for the inaugural post is
+[Building Milhouse in public: foundations before features](engineering-journal/2026-07-22-foundations-before-features.md).

--- a/docs/engineering-journal/2026-07-22-foundations-before-features.md
+++ b/docs/engineering-journal/2026-07-22-foundations-before-features.md
@@ -1,0 +1,115 @@
+# Building Milhouse in public: foundations before features
+
+> **Build Journal #1 — July 22, 2026.** Milhouse is pre-alpha, has no public release, and is not
+> ready for production data. This post distinguishes code already verified on `main` from the
+> architecture we are still building.
+
+Milhouse is meant to turn operational evidence into engineering feedback that can later be proved
+effective. That sounds like a dashboard problem. It is really a trust problem: before collecting a
+single production signal, the system needs stable identity, privacy boundaries, deterministic
+records, and a definition of what “verified” means.
+
+## The architecture in one minute
+
+```mermaid
+flowchart LR
+  A["Collect bounded signals"] --> B["Validate and normalize"]
+  B --> C["Redact before persistence"]
+  C --> D["Commit to local spool"]
+  D --> E["Project and analyze locally"]
+  E --> F["Create evidence-backed feedback"]
+  F --> G["Ship a change"]
+  G --> H["Re-observe the same signal class"]
+  H --> I["Verify or regress"]
+```
+
+The complete flow is the planned 1.0 architecture. Today, protected `main` contains the contracts
+and privacy foundations at the front of that flow. The durable spool, SQLite and ClickHouse
+integration, collectors, feedback runtime, reports, MCP server, and services remain future
+dependency-bound work.
+
+## What is implemented and verified
+
+The W02 foundation now includes:
+
+- strict versioned configuration with unknown-key rejection and deterministic JSON Schema output;
+- canonical bytes, deterministic record IDs, content hashes, immutable record envelopes, and
+  append-only feedback-transition validation;
+- installation-keyed pseudonyms instead of public unsalted hashes;
+- layered redaction, field allowlists, URL and path sanitization, and untrusted-text rendering;
+- secure runtime-path and explicit secret-loading primitives;
+- injected clocks, bounded duration parsing, stable coded errors, and catalog-owned structured
+  operational events without arbitrary message fields;
+- a fail-closed egress matrix for every planned persistence and output surface; and
+- exact third-party plugin metadata validation without importing plugin code.
+
+[PR #21](https://github.com/that1guy15/Milhouse-oss/pull/21) added a public-safe identity corpus and
+recomputed the same identity wires in independent processes across mapping orders, hash seeds,
+timezones, locales, Python 3.11 and 3.14 on macOS 14, and Python 3.11 through 3.14 on Ubuntu. It also
+fixed strict raw-JSON draft parsing when an optional nested correlation object is omitted.
+
+Why spend this much effort on identity? Because retry, replay, and outage recovery are normal in an
+observability system. If identical evidence can acquire a different logical identity on another
+process or platform, later storage cannot reliably deduplicate it and feedback cannot be traced to
+the evidence that created it.
+
+## A feedback loop, not an AI opinion
+
+The central product rule is already locked even though its full runtime is not built: neither a
+human nor an agent can simply declare work verified. Milhouse will require a new observation of the
+same configured signal class after the change. A result can become verified when the evidence
+improves, and regress when later evidence shows the problem returned.
+
+That distinction is why the architecture starts with deterministic records and append-only state.
+“The agent said it fixed it” is useful context. It is not verification.
+
+## What the gates taught us
+
+Our own delivery controls caught a malformed DCO trailer immediately after PR #21 was squash
+merged. The production tree was exactly the reviewed tree and its source commit was correctly
+signed, but the protected squash message contained escaped newline characters instead of a
+parseable trailer. Required CI failed.
+
+We did not rewrite protected history or weaken the checker. PR #22 added the bounded signed
+remediation, PR #23 recorded the exact incident evidence, and the original malformed range remains
+detectably noncompliant. The durable record is
+[PR21-DCO.md](https://github.com/that1guy15/Milhouse-oss/blob/main/docs/gate-evidence/PR21-DCO.md).
+
+That is the kind of failure an observability project should surface: specific, reproducible, and
+recoverable without pretending it never happened.
+
+## Verification evidence
+
+- Protected evidence head:
+  [`ce0aaecbf05f14b566d45446f756aeda24bfe1f3`](https://github.com/that1guy15/Milhouse-oss/commit/ce0aaecbf05f14b566d45446f756aeda24bfe1f3)
+- Current-main Required CI:
+  [`29910290888`](https://github.com/that1guy15/Milhouse-oss/actions/runs/29910290888)
+- Identity portability implementation:
+  [PR #21](https://github.com/that1guy15/Milhouse-oss/pull/21)
+- Immediate DCO remediation and evidence:
+  [PR #22](https://github.com/that1guy15/Milhouse-oss/pull/22) and
+  [PR #23](https://github.com/that1guy15/Milhouse-oss/pull/23)
+- Current work-package ledger:
+  [implementation status](https://github.com/that1guy15/Milhouse-oss/blob/main/docs/implementation-status.md)
+
+The required workflow covers quality, tests and coverage, Python compatibility, macOS identity
+portability, package construction, artifact installation, secret scanning, dependency review,
+license and vulnerability audit, CodeQL, DCO, and the fail-closed aggregate.
+
+## What is not available yet
+
+There is no supported Milhouse runtime deployment today. Durable spool and SQLite state, ClickHouse
+delivery, collectors, feedback verification, reports, MCP, notifications, scheduling, recovery,
+installation, and release artifacts are not yet accepted. Do not use the repository with production
+credentials or telemetry.
+
+## What comes next
+
+W02 closes only after the remaining owner-approved contract decisions and their implementation
+evidence are complete. The next production slices define the bounded local structured-log wire and
+privacy authorization, then close G02. W03 can then build the crash-safe spool, SQLite state,
+replay, and retention foundation that the runtime depends on.
+
+Follow the
+[Announcements build journal](https://github.com/that1guy15/Milhouse-oss/discussions/categories/announcements)
+to watch each verified architecture slice land.

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -8,7 +8,8 @@ Default branch: `main`
 ## Required controls
 
 - Issues, pull requests, and private vulnerability reporting enabled.
-- Discussions optional; every template warns against real telemetry or credentials.
+- Discussions enabled with a maintainer-authored `Announcements` build journal; every template warns
+  against real telemetry, credentials, private identifiers, and raw agent content.
 - Secret scanning and push protection enabled.
 - Dependabot alerts/updates, dependency review, and CodeQL enabled by W17.
 - Actions permitted only from the checked-in `.github/workflows/` definitions.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -16,7 +16,7 @@ status and evidence; it does not amend the plan.
 | Git state | Immediate [D01 recovery](gate-evidence/PR21-DCO.md) completed at protected, correctly signed `main` commit `c0f9f2a8a1300eef18e651a20b6e2111d9cbd6a5` with the exact reviewed PR #22 tree. Post-merge Required CI run `29903480661` passed on its failed-jobs-only second attempt after the first attempt's `gitleaks` job timed out during uv setup before scanning. The original PR #21 squash remains noncompliant, and its permanent exact historical disposition remains owner-pending |
 | Public source baseline | `that1guy15/Milhouse-oss@fb81a7faf2c101e8bb3f08ef9120d82c2b20600b` |
 | Private reference baseline | `that1guy15/milhouse@18ee9514ee11413812fde8fe361405b3686e025f` |
-| External mutation authority | Owner authorized build-branch pushes, pull requests, and merges to `main` after required checks on 2026-07-19. Tags, package publication, announcements, live-provider calls, and unrelated external mutation remain separately controlled |
+| External mutation authority | Owner authorized build-branch pushes, pull requests, and merges to `main` after required checks on 2026-07-19. On 2026-07-22 the owner separately authorized maintainer-authored engineering-journal posts in GitHub Discussions when they use only merged public evidence and clearly remain pre-release. Tags, package publication, release/availability announcements, live-provider calls, and unrelated external mutation remain separately controlled |
 | Highest passed gate | G01 |
 | Active package | W02 contract closure: owner decisions for the exact historical DCO disposition and persisted local structured-log contract |
 
@@ -203,6 +203,7 @@ exact request/evidence, and the named owner must authorize or perform it.
 | E07 | G18 | Project owner/elapsed monitor | Keep the approved environment available for the 7-day alpha, 14-day beta, and 7-day RC soaks; preserve continuity evidence and respond to monitor alerts | Pending |
 | E08 | G17/G18/release | Project/release owner | Build-branch push/PR/merge is authorized. Separately authorize protected release environment, signed tag/build, Trusted Publishing, GitHub Release, any visibility change, and announcement. Approval for one step does not imply the next | Branch push/PR/merge authorized 2026-07-19; release actions pending |
 | E09 | Release completion | Project owner/release monitor | Authorize public-registry installs, announcement only after verification, and at least 72 hours of post-publication monitoring | Pending |
+| E10 | Active implementation | Project owner and maintainers | Publish human-readable engineering-journal posts from meaningful `merged_verified` milestones using only public evidence, explicit implemented/planned boundaries, and the checked-in privacy template | Authorized 2026-07-22 for GitHub Discussions `Announcements`; this is not release, availability, package-publication, or live-provider authority |
 
 ## Defects, amendments, and stop conditions
 


### PR DESCRIPTION
## Summary

- add an evidence-gated engineering-journal workflow for GitHub Discussions Announcements
- add the maintainer discussion form with privacy and truthfulness attestations
- publish the checked-in source for the inaugural pre-alpha architecture story
- record the owner-authorized journal boundary without extending release, package, provider, or availability authority

## Verification

- scripts/run_make.py quality
- private-identifier scan: 235 tracked text files passed
- secret scan over tree and 53-commit history passed
- secret-scan self-test passed
- full test suite: 3657 passed, 1 skipped
- git diff --cached --check
- scripts/check_dco.py --range HEAD^..HEAD

## Publication boundary

The Discussion must not be published until this source reaches protected main and post-merge Required CI passes. The post is a pre-alpha build journal, not a release or availability announcement.

## Review state

Independent milhouse-gate-review: pending. Review must be report-only and cover claim accuracy, implemented-versus-planned boundaries, privacy, recovery, evidence links, and Discussion form validity.