### PR TITLE
feat(core): add CanonicalJSONV1 stored log-wire projection

### DIFF
--- a/src/milhouse/core/log_wire.py
+++ b/src/milhouse/core/log_wire.py
@@ -1,0 +1,81 @@
+"""CanonicalJSONV1 stored projection of catalog-owned structured log events.
+
+This is the W02-owned event-line wire: it maps a constructor-controlled
+``StructuredLogEventV1`` to bounded CanonicalJSONV1 UTF-8 JSONL bytes with one trailing
+line feed. It performs no file or sink I/O (that is W03) and carries no arbitrary-text or
+exception-detail field.
+"""
+
+from __future__ import annotations
+
+from milhouse.core.canonical import canonical_json_bytes
+from milhouse.core.logging import LoggingError, StructuredLogEventV1
+from milhouse.domain.records import PrivacyClassV1
+from milhouse.privacy.egress import EgressDisposition, EgressSurface, require_egress
+
+STRUCTURED_LOG_SCHEMA_VERSION = 1
+STRUCTURED_LOG_LINE_EVENT = "event"
+STRUCTURED_LOG_PRIVACY_CLASS: PrivacyClassV1 = "internal"
+MAX_EVENT_LINE_BYTES = 4_096
+
+_LINE_FEED = b"\n"
+
+
+def _authorize_local_log() -> None:
+    """Fail closed unless the local_log surface still authorizes internal metadata.
+
+    The stored log wire exists only because the binding egress matrix authorizes internal
+    operational metadata on the ``local_log`` surface. If a future matrix change denied or
+    widened that authorization, projection stops here rather than emitting bytes.
+    """
+
+    disposition = require_egress(
+        surface=EgressSurface.LOCAL_LOG,
+        privacy_class=STRUCTURED_LOG_PRIVACY_CLASS,
+    )
+    if disposition is not EgressDisposition.REDACTED_METADATA:
+        raise LoggingError(
+            "MH_LOG_WIRE_EGRESS",
+            "local_log authorization is not internal metadata",
+        )
+
+
+def structured_log_event_line(event: StructuredLogEventV1) -> bytes:
+    """Project one event into a bounded CanonicalJSONV1 JSONL line with a trailing LF."""
+
+    if type(event) is not StructuredLogEventV1:
+        raise LoggingError("MH_LOG_WIRE_EVENT", "a StructuredLogEventV1 is required")
+    _authorize_local_log()
+
+    payload: dict[str, object] = {
+        "schema": STRUCTURED_LOG_SCHEMA_VERSION,
+        "line": STRUCTURED_LOG_LINE_EVENT,
+        "privacy": STRUCTURED_LOG_PRIVACY_CLASS,
+        "ts": event.timestamp,
+        "name": event.name,
+        "level": event.level.name,
+        "metrics": [
+            {
+                "kind": metric.spec.kind.value,
+                "name": metric.spec.name,
+                "value": metric.value,
+            }
+            for metric in event.metrics
+        ],
+        "error": event.error.code if event.error is not None else None,
+        "fingerprint": event.fingerprint,
+    }
+
+    # Reserve one byte for the trailing line feed so the full line, including its LF,
+    # never exceeds the section 4.15 bound.
+    encoded = canonical_json_bytes(payload, max_bytes=MAX_EVENT_LINE_BYTES - len(_LINE_FEED))
+    return encoded + _LINE_FEED
+
+
+__all__ = [
+    "MAX_EVENT_LINE_BYTES",
+    "STRUCTURED_LOG_LINE_EVENT",
+    "STRUCTURED_LOG_PRIVACY_CLASS",
+    "STRUCTURED_LOG_SCHEMA_VERSION",
+    "structured_log_event_line",
+]

--- a/tests/unit/test_log_wire.py
+++ b/tests/unit/test_log_wire.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import pytest
+
+from milhouse.config import ConfigError
+from milhouse.core import FixedClock
+from milhouse.core.log_wire import (
+    MAX_EVENT_LINE_BYTES,
+    STRUCTURED_LOG_LINE_EVENT,
+    STRUCTURED_LOG_PRIVACY_CLASS,
+    STRUCTURED_LOG_SCHEMA_VERSION,
+    structured_log_event_line,
+)
+from milhouse.core.logging import (
+    LogEventSpec,
+    LogFingerprintSpec,
+    LoggingError,
+    LogLevel,
+    LogMetric,
+    LogMetricKind,
+    LogMetricSpec,
+    StructuredLogEventV1,
+    StructuredLogger,
+)
+from milhouse.privacy import Pseudonymizer
+
+_RECORDS = LogMetricSpec("records", LogMetricKind.COUNT)
+_DEGRADED = LogMetricSpec("degraded", LogMetricKind.FLAG)
+_CORRELATION = LogFingerprintSpec("logging")
+_PLAIN = LogEventSpec(
+    "collector.completed",
+    LogLevel.INFO,
+    metrics=(_RECORDS, _DEGRADED),
+)
+_RICH = LogEventSpec(
+    "collector.completed",
+    LogLevel.WARNING,
+    metrics=(_RECORDS,),
+    error_codes=("config.test.failure",),
+    fingerprint=_CORRELATION,
+)
+
+
+@dataclass
+class _CapturingSink:
+    events: list[StructuredLogEventV1] = field(default_factory=list)
+
+    def write(self, event: StructuredLogEventV1) -> None:
+        self.events.append(event)
+
+
+def _emit(spec: LogEventSpec, **emit_kwargs: object) -> StructuredLogEventV1:
+    logger = StructuredLogger(
+        catalog=(spec,),
+        clock=FixedClock(datetime(2026, 7, 21, 12, 34, 56, 987654, tzinfo=UTC)),
+        sink=_CapturingSink(),
+        minimum_level=LogLevel.DEBUG,
+        pseudonymizer=Pseudonymizer(b"f" * 32),
+    )
+    event = logger.emit(spec, **emit_kwargs)  # type: ignore[arg-type]
+    assert event is not None
+    return event
+
+
+def test_event_line_golden_bytes() -> None:
+    event = _emit(_PLAIN, metrics=(LogMetric(_RECORDS, 3),))
+
+    assert structured_log_event_line(event) == (
+        b'{"error":null,"fingerprint":null,"level":"INFO","line":"event",'
+        b'"metrics":[{"kind":"count","name":"records","value":3}],'
+        b'"name":"collector.completed","privacy":"internal","schema":1,'
+        b'"ts":"2026-07-21T12:34:56.987Z"}\n'
+    )
+
+
+def test_event_line_golden_bytes_with_coded_error() -> None:
+    event = _emit(
+        _RICH,
+        metrics=(LogMetric(_RECORDS, 1),),
+        error=ConfigError("config.test.failure", "unused-detail"),
+    )
+
+    assert structured_log_event_line(event) == (
+        b'{"error":"config.test.failure","fingerprint":null,"level":"WARNING",'
+        b'"line":"event","metrics":[{"kind":"count","name":"records","value":1}],'
+        b'"name":"collector.completed","privacy":"internal","schema":1,'
+        b'"ts":"2026-07-21T12:34:56.987Z"}\n'
+    )
+
+
+def test_event_line_is_a_closed_key_set_with_one_trailing_lf() -> None:
+    event = _emit(_PLAIN, metrics=(LogMetric(_RECORDS, 3), LogMetric(_DEGRADED, True)))
+    line = structured_log_event_line(event)
+
+    assert line.endswith(b"\n")
+    assert line.count(b"\n") == 1
+    decoded = json.loads(line)
+    assert set(decoded) == {
+        "schema",
+        "line",
+        "privacy",
+        "ts",
+        "name",
+        "level",
+        "metrics",
+        "error",
+        "fingerprint",
+    }
+    assert decoded["schema"] == STRUCTURED_LOG_SCHEMA_VERSION
+    assert decoded["line"] == STRUCTURED_LOG_LINE_EVENT
+    assert decoded["privacy"] == STRUCTURED_LOG_PRIVACY_CLASS
+    assert decoded["level"] == "INFO"
+    # metrics stay sorted by name and expose only kind/name/value
+    assert decoded["metrics"] == [
+        {"kind": "flag", "name": "degraded", "value": True},
+        {"kind": "count", "name": "records", "value": 3},
+    ]
+    assert all(set(metric) == {"kind", "name", "value"} for metric in decoded["metrics"])
+
+
+def test_event_line_never_carries_arbitrary_text_or_exception_detail() -> None:
+    canary = "runtime-secret-message-7f31ac"
+    event = _emit(
+        _RICH,
+        metrics=(LogMetric(_RECORDS, 1),),
+        error=ConfigError("config.test.failure", canary),
+        fingerprint_value=canary,
+    )
+    line = structured_log_event_line(event)
+
+    assert canary.encode("utf-8") not in line
+    decoded = json.loads(line)
+    assert decoded["error"] == "config.test.failure"
+    assert decoded["fingerprint"].startswith("mh_fp1_e1_logging_")
+    assert decoded["level"] == "WARNING"
+
+
+def test_event_line_rejects_a_non_event_value() -> None:
+    with pytest.raises(LoggingError) as captured:
+        structured_log_event_line({"name": "collector.completed"})  # type: ignore[arg-type]
+    assert captured.value.code == "MH_LOG_WIRE_EVENT"
+
+
+def test_event_line_stays_within_the_line_byte_bound() -> None:
+    event = _emit(_PLAIN, metrics=(LogMetric(_RECORDS, 3),))
+    assert len(structured_log_event_line(event)) <= MAX_EVENT_LINE_BYTES
+
+
+def test_event_line_fails_closed_when_local_log_authorization_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from milhouse.core import log_wire
+    from milhouse.privacy import EgressDisposition
+
+    monkeypatch.setattr(
+        log_wire,
+        "require_egress",
+        lambda **_kwargs: EgressDisposition.REDACTED_RECORD,
+    )
+    event = _emit(_PLAIN, metrics=(LogMetric(_RECORDS, 3),))
+    with pytest.raises(LoggingError) as captured:
+        log_wire.structured_log_event_line(event)
+    assert captured.value.code == "MH_LOG_WIRE_EGRESS"


### PR DESCRIPTION
## Summary

**W02 implementation PR-2 of 5** toward G02. Adds the W02-owned **`StructuredLogEventLineV1` wire**:
`milhouse.core.log_wire.structured_log_event_line` projects a constructor-controlled
`StructuredLogEventV1` into bounded **CanonicalJSONV1** UTF-8 JSONL bytes with one trailing LF, per
ratified **A02 §4.15**. Pure in-memory projection — no file/sink I/O.

- **Closed 9-key line:** `schema`, `line` (`"event"`), `privacy` (`"internal"`), `ts` (canonical
  timestamp), `name`, `level` (enum name), `metrics` (sorted typed `{kind,name,value}`), `error`
  (normalized **code only**), `fingerprint` (keyed token or null). **No arbitrary-text or
  exception-detail field.**
- **Fail-closed egress:** asserts `require_egress(LOCAL_LOG, "internal")` before emitting bytes
  (`MH_LOG_WIRE_EGRESS` otherwise) — coupling the wire to PR-1's authorization.
- **Bound:** reserves the LF byte in the canonical `max_bytes` so the line (incl. LF) never exceeds
  §4.15's 4096.

## Proof-first tests (`tests/unit/test_log_wire.py`)
Golden byte vectors (empty + coded-error), closed-key-set with one LF, **planted-secret absence** (a
canary in both the error message and fingerprint input never appears in the bytes), non-event
rejection, byte bound, and the fail-closed egress guard. Written before the module (import-gated).

## Evidence
- Independent report-only `milhouse-gate-review`: **pass**, no actionable findings (one P3 "consider"
  addressed with a second golden; the other dispositioned as effectively unreachable).
- `make quality` ✅ · `make test` (3671 passed, 1 skipped) ✅ · `make test-coverage` (line 98.24%,
  **branch 97.18%**) ✅ · docs/skill/secret-scan + self-test ✅ · `git diff --check` clean.

## Scope fences (not here)
No filesystem persistence / rotation / recovery / header / trailer (**W03**), no CLI/stderr (**W06**),
no backup/purge (**W16**). No gate marked passed. Next: PR-3 (golden corpus + cross-process
determinism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
