### PR TITLE
feat(privacy): add local_log fail-closed egress surface

### DIFF
--- a/src/milhouse/privacy/egress.py
+++ b/src/milhouse/privacy/egress.py
@@ -24,6 +24,7 @@ class EgressSurface(StrEnum):
     GITHUB_ISSUES = "github_issues"
     HOSTED_CLICKHOUSE = "hosted_clickhouse"
     DIAGNOSTICS = "diagnostics"
+    LOCAL_LOG = "local_log"
 
 
 class EgressDisposition(StrEnum):
@@ -116,6 +117,12 @@ _MATRIX: Mapping[
             }
         ),
         EgressSurface.DIAGNOSTICS: MappingProxyType(
+            {
+                "public": EgressDisposition.METADATA,
+                "internal": EgressDisposition.REDACTED_METADATA,
+            }
+        ),
+        EgressSurface.LOCAL_LOG: MappingProxyType(
             {
                 "public": EgressDisposition.METADATA,
                 "internal": EgressDisposition.REDACTED_METADATA,

--- a/tests/contract/test_egress_matrix_contract.py
+++ b/tests/contract/test_egress_matrix_contract.py
@@ -57,6 +57,10 @@ _EXPECTED = {
         "public": EgressDisposition.METADATA,
         "internal": EgressDisposition.REDACTED_METADATA,
     },
+    EgressSurface.LOCAL_LOG: {
+        "public": EgressDisposition.METADATA,
+        "internal": EgressDisposition.REDACTED_METADATA,
+    },
 }
 
 
@@ -96,6 +100,7 @@ def test_public_api_uses_stable_string_values() -> None:
         "github_issues",
         "hosted_clickhouse",
         "diagnostics",
+        "local_log",
     }
     assert {disposition.value for disposition in EgressDisposition} == {
         "redacted_record",

--- a/tests/property/test_egress_policy_properties.py
+++ b/tests/property/test_egress_policy_properties.py
@@ -95,3 +95,50 @@ def test_arbitrary_allowlists_cannot_elevate_telegram(allowlist: frozenset[str])
     assert result is EgressDisposition.POLICY_FILTERED_SUMMARY
     assert "public" in allowlist
     assert allowlist <= {"public", "internal"}
+
+
+_METADATA_DISPOSITIONS = frozenset(
+    {EgressDisposition.METADATA, EgressDisposition.REDACTED_METADATA}
+)
+
+
+@pytest.mark.property
+@given(st.sampled_from(_CLASSES), _CLASS_SETS)
+def test_local_log_never_exceeds_internal_metadata_ceiling(
+    privacy_class: str,
+    allowlist: frozenset[str],
+) -> None:
+    # restricted is refused before any surface policy is considered.
+    if privacy_class == "restricted":
+        with pytest.raises(PrivacyError) as restricted:
+            require_egress(
+                surface=EgressSurface.LOCAL_LOG,
+                privacy_class="restricted",
+                allowed_classifications=cast(frozenset[PrivacyClassV1], allowlist),
+            )
+        assert restricted.value.code == "MH_EGRESS_RESTRICTED"
+        return
+
+    # LOCAL_LOG is a local surface, so any non-empty external policy must be refused outright.
+    if allowlist:
+        with pytest.raises(PrivacyError) as policy:
+            require_egress(
+                surface=EgressSurface.LOCAL_LOG,
+                privacy_class=cast(PrivacyClassV1, privacy_class),
+                allowed_classifications=cast(frozenset[PrivacyClassV1], allowlist),
+            )
+        assert policy.value.code == "MH_EGRESS_POLICY"
+        return
+
+    try:
+        result = require_egress(
+            surface=EgressSurface.LOCAL_LOG,
+            privacy_class=cast(PrivacyClassV1, privacy_class),
+        )
+    except PrivacyError as denied:
+        assert privacy_class == "sensitive"
+        assert denied.code == "MH_EGRESS_CLASS_DENIED"
+        return
+
+    assert privacy_class in {"public", "internal"}
+    assert result in _METADATA_DISPOSITIONS

--- a/tests/security/test_egress_boundary.py
+++ b/tests/security/test_egress_boundary.py
@@ -65,3 +65,22 @@ def test_machine_shaped_strings_cannot_create_an_egress_capability() -> None:
             allowed_classifications=frozenset({"public", "sensitive"}),  # type: ignore[arg-type]
         )
     assert policy.value.code == "MH_EGRESS_POLICY"
+
+
+@pytest.mark.security
+def test_local_log_surface_cannot_be_externally_enabled() -> None:
+    with pytest.raises(PrivacyError) as enabled:
+        require_egress(
+            surface=EgressSurface.LOCAL_LOG,
+            privacy_class="public",
+            explicitly_enabled=True,
+        )
+    assert enabled.value.code == "MH_EGRESS_POLICY"
+
+    with pytest.raises(PrivacyError) as allowlisted:
+        require_egress(
+            surface=EgressSurface.LOCAL_LOG,
+            privacy_class="internal",
+            allowed_classifications=frozenset({"internal"}),
+        )
+    assert allowlisted.value.code == "MH_EGRESS_POLICY"

--- a/tests/unit/test_egress_policy.py
+++ b/tests/unit/test_egress_policy.py
@@ -157,6 +157,43 @@ def test_runtime_types_are_strict_and_value_safe(arguments: dict[str, Any], code
     assert "unknown" not in str(captured.value)
 
 
+def test_local_log_surface_is_metadata_only() -> None:
+    assert (
+        require_egress(surface=EgressSurface.LOCAL_LOG, privacy_class="public")
+        is EgressDisposition.METADATA
+    )
+    assert (
+        require_egress(surface=EgressSurface.LOCAL_LOG, privacy_class="internal")
+        is EgressDisposition.REDACTED_METADATA
+    )
+
+    with pytest.raises(PrivacyError) as sensitive:
+        require_egress(surface=EgressSurface.LOCAL_LOG, privacy_class="sensitive")
+    assert sensitive.value.code == "MH_EGRESS_CLASS_DENIED"
+
+    with pytest.raises(PrivacyError) as restricted:
+        require_egress(surface=EgressSurface.LOCAL_LOG, privacy_class="restricted")
+    assert restricted.value.code == "MH_EGRESS_RESTRICTED"
+
+
+def test_local_log_is_a_local_surface_and_rejects_external_policy() -> None:
+    with pytest.raises(PrivacyError) as enabled:
+        require_egress(
+            surface=EgressSurface.LOCAL_LOG,
+            privacy_class="public",
+            explicitly_enabled=True,
+        )
+    assert enabled.value.code == "MH_EGRESS_POLICY"
+
+    with pytest.raises(PrivacyError) as allowlisted:
+        require_egress(
+            surface=EgressSurface.LOCAL_LOG,
+            privacy_class="public",
+            allowed_classifications=frozenset({"public"}),
+        )
+    assert allowlisted.value.code == "MH_EGRESS_POLICY"
+
+
 def test_hard_matrix_denial_is_distinct_from_external_policy_denial() -> None:
     with pytest.raises(PrivacyError) as hard_denial:
         require_egress(surface=EgressSurface.REPO_BRIEF, privacy_class="sensitive")


### PR DESCRIPTION
## Summary

**W02 implementation PR-1 of 5** toward G02, implementing the just-ratified **A02** `local_log`
contract. This is the **privacy-authorization slice only**: it promotes `local_log` to a first-class
surface in the binding v1 egress matrix (`src/milhouse/privacy/egress.py`).

- `EgressSurface.LOCAL_LOG` authorizes **only** installation-scoped operational metadata:
  `public → METADATA`, `internal → REDACTED_METADATA`.
- `sensitive` → hard-denied (`MH_EGRESS_CLASS_DENIED`); `restricted` → globally denied
  (`MH_EGRESS_RESTRICTED`) — matching §4.7 (`No` / `Never`).
- It is a **local** surface: `explicitly_enabled` or a caller allowlist is rejected
  (`MH_EGRESS_POLICY`); `require_egress` still accepts **no content or destination value**.
- The matrix row is intentionally identical in shape to `DIAGNOSTICS`.

## Proof-first tests (5 files)
Written before the implementation (they fail without `EgressSurface.LOCAL_LOG`): contract matrix +
stable string set, unit metadata-only + local-policy rejection, security external-enable rejection, and
a property test for the metadata ceiling with correct restricted-before-policy precedence.

## Evidence
- Independent report-only `milhouse-gate-review`: **pass**, no actionable findings.
- `make quality` ✅ · `make test` (3665 passed, 1 skipped) ✅ · `make test-coverage` (line 98.23%,
  **branch 97.17%** ≥95%) ✅ · `docs-check` ✅ · `skill-check` ✅ · `secret-scan` + self-test ✅ ·
  `git diff --check` clean.

## Scope fences (not in this PR)
No filesystem persistence / rotation / recovery (**W03**), no CLI/stderr binding (**W06**), no
backup/restore/purge (**W16**). No gate marked passed. Next: PR-2 (`CanonicalJSONV1` stored wire
projection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
