### PR TITLE
feat(core): add stderr-style structured-log stream sink

### DIFF
--- a/src/milhouse/core/log_wire.py
+++ b/src/milhouse/core/log_wire.py
@@ -2,11 +2,14 @@
 
 This is the W02-owned event-line wire: it maps a constructor-controlled
 ``StructuredLogEventV1`` to bounded CanonicalJSONV1 UTF-8 JSONL bytes with one trailing
-line feed. It performs no file or sink I/O (that is W03) and carries no arbitrary-text or
-exception-detail field.
+line feed, plus the injected-stream ``StreamLogSink`` that emits those exact bytes. It performs no
+file I/O, rotation, or persistence (that is W03) and carries no arbitrary-text or exception-detail
+field.
 """
 
 from __future__ import annotations
+
+from typing import Protocol
 
 from milhouse.core.canonical import canonical_json_bytes
 from milhouse.core.logging import LoggingError, StructuredLogEventV1
@@ -72,10 +75,46 @@ def structured_log_event_line(event: StructuredLogEventV1) -> bytes:
     return encoded + _LINE_FEED
 
 
+class _BinaryStream(Protocol):
+    def write(self, data: bytes, /) -> object:
+        """Write raw bytes to the underlying stream."""
+
+
+class StreamLogSink:
+    """A ``StructuredLogSink`` that writes exact event-line bytes to an injected binary stream.
+
+    W02 owns the sink interface and the exact bytes. Binding a concrete stream (for example
+    ``sys.stderr.buffer``) and any flushing or buffering policy are W06 responsibilities. The
+    ``local_log`` egress guard runs inside ``structured_log_event_line`` before any byte is
+    written, so a denied or widened matrix emits nothing.
+    """
+
+    __slots__ = ("_stream",)
+
+    def __init__(self, stream: _BinaryStream) -> None:
+        if not callable(getattr(stream, "write", None)):
+            raise LoggingError("MH_LOG_SINK_STREAM", "a writable binary stream is required")
+        self._stream = stream
+
+    def write(self, event: StructuredLogEventV1) -> None:
+        if type(event) is not StructuredLogEventV1:
+            raise LoggingError("MH_LOG_SINK_EVENT", "a StructuredLogEventV1 is required")
+        line = structured_log_event_line(event)
+        try:
+            self._stream.write(line)
+        except LoggingError:
+            raise
+        except Exception:
+            raise LoggingError(
+                "MH_LOG_SINK_WRITE", "structured log sink stream write failed"
+            ) from None
+
+
 __all__ = [
     "MAX_EVENT_LINE_BYTES",
     "STRUCTURED_LOG_LINE_EVENT",
     "STRUCTURED_LOG_PRIVACY_CLASS",
     "STRUCTURED_LOG_SCHEMA_VERSION",
+    "StreamLogSink",
     "structured_log_event_line",
 ]

--- a/src/milhouse/core/log_wire.py
+++ b/src/milhouse/core/log_wire.py
@@ -9,6 +9,7 @@ field.
 
 from __future__ import annotations
 
+import threading
 from typing import Protocol
 
 from milhouse.core.canonical import canonical_json_bytes
@@ -89,25 +90,53 @@ class StreamLogSink:
     written, so a denied or widened matrix emits nothing.
     """
 
-    __slots__ = ("_stream",)
+    __slots__ = ("_lock", "_stream")
 
     def __init__(self, stream: _BinaryStream) -> None:
-        if not callable(getattr(stream, "write", None)):
+        writable = False
+        try:
+            writable = callable(getattr(stream, "write", None))
+        except Exception:
+            writable = False
+        if not writable:
             raise LoggingError("MH_LOG_SINK_STREAM", "a writable binary stream is required")
         self._stream = stream
+        self._lock = threading.Lock()
 
     def write(self, event: StructuredLogEventV1) -> None:
         if type(event) is not StructuredLogEventV1:
             raise LoggingError("MH_LOG_SINK_EVENT", "a StructuredLogEventV1 is required")
+        # Projection and its local_log egress guard run outside the stream-write handler so their
+        # fixed-code errors are never masked or normalized away.
         line = structured_log_event_line(event)
-        try:
-            self._stream.write(line)
-        except LoggingError:
-            raise
-        except Exception:
-            raise LoggingError(
-                "MH_LOG_SINK_WRITE", "structured log sink stream write failed"
-            ) from None
+        if not self._write_all(line):
+            # Raised outside any exception handler: both __cause__ and __context__ stay empty, so no
+            # stream-originated detail is reachable through the exception object.
+            raise LoggingError("MH_LOG_SINK_WRITE", "structured log sink stream write failed")
+
+    def _write_all(self, line: bytes) -> bool:
+        """Write the whole line under the sink lock; never surface stream-originated detail.
+
+        Returns ``True`` only when every byte was written exactly once. Any raised failure, or a
+        return that is not a positive integer within the remaining length, fails closed so a
+        partial, zero, or invalid write is never acknowledged as a complete event line. The lock
+        keeps concurrent writers from interleaving one event line across retries.
+        """
+
+        total = len(line)
+        offset = 0
+        with self._lock:
+            while offset < total:
+                try:
+                    written = self._stream.write(line[offset:])
+                except Exception:
+                    return False
+                if type(written) is not int:
+                    return False
+                if not 0 < written <= total - offset:
+                    return False
+                offset += written
+        return True
 
 
 __all__ = [

--- a/tests/security/test_log_sink_boundary.py
+++ b/tests/security/test_log_sink_boundary.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import io
+from datetime import UTC, datetime
+
+import pytest
+
+from milhouse.config import ConfigError
+from milhouse.core import FixedClock
+from milhouse.core.log_wire import StreamLogSink
+from milhouse.core.logging import (
+    LogEventSpec,
+    LogFingerprintSpec,
+    LoggingError,
+    LogLevel,
+    LogMetricKind,
+    LogMetricSpec,
+    StructuredLogEventV1,
+    StructuredLogger,
+)
+from milhouse.privacy import Pseudonymizer
+
+_RECORDS = LogMetricSpec("records", LogMetricKind.COUNT)
+_FINGERPRINT = LogFingerprintSpec("logging")
+_FAILED = LogEventSpec(
+    "operation.failed",
+    LogLevel.ERROR,
+    metrics=(_RECORDS,),
+    error_codes=("config.test.failure",),
+    fingerprint=_FINGERPRINT,
+)
+
+
+class _Sink:
+    def write(self, event: StructuredLogEventV1) -> None:
+        return None
+
+
+def _event(**emit_kwargs: object) -> StructuredLogEventV1:
+    logger = StructuredLogger(
+        catalog=(_FAILED,),
+        clock=FixedClock(datetime(2026, 7, 21, tzinfo=UTC)),
+        sink=_Sink(),
+        pseudonymizer=Pseudonymizer(b"s" * 32),
+    )
+    event = logger.emit(_FAILED, **emit_kwargs)  # type: ignore[arg-type]
+    assert event is not None
+    return event
+
+
+@pytest.mark.security
+def test_stream_sink_never_emits_a_planted_secret() -> None:
+    canary = "runtime-secret-log-sink-5b7e21"
+    stream = io.BytesIO()
+
+    StreamLogSink(stream).write(
+        _event(
+            error=ConfigError("config.test.failure", "synthetic"),
+            fingerprint_value=canary,
+        )
+    )
+
+    emitted = stream.getvalue()
+    assert canary.encode("utf-8") not in emitted
+    assert b"synthetic" not in emitted  # the error message text never reaches the wire
+    assert emitted.count(b"\n") == 1
+
+
+@pytest.mark.security
+def test_stream_sink_fails_closed_and_emits_nothing_when_egress_denies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from milhouse.core import log_wire
+    from milhouse.privacy import EgressDisposition
+
+    monkeypatch.setattr(
+        log_wire,
+        "require_egress",
+        lambda **_kwargs: EgressDisposition.REDACTED_RECORD,
+    )
+    stream = io.BytesIO()
+    with pytest.raises(LoggingError) as captured:
+        StreamLogSink(stream).write(_event())
+
+    assert captured.value.code == "MH_LOG_WIRE_EGRESS"
+    assert stream.getvalue() == b""

--- a/tests/security/test_log_sink_boundary.py
+++ b/tests/security/test_log_sink_boundary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import traceback
 from datetime import UTC, datetime
 
 import pytest
@@ -84,3 +85,49 @@ def test_stream_sink_fails_closed_and_emits_nothing_when_egress_denies(
 
     assert captured.value.code == "MH_LOG_WIRE_EGRESS"
     assert stream.getvalue() == b""
+
+
+def _graph(error: BaseException) -> tuple[str, ...]:
+    return (
+        str(error),
+        repr(error),
+        repr(error.args),
+        "".join(traceback.format_exception(error)),
+    )
+
+
+@pytest.mark.security
+def test_stream_sink_normalizes_a_stream_raised_logging_error() -> None:
+    canary = "runtime-private-logging-detail-3a7d"
+
+    class _Raiser:
+        def write(self, _data: object) -> object:
+            raise LoggingError("MH_LOG_SINK", canary)
+
+    with pytest.raises(LoggingError) as captured:
+        StreamLogSink(_Raiser()).write(_event())
+
+    error = captured.value
+    assert error.code == "MH_LOG_SINK_WRITE"  # normalized, never passed through
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert all(canary not in part for part in _graph(error))
+
+
+@pytest.mark.security
+def test_stream_sink_normalizes_a_hostile_write_descriptor() -> None:
+    canary = "runtime-private-descriptor-detail-6b2e"
+
+    class _Hostile:
+        @property
+        def write(self) -> object:
+            raise RuntimeError(canary)
+
+    with pytest.raises(LoggingError) as captured:
+        StreamLogSink(_Hostile())
+
+    error = captured.value
+    assert error.code == "MH_LOG_SINK_STREAM"
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert all(canary not in part for part in _graph(error))

--- a/tests/unit/test_log_sink.py
+++ b/tests/unit/test_log_sink.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import pytest
+
+from milhouse.core import FixedClock
+from milhouse.core.log_wire import StreamLogSink, structured_log_event_line
+from milhouse.core.logging import (
+    LogEventSpec,
+    LoggingError,
+    LogLevel,
+    LogMetric,
+    LogMetricKind,
+    LogMetricSpec,
+    StructuredLogEventV1,
+    StructuredLogger,
+)
+
+_RECORDS = LogMetricSpec("records", LogMetricKind.COUNT)
+_COMMIT = LogEventSpec("spool.commit", LogLevel.INFO, metrics=(_RECORDS,))
+_RETRY = LogEventSpec("spool.retry", LogLevel.WARNING, metrics=(_RECORDS,))
+
+
+@dataclass
+class _CapturingSink:
+    events: list[StructuredLogEventV1] = field(default_factory=list)
+
+    def write(self, event: StructuredLogEventV1) -> None:
+        self.events.append(event)
+
+
+def _logger(
+    sink: object, *, catalog: tuple[LogEventSpec, ...] = (_COMMIT, _RETRY)
+) -> StructuredLogger:
+    return StructuredLogger(
+        catalog=catalog,
+        clock=FixedClock(datetime(2026, 7, 21, 12, 0, 0, tzinfo=UTC)),
+        sink=sink,  # type: ignore[arg-type]
+        minimum_level=LogLevel.DEBUG,
+    )
+
+
+def _event() -> StructuredLogEventV1:
+    capture = _CapturingSink()
+    event = _logger(capture).emit(_COMMIT, metrics=(LogMetric(_RECORDS, 3),))
+    assert event is not None
+    return event
+
+
+def test_stream_sink_writes_exactly_one_canonical_line() -> None:
+    stream = io.BytesIO()
+    event = _event()
+
+    StreamLogSink(stream).write(event)
+
+    written = stream.getvalue()
+    assert written == structured_log_event_line(event)
+    assert written.endswith(b"\n")
+    assert written.count(b"\n") == 1
+
+
+def test_stream_sink_appends_sequential_event_lines() -> None:
+    stream = io.BytesIO()
+    sink = StreamLogSink(stream)
+    capture = _CapturingSink()
+    logger = _logger(capture)
+
+    first = logger.emit(_COMMIT, metrics=(LogMetric(_RECORDS, 1),))
+    second = logger.emit(_RETRY, metrics=(LogMetric(_RECORDS, 2),))
+    assert first is not None
+    assert second is not None
+    sink.write(first)
+    sink.write(second)
+
+    assert stream.getvalue() == structured_log_event_line(first) + structured_log_event_line(second)
+    assert stream.getvalue().count(b"\n") == 2
+
+
+def test_stream_sink_rejects_a_non_writable_stream() -> None:
+    with pytest.raises(LoggingError) as captured:
+        StreamLogSink(object())  # type: ignore[arg-type]
+    assert captured.value.code == "MH_LOG_SINK_STREAM"
+
+
+def test_stream_sink_rejects_a_non_event_value() -> None:
+    sink = StreamLogSink(io.BytesIO())
+    with pytest.raises(LoggingError) as captured:
+        sink.write({"name": "spool.commit"})  # type: ignore[arg-type]
+    assert captured.value.code == "MH_LOG_SINK_EVENT"
+
+
+def test_stream_sink_wraps_a_hostile_stream_failure_without_leaking_detail() -> None:
+    canary = "runtime-private-stream-detail-9c1f"
+
+    class _HostileStream:
+        def write(self, _data: bytes) -> int:
+            raise OSError(canary)
+
+    with pytest.raises(LoggingError) as captured:
+        StreamLogSink(_HostileStream()).write(_event())
+
+    assert captured.value.code == "MH_LOG_SINK_WRITE"
+    assert canary not in str(captured.value)
+    assert captured.value.__cause__ is None
+
+
+def test_structured_logger_delivers_to_a_stream_sink_without_touching_stdio(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stream = io.BytesIO()
+    event = _logger(StreamLogSink(stream)).emit(_COMMIT, metrics=(LogMetric(_RECORDS, 7),))
+
+    assert event is not None
+    assert stream.getvalue() == structured_log_event_line(event)
+    assert capsys.readouterr() == ("", "")

--- a/tests/unit/test_log_sink.py
+++ b/tests/unit/test_log_sink.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import traceback
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
@@ -102,9 +103,17 @@ def test_stream_sink_wraps_a_hostile_stream_failure_without_leaking_detail() -> 
     with pytest.raises(LoggingError) as captured:
         StreamLogSink(_HostileStream()).write(_event())
 
-    assert captured.value.code == "MH_LOG_SINK_WRITE"
-    assert canary not in str(captured.value)
-    assert captured.value.__cause__ is None
+    error = captured.value
+    assert error.code == "MH_LOG_SINK_WRITE"
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    graph = (
+        str(error),
+        repr(error),
+        repr(error.args),
+        "".join(traceback.format_exception(error)),
+    )
+    assert all(canary not in part for part in graph)
 
 
 def test_structured_logger_delivers_to_a_stream_sink_without_touching_stdio(
@@ -116,3 +125,61 @@ def test_structured_logger_delivers_to_a_stream_sink_without_touching_stdio(
     assert event is not None
     assert stream.getvalue() == structured_log_event_line(event)
     assert capsys.readouterr() == ("", "")
+
+
+class _ScriptedStream:
+    """A binary stream whose write() returns scripted values and records accepted bytes."""
+
+    def __init__(self, script: list[object]) -> None:
+        self._script = list(script)
+        self.written = bytearray()
+
+    def write(self, data: object) -> object:
+        outcome = self._script.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        buffer = bytes(data)  # type: ignore[arg-type]
+        if type(outcome) is int and 0 <= outcome <= len(buffer):
+            self.written += buffer[:outcome]
+        return outcome
+
+
+def test_stream_sink_completes_a_short_then_complete_write() -> None:
+    event = _event()
+    line = structured_log_event_line(event)
+    stream = _ScriptedStream([7, len(line) - 7])
+
+    StreamLogSink(stream).write(event)
+
+    assert bytes(stream.written) == line
+
+
+def test_stream_sink_completes_a_repeatedly_short_write() -> None:
+    event = _event()
+    line = structured_log_event_line(event)
+    stream = _ScriptedStream([1, 1, len(line) - 2])
+
+    StreamLogSink(stream).write(event)
+
+    assert bytes(stream.written) == line
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        [0],  # zero progress
+        [-1],  # negative
+        [None],  # non-integer
+        [True],  # bool is not int
+        [10_000],  # oversized (greater than the remaining length)
+        [7, OSError("short then fail")],  # partial then raise
+    ],
+)
+def test_stream_sink_fails_closed_on_invalid_or_incomplete_writes(script: list[object]) -> None:
+    stream = _ScriptedStream(script)
+    with pytest.raises(LoggingError) as captured:
+        StreamLogSink(stream).write(_event())
+
+    assert captured.value.code == "MH_LOG_SINK_WRITE"
+    # a partial or rejected acceptance is never reported as a complete event line
+    assert bytes(stream.written) != structured_log_event_line(_event())


### PR DESCRIPTION
## Summary

**W02 implementation PR-4 of 5** toward G02. Adds **`StreamLogSink`** — a `StructuredLogSink` that
writes exactly the CanonicalJSONV1 event-line bytes (from PR-2's `structured_log_event_line`) to an
**injected binary stream**, per A02 §4.15 ("stderr uses the exact event-line bytes without file header,
trailer, or sequence").

- **Fail-closed:** the `local_log` egress guard runs inside the projection *before* any byte is
  written, so a denied/widened matrix emits **nothing**.
- **Leak-safe:** a hostile stream failure wraps to a fixed `MH_LOG_SINK_WRITE` with no detail and
  `__cause__` cleared; non-writable stream → `MH_LOG_SINK_STREAM`; non-event → `MH_LOG_SINK_EVENT`.
- Structurally satisfies the `StructuredLogSink` Protocol, so a `StructuredLogger` can deliver to it.

## Proof-first tests
- `tests/unit/test_log_sink.py` — exact-one-line bytes, sequential append, input validation, hostile
  stream-failure wrapping, and a `StructuredLogger` integration test asserting **stdout/stderr stay
  empty** (capsys).
- `tests/security/test_log_sink_boundary.py` — planted-secret (fingerprint + error message) never
  reaches the emitted bytes; **fail-closed emits nothing** when egress denies.

## Evidence
- Independent report-only `milhouse-gate-review`: **pass**, no actionable findings.
- `make quality` ✅ · `make test` (3712 passed) ✅ · `make test-coverage` (line 98.23%, **branch
  97.18%**) ✅ · docs/skill/secret ✅ · `git diff --check` clean.

## Scope fences
No file I/O / rotation / persistence (**W03**); no CLI/stderr binding or flush/buffer policy (**W06**) —
writes only to an injected stream. No gate marked passed. Next: PR-5 (G02 evidence packet +
report-only review; owner accepts G02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
