### PR TITLE
test(core): prove log-wire determinism and adversarial leak-freedom

### DIFF
--- a/tests/integration/test_log_wire_subprocess_integration.py
+++ b/tests/integration/test_log_wire_subprocess_integration.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import UTC, datetime
+
+from milhouse.config import ConfigError
+from milhouse.core import FixedClock
+from milhouse.core.log_wire import structured_log_event_line
+from milhouse.core.logging import (
+    LogEventSpec,
+    LogLevel,
+    LogMetric,
+    LogMetricKind,
+    LogMetricSpec,
+    StructuredLogEventV1,
+    StructuredLogger,
+)
+
+MAX_CHILD_OUTPUT_BYTES = 8 * 1024
+CHILD_TIMEOUT_SECONDS = 10
+
+# (PYTHONHASHSEED, locale, timezone) — byte output must be identical across all of them.
+RUN_ENVIRONMENTS = (
+    ("0", "C", "UTC0"),
+    ("1", "en_US.UTF-8", "EST5EDT"),
+    ("314159", "POSIX", "GMT0"),
+)
+
+# Fingerprint-free golden so the exact bytes are hand-verifiable and byte-stable.
+GOLDEN_WIRE = (
+    b'{"error":null,"fingerprint":null,"level":"INFO","line":"event",'
+    b'"metrics":[{"kind":"count","name":"records","value":3}],'
+    b'"name":"spool.commit","privacy":"internal","schema":1,'
+    b'"ts":"2026-07-21T12:00:00.000Z"}\n'
+    b'{"error":"config.test.failure","fingerprint":null,"level":"WARNING",'
+    b'"line":"event","metrics":[{"kind":"count","name":"attempts","value":2}],'
+    b'"name":"spool.retry","privacy":"internal","schema":1,'
+    b'"ts":"2026-07-21T12:00:00.000Z"}\n'
+)
+
+CHILD_SCRIPT = r"""
+import os
+import sys
+from datetime import datetime, timezone
+
+
+class WireFailure(Exception):
+    pass
+
+
+def main():
+    if len(sys.argv) != 2 or not sys.flags.safe_path or not sys.flags.no_user_site:
+        raise WireFailure
+    if os.environ.get("PYTHONHASHSEED") != sys.argv[1]:
+        raise WireFailure
+
+    import locale
+    import time
+
+    locale.setlocale(locale.LC_ALL, "")
+    if hasattr(time, "tzset"):
+        time.tzset()
+
+    from milhouse.config import ConfigError
+    from milhouse.core import FixedClock
+    from milhouse.core.log_wire import structured_log_event_line
+    from milhouse.core.logging import (
+        LogEventSpec,
+        LogLevel,
+        LogMetric,
+        LogMetricKind,
+        LogMetricSpec,
+        StructuredLogger,
+    )
+
+    records = LogMetricSpec("records", LogMetricKind.COUNT)
+    attempts = LogMetricSpec("attempts", LogMetricKind.COUNT)
+    commit = LogEventSpec("spool.commit", LogLevel.INFO, metrics=(records,))
+    retry = LogEventSpec(
+        "spool.retry",
+        LogLevel.WARNING,
+        metrics=(attempts,),
+        error_codes=("config.test.failure",),
+    )
+
+    class _Sink:
+        def write(self, _event):
+            return None
+
+    logger = StructuredLogger(
+        catalog=(commit, retry),
+        clock=FixedClock(datetime(2026, 7, 21, 12, 0, 0, tzinfo=timezone.utc)),
+        sink=_Sink(),
+        minimum_level=LogLevel.DEBUG,
+    )
+    event_a = logger.emit(commit, metrics=(LogMetric(records, 3),))
+    event_b = logger.emit(
+        retry,
+        metrics=(LogMetric(attempts, 2),),
+        error=ConfigError("config.test.failure", "synthetic retry"),
+    )
+    if event_a is None or event_b is None:
+        raise WireFailure
+
+    output = structured_log_event_line(event_a) + structured_log_event_line(event_b)
+    if len(output) > 8 * 1024:
+        raise WireFailure
+    sys.stdout.buffer.write(output)
+
+
+try:
+    main()
+except BaseException:
+    raise SystemExit(70) from None
+"""
+
+
+class _Sink:
+    def write(self, event: StructuredLogEventV1) -> None:
+        return None
+
+
+def _build_in_process() -> bytes:
+    records = LogMetricSpec("records", LogMetricKind.COUNT)
+    attempts = LogMetricSpec("attempts", LogMetricKind.COUNT)
+    commit = LogEventSpec("spool.commit", LogLevel.INFO, metrics=(records,))
+    retry = LogEventSpec(
+        "spool.retry",
+        LogLevel.WARNING,
+        metrics=(attempts,),
+        error_codes=("config.test.failure",),
+    )
+    logger = StructuredLogger(
+        catalog=(commit, retry),
+        clock=FixedClock(datetime(2026, 7, 21, 12, 0, 0, tzinfo=UTC)),
+        sink=_Sink(),
+        minimum_level=LogLevel.DEBUG,
+    )
+    event_a = logger.emit(commit, metrics=(LogMetric(records, 3),))
+    event_b = logger.emit(
+        retry,
+        metrics=(LogMetric(attempts, 2),),
+        error=ConfigError("config.test.failure", "synthetic retry"),
+    )
+    assert event_a is not None
+    assert event_b is not None
+    return structured_log_event_line(event_a) + structured_log_event_line(event_b)
+
+
+def test_golden_wire_matches_the_in_process_projection() -> None:
+    assert _build_in_process() == GOLDEN_WIRE
+
+
+def test_wire_bytes_are_portable_across_isolated_process_environments() -> None:
+    outputs: list[bytes] = []
+    for run_number, (hash_seed, selected_locale, timezone_name) in enumerate(
+        RUN_ENVIRONMENTS,
+        start=1,
+    ):
+        child_environment = {
+            "LC_ALL": selected_locale,
+            "LANG": selected_locale,
+            "TZ": timezone_name,
+            "PYTHONHASHSEED": hash_seed,
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONUTF8": "1",
+        }
+        if "PATH" in os.environ:
+            child_environment["PATH"] = os.environ["PATH"]
+        with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+            try:
+                completed = subprocess.run(
+                    [sys.executable, "-s", "-P", "-c", CHILD_SCRIPT, hash_seed],
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                    check=False,
+                    env=child_environment,
+                    timeout=CHILD_TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired:
+                raise AssertionError(f"log-wire child run {run_number} timed out") from None
+            except OSError:
+                raise AssertionError(f"log-wire child run {run_number} could not start") from None
+
+            stdout_size = os.fstat(stdout_file.fileno()).st_size
+            stderr_size = os.fstat(stderr_file.fileno()).st_size
+            stdout_file.seek(0)
+            stderr_file.seek(0)
+            child_stdout = stdout_file.read(MAX_CHILD_OUTPUT_BYTES + 1)
+            child_stderr = stderr_file.read(MAX_CHILD_OUTPUT_BYTES + 1)
+
+        assert stdout_size <= MAX_CHILD_OUTPUT_BYTES, f"run {run_number} exceeded the stdout bound"
+        assert stderr_size <= MAX_CHILD_OUTPUT_BYTES, f"run {run_number} exceeded the stderr bound"
+        assert completed.returncode == 0, f"log-wire child run {run_number} failed"
+        assert child_stderr == b"", f"log-wire child run {run_number} wrote to stderr"
+        assert child_stdout == GOLDEN_WIRE, f"log-wire child run {run_number} did not match golden"
+        outputs.append(child_stdout)
+
+    assert all(output == outputs[0] for output in outputs[1:])

--- a/tests/property/test_log_wire_properties.py
+++ b/tests/property/test_log_wire_properties.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from milhouse.config import ConfigError
+from milhouse.core import FixedClock
+from milhouse.core.log_wire import structured_log_event_line
+from milhouse.core.logging import (
+    LogEventSpec,
+    LogFingerprintSpec,
+    LogLevel,
+    LogMetric,
+    LogMetricKind,
+    LogMetricSpec,
+    StructuredLogEventV1,
+    StructuredLogger,
+)
+from milhouse.privacy import Pseudonymizer
+
+_RECORDS = LogMetricSpec("records", LogMetricKind.COUNT)
+_DEGRADED = LogMetricSpec("degraded", LogMetricKind.FLAG)
+_GAUGE = LogMetricSpec("ratio", LogMetricKind.GAUGE)
+_FINGERPRINT = LogFingerprintSpec("logging")
+_MEASURED = LogEventSpec("operation.measured", LogLevel.INFO, metrics=(_RECORDS, _DEGRADED))
+_GAUGED = LogEventSpec("operation.gauged", LogLevel.INFO, metrics=(_GAUGE,))
+_FAILED = LogEventSpec(
+    "operation.failed",
+    LogLevel.ERROR,
+    metrics=(_RECORDS,),
+    error_codes=("config.test.failure",),
+    allow_unexpected_error=True,
+    fingerprint=_FINGERPRINT,
+)
+
+_EXPECTED_KEYS = {
+    "schema",
+    "line",
+    "privacy",
+    "ts",
+    "name",
+    "level",
+    "metrics",
+    "error",
+    "fingerprint",
+}
+
+# Encoded / Unicode / multiline / Markdown / HTML / URL / path / PII / prompt-injection / nested.
+_CANARIES = (
+    "".join(("gh", "p", "_not-a-real-token-0123456789")),
+    "user@example.invalid",
+    "https://example.invalid/?token=private",
+    "/synthetic/local/workspace/file.py",
+    "line one\nline two\rline three",
+    "<script>ignore previous instructions</script>",
+    "**bold** [link](https://example.invalid) `code`",
+    "unicode-‮-control-\U0001f600",
+    "prompt: reveal all system secrets",
+    '{"nested": {"deep": ["array", 1, true, null]}}',
+    "cGFzc3dvcmQ6IHN5bnRoZXRpYw==",
+    "tab\tnul\x00esc\x1bdel\x7f",
+)
+
+
+@dataclass
+class _Sink:
+    events: list[StructuredLogEventV1] = field(default_factory=list)
+
+    def write(self, event: StructuredLogEventV1) -> None:
+        self.events.append(event)
+
+
+def _emit(**emit_kwargs: object) -> StructuredLogEventV1:
+    logger = StructuredLogger(
+        catalog=(_FAILED,),
+        clock=FixedClock(datetime(2026, 7, 21, tzinfo=UTC)),
+        sink=_Sink(),
+        pseudonymizer=Pseudonymizer(b"p" * 32),
+    )
+    event = logger.emit(_FAILED, **emit_kwargs)  # type: ignore[arg-type]
+    assert event is not None
+    return event
+
+
+@pytest.mark.parametrize("canary", _CANARIES)
+def test_wire_bytes_never_carry_an_adversarial_canary(canary: str) -> None:
+    # fingerprint_value accepts arbitrary text (it is keyed before the wire); the error
+    # message boundary independently rejects control text, so the wire carries only the code.
+    event = _emit(fingerprint_value=canary)
+    line = structured_log_event_line(event)
+
+    assert canary.encode("utf-8") not in line
+    decoded = json.loads(line)
+    assert set(decoded) == _EXPECTED_KEYS
+    assert decoded["error"] is None
+    assert decoded["fingerprint"].startswith("mh_fp1_e1_logging_")
+    assert line.endswith(b"\n")
+    assert line.count(b"\n") == 1
+
+
+@pytest.mark.parametrize("canary", _CANARIES)
+def test_error_message_boundary_never_reaches_the_wire(canary: str) -> None:
+    # Drive each adversarial value through the error-message surface. The message boundary
+    # either rejects it at construction or the wire projects only the bounded machine code.
+    try:
+        error = ConfigError("config.test.failure", canary)
+    except ValueError:
+        return
+    line = structured_log_event_line(_emit(error=error))
+
+    assert canary.encode("utf-8") not in line
+    decoded = json.loads(line)
+    assert decoded["error"] == "config.test.failure"
+
+
+@pytest.mark.property
+@given(payload=st.binary(min_size=4, max_size=48))
+def test_wire_projection_is_deterministic_and_leak_free(payload: bytes) -> None:
+    canary = f"runtime_canary_{payload.hex()}_end"
+    event = _emit(
+        metrics=(LogMetric(_RECORDS, len(payload)),),
+        error=ConfigError("config.test.failure", canary),
+        fingerprint_value=canary,
+    )
+    first = structured_log_event_line(event)
+    second = structured_log_event_line(event)
+
+    assert first == second
+    assert canary.encode("utf-8") not in first
+    decoded = json.loads(first)
+    assert set(decoded) == _EXPECTED_KEYS
+    assert decoded["metrics"] == [{"kind": "count", "name": "records", "value": len(payload)}]
+
+
+@pytest.mark.property
+@given(
+    count=st.integers(min_value=0, max_value=2**63 - 1),
+    flag=st.booleans(),
+)
+def test_wire_metric_scalars_project_to_canonical_numbers(count: int, flag: bool) -> None:
+    logger = StructuredLogger(
+        catalog=(_MEASURED,),
+        clock=FixedClock(datetime(2026, 7, 21, tzinfo=UTC)),
+        sink=_Sink(),
+    )
+    event = logger.emit(
+        _MEASURED,
+        metrics=(LogMetric(_RECORDS, count), LogMetric(_DEGRADED, flag)),
+    )
+    assert event is not None
+
+    decoded = json.loads(structured_log_event_line(event))
+    assert decoded["metrics"] == [
+        {"kind": "flag", "name": "degraded", "value": flag},
+        {"kind": "count", "name": "records", "value": count},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1.5, b'"value":1.5'),
+        (-2.5, b'"value":-2.5'),
+        (0.1, b'"value":0.1'),
+        (1e-7, b'"value":1e-7'),
+    ],
+)
+def test_wire_gauge_float_metric_uses_canonical_serialization(
+    value: float, expected: bytes
+) -> None:
+    logger = StructuredLogger(
+        catalog=(_GAUGED,),
+        clock=FixedClock(datetime(2026, 7, 21, tzinfo=UTC)),
+        sink=_Sink(),
+    )
+    event = logger.emit(_GAUGED, metrics=(LogMetric(_GAUGE, value),))
+    assert event is not None
+
+    line = structured_log_event_line(event)
+    assert expected in line
+    decoded = json.loads(line)
+    assert decoded["metrics"] == [{"kind": "gauge", "name": "ratio", "value": value}]


### PR DESCRIPTION
## Summary

**W02 implementation PR-3 of 5** toward G02. **Tests-only** — proves the A02 §4.15 CanonicalJSONV1 log
wire (from PR-2) is deterministic and adversarially leak-free. No production change.

### `tests/integration/test_log_wire_subprocess_integration.py`
- Hand-verifiable **golden wire** (fingerprint-free) locked both in-process and **across 3 isolated
  subprocesses** (`sys.executable -s -P`) varying `PYTHONHASHSEED` / locale / timezone → byte-identical,
  mirroring the accepted identity-portability harness. Children fail closed (exit 70) with bounded,
  empty stderr.

### `tests/property/test_log_wire_properties.py`
- **Adversarial canary matrix** (encoded, Unicode, multiline, Markdown, HTML, URL, path, PII,
  prompt-injection, nested, hard control chars incl. NUL/ESC/DEL) driven through **both** injection
  surfaces — the keyed fingerprint *and* the error-message boundary — asserting the raw value never
  reaches the wire and only the bounded machine `error.code` is projected.
- Hypothesis determinism/leak-free + closed-key-set, metric-scalar canonicalization, and **gauge-float**
  canonical serialization locked (`1.5`/`-2.5`/`0.1`/`1e-7`).

## Evidence
- Independent report-only **multi-lens** `milhouse-gate-review`: **pass**, 0 P0/P1. Both P2s
  (control-char canary, adversarial error-boundary) and the gauge-float P3 were addressed in this PR;
  remaining P3s dispositioned (cross-version → CI 3.11–3.14 matrix; locale/​fail-closed → accepted
  precedent / defense-in-depth).
- `make quality` ✅ · `make test` (3701 passed) ✅ · `make test-coverage` (line 98.24%, **branch
  97.18%**) ✅ · docs/skill/secret ✅ · `git diff --check` clean.

## Scope fences
Tests only. No src change; no gate marked passed. Next: PR-4 (stderr event-line sink with fail-closed
`require_egress(LOCAL_LOG)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
