### PR TITLE
feat(state): W03 SQLite control-plane foundation (slice 1)

### DIFF
--- a/src/milhouse/state/__init__.py
+++ b/src/milhouse/state/__init__.py
@@ -5,19 +5,29 @@ from __future__ import annotations
 from milhouse.state.barrier import GlobalCommitBarrier
 from milhouse.state.database import ControlDatabase, open_control_database
 from milhouse.state.errors import StateError
-from milhouse.state.leases import Lease, acquire_lease, release_lease, renew_lease
-from milhouse.state.migrations import Migration, apply_migrations, schema_version
+from milhouse.state.leases import (
+    Lease,
+    acquire_lease,
+    release_lease,
+    renew_lease,
+    require_current_lease,
+)
+from milhouse.state.migrations import Migration, migrate, schema_version
+from milhouse.state.schema import CONTROL_MIGRATIONS, initialize_control_state
 
 __all__ = [
+    "CONTROL_MIGRATIONS",
     "ControlDatabase",
     "GlobalCommitBarrier",
     "Lease",
     "Migration",
     "StateError",
     "acquire_lease",
-    "apply_migrations",
+    "initialize_control_state",
+    "migrate",
     "open_control_database",
     "release_lease",
     "renew_lease",
+    "require_current_lease",
     "schema_version",
 ]

--- a/src/milhouse/state/__init__.py
+++ b/src/milhouse/state/__init__.py
@@ -1,0 +1,23 @@
+"""W03 control-plane state: secure SQLite database, migrations, leases, and the commit barrier."""
+
+from __future__ import annotations
+
+from milhouse.state.barrier import GlobalCommitBarrier
+from milhouse.state.database import ControlDatabase, open_control_database
+from milhouse.state.errors import StateError
+from milhouse.state.leases import Lease, acquire_lease, release_lease, renew_lease
+from milhouse.state.migrations import Migration, apply_migrations, schema_version
+
+__all__ = [
+    "ControlDatabase",
+    "GlobalCommitBarrier",
+    "Lease",
+    "Migration",
+    "StateError",
+    "acquire_lease",
+    "apply_migrations",
+    "open_control_database",
+    "release_lease",
+    "renew_lease",
+    "schema_version",
+]

--- a/src/milhouse/state/barrier.py
+++ b/src/milhouse/state/barrier.py
@@ -1,0 +1,130 @@
+"""The global commit barrier: shared for durable writers, exclusive for maintenance (W03 slice 1).
+
+Plan section 4.3 and ADR 0004 require every durable writer to hold the *shared* side of one global
+commit barrier while backup, restore, migration, and declared maintenance take the *exclusive* side.
+That is a cross-process readers-writer lock: many writers coexist, and the exclusive side waits for
+all of them to release and blocks new ones.
+
+The exclusive side is a ``filelock.FileLock`` (BSD ``flock`` ``LOCK_EX``); the shared side is
+``fcntl.flock`` ``LOCK_SH`` on the same lock file. ``filelock`` exposes only exclusive locks, so it
+cannot express the shared writer side alone, but both use BSD ``flock`` so they conflict correctly
+across processes. The barrier is advisory, POSIX-only, and fails closed without ``flock``.
+Contention on a non-blocking acquisition raises a fixed ``MH_STATE_BARRIER_BUSY``.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import NoReturn
+
+from filelock import FileLock, Timeout
+
+from milhouse.config.filesystem import lexical_absolute_path
+from milhouse.state.errors import StateError
+
+_LOCK_FILE_MODE = 0o600
+_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_CLOEXEC = getattr(os, "O_CLOEXEC", 0)
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise StateError(code, message)
+
+
+class GlobalCommitBarrier:
+    """A cross-process readers-writer commit barrier keyed by one advisory lock file."""
+
+    __slots__ = ("_path",)
+
+    def __init__(self, lock_path: str | Path) -> None:
+        if _NOFOLLOW == 0:  # pragma: no cover - Milhouse supports only no-follow POSIX hosts
+            _fail("MH_STATE_UNSUPPORTED", "the commit barrier requires no-follow file support")
+        self._path = lexical_absolute_path(lock_path)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def _ensure_lock_file(self) -> None:
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | _NOFOLLOW | _CLOEXEC
+        descriptor: int | None = None
+        failed = False
+        try:
+            descriptor = os.open(self._path, flags, _LOCK_FILE_MODE)
+        except FileExistsError:
+            failed = False
+        except OSError:
+            failed = True
+        finally:
+            if descriptor is not None:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+        if failed:
+            _fail("MH_STATE_BARRIER", "the commit barrier lock could not be created")
+
+    @contextmanager
+    def shared(self, *, blocking: bool = True) -> Iterator[None]:
+        """Hold the shared writer side; concurrent shared holders coexist."""
+
+        self._ensure_lock_file()
+        descriptor: int | None = None
+        acquired = False
+        try:
+            try:
+                descriptor = os.open(self._path, os.O_RDWR | _NOFOLLOW | _CLOEXEC)
+            except OSError:
+                descriptor = None
+            if descriptor is None:
+                _fail("MH_STATE_BARRIER", "the commit barrier lock could not be opened")
+            mode = fcntl.LOCK_SH if blocking else fcntl.LOCK_SH | fcntl.LOCK_NB
+            try:
+                fcntl.flock(descriptor, mode)
+                acquired = True
+            except OSError:
+                acquired = False
+            if not acquired:
+                _fail("MH_STATE_BARRIER_BUSY", "the shared commit barrier is exclusively held")
+            yield
+        finally:
+            if descriptor is not None:
+                if acquired:
+                    try:
+                        fcntl.flock(descriptor, fcntl.LOCK_UN)
+                    except OSError:
+                        pass
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+
+    @contextmanager
+    def exclusive(self, *, blocking: bool = True) -> Iterator[None]:
+        """Hold the exclusive maintenance side; blocks until every shared holder releases."""
+
+        self._ensure_lock_file()
+        lock = FileLock(str(self._path))
+        timed_out = False
+        os_failed = False
+        try:
+            lock.acquire(blocking=blocking)
+        except Timeout:
+            timed_out = True
+        except OSError:
+            os_failed = True
+        if os_failed:
+            _fail("MH_STATE_BARRIER", "the exclusive commit barrier could not be acquired")
+        if timed_out:
+            _fail("MH_STATE_BARRIER_BUSY", "the exclusive commit barrier is held")
+        try:
+            yield
+        finally:
+            try:
+                lock.release()
+            except (OSError, RuntimeError):
+                pass

--- a/src/milhouse/state/barrier.py
+++ b/src/milhouse/state/barrier.py
@@ -2,129 +2,197 @@
 
 Plan section 4.3 and ADR 0004 require every durable writer to hold the *shared* side of one global
 commit barrier while backup, restore, migration, and declared maintenance take the *exclusive* side.
-That is a cross-process readers-writer lock: many writers coexist, and the exclusive side waits for
-all of them to release and blocks new ones.
+That is a cross-process readers-writer lock with writer preference: many writers coexist, and once a
+maintainer is queued, new writers wait behind it while existing writers drain.
 
-The exclusive side is a ``filelock.FileLock`` (BSD ``flock`` ``LOCK_EX``); the shared side is
-``fcntl.flock`` ``LOCK_SH`` on the same lock file. ``filelock`` exposes only exclusive locks, so it
-cannot express the shared writer side alone, but both use BSD ``flock`` so they conflict correctly
-across processes. The barrier is advisory, POSIX-only, and fails closed without ``flock``.
-Contention on a non-blocking acquisition raises a fixed ``MH_STATE_BARRIER_BUSY``.
+Both sides use ``fcntl.flock`` on a securely opened, read-only, no-follow descriptor validated as an
+owner-only, single-link, regular file (reusing the W02 secure-open machinery). It is never reopened
+for writing or truncated, so a stale, accidental, or hostile same-user hard link, symlink, or
+loose-mode file can never turn acquisition into control-state destruction; unsafe files fail closed.
+Writer preference is a two-file turnstile: a shared holder briefly takes the gate shared, takes the
+main lock shared, then releases the gate; an exclusive holder holds the gate exclusive for its whole
+duration, so later shared entrants block at the gate. The barrier is advisory, POSIX-only, and fails
+closed without ``flock``; contention on a non-blocking acquisition raises ``MH_STATE_BARRIER_BUSY``.
 """
 
 from __future__ import annotations
 
 import fcntl
 import os
+import stat
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import NoReturn
 
-from filelock import FileLock, Timeout
-
-from milhouse.config.filesystem import lexical_absolute_path
+from milhouse.config.filesystem import (
+    SecureFileError,
+    SecureFileErrorKind,
+    create_regular_file_no_follow,
+    lexical_absolute_path,
+    open_regular_file_no_follow,
+)
 from milhouse.state.errors import StateError
 
-_LOCK_FILE_MODE = 0o600
+_LOCK_MODE = 0o600
+_LOCK_SEED = b"milhouse-commit-barrier\n"
+_GATE_SUFFIX = ".gate"
 _NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
-_CLOEXEC = getattr(os, "O_CLOEXEC", 0)
 
 
 def _fail(code: str, message: str) -> NoReturn:
     raise StateError(code, message)
 
 
-class GlobalCommitBarrier:
-    """A cross-process readers-writer commit barrier keyed by one advisory lock file."""
+def _current_uid() -> int:
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:  # pragma: no cover - Milhouse supports only POSIX hosts
+        _fail("MH_STATE_UNSUPPORTED", "the commit barrier requires a POSIX ownership model")
+    return int(getuid())
 
-    __slots__ = ("_path",)
+
+def _create_lock_if_absent(path: Path) -> None:
+    other_failure = False
+    try:
+        create_regular_file_no_follow(
+            path, _LOCK_SEED, mode=_LOCK_MODE, require_private_parent=True
+        )
+    except SecureFileError as error:
+        if error.kind is not SecureFileErrorKind.ALREADY_EXISTS:
+            other_failure = True
+    if other_failure:
+        _fail("MH_STATE_BARRIER", "the commit barrier lock could not be created")
+
+
+def _secure_lock_descriptor(path: Path) -> int:
+    """Open the validated owner-only single-link lock file read-only, creating it if absent."""
+
+    created = False
+    while True:
+        descriptor: int | None = None
+        not_found = False
+        open_failed = False
+        try:
+            descriptor = open_regular_file_no_follow(path, require_private_parent=True).descriptor
+        except SecureFileError as error:
+            not_found = error.kind is SecureFileErrorKind.NOT_FOUND
+            open_failed = not not_found
+        if open_failed:
+            _fail("MH_STATE_BARRIER", "the commit barrier lock could not be securely opened")
+        if not_found:
+            if created:
+                _fail("MH_STATE_BARRIER", "the commit barrier lock could not be securely opened")
+            _create_lock_if_absent(path)
+            created = True
+            continue
+        metadata = os.fstat(descriptor)  # type: ignore[arg-type]
+        if (
+            metadata.st_nlink != 1
+            or stat.S_IMODE(metadata.st_mode) != _LOCK_MODE
+            or metadata.st_uid != _current_uid()
+        ):
+            try:
+                os.close(descriptor)  # type: ignore[arg-type]
+            except OSError:
+                pass
+            _fail(
+                "MH_STATE_BARRIER_UNSAFE",
+                "the commit barrier lock must be an owner-only single-link regular file",
+            )
+        return descriptor  # type: ignore[return-value]
+
+
+def _acquire(descriptor: int, operation: int, *, blocking: bool) -> None:
+    mode = operation if blocking else operation | fcntl.LOCK_NB
+    busy = False
+    errored = False
+    try:
+        fcntl.flock(descriptor, mode)
+    except BlockingIOError:
+        busy = True
+    except OSError:
+        errored = True
+    if errored:
+        _fail("MH_STATE_BARRIER", "the commit barrier could not be acquired")
+    if busy:
+        _fail("MH_STATE_BARRIER_BUSY", "the commit barrier is held")
+
+
+def _release(descriptor: int) -> None:
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+    except OSError:  # pragma: no cover - defensive: releasing our own flock does not fail
+        pass
+
+
+def _close(descriptor: int) -> None:
+    try:
+        os.close(descriptor)
+    except OSError:  # pragma: no cover - defensive: closing our own descriptor does not fail
+        pass
+
+
+class GlobalCommitBarrier:
+    """A cross-process, writer-preferring readers-writer commit barrier over one lock file pair."""
+
+    __slots__ = ("_gate_path", "_path")
 
     def __init__(self, lock_path: str | Path) -> None:
         if _NOFOLLOW == 0:  # pragma: no cover - Milhouse supports only no-follow POSIX hosts
             _fail("MH_STATE_UNSUPPORTED", "the commit barrier requires no-follow file support")
         self._path = lexical_absolute_path(lock_path)
+        self._gate_path = self._path.with_name(self._path.name + _GATE_SUFFIX)
 
     @property
     def path(self) -> Path:
         return self._path
 
-    def _ensure_lock_file(self) -> None:
-        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY | _NOFOLLOW | _CLOEXEC
-        descriptor: int | None = None
-        failed = False
-        try:
-            descriptor = os.open(self._path, flags, _LOCK_FILE_MODE)
-        except FileExistsError:
-            failed = False
-        except OSError:
-            failed = True
-        finally:
-            if descriptor is not None:
-                try:
-                    os.close(descriptor)
-                except OSError:
-                    pass
-        if failed:
-            _fail("MH_STATE_BARRIER", "the commit barrier lock could not be created")
-
     @contextmanager
     def shared(self, *, blocking: bool = True) -> Iterator[None]:
-        """Hold the shared writer side; concurrent shared holders coexist."""
+        """Hold the shared writer side; shared holders coexist under writer preference."""
 
-        self._ensure_lock_file()
-        descriptor: int | None = None
-        acquired = False
+        main_fd = _secure_lock_descriptor(self._path)
+        gate_fd: int | None = None
+        gate_held = False
+        main_held = False
         try:
-            try:
-                descriptor = os.open(self._path, os.O_RDWR | _NOFOLLOW | _CLOEXEC)
-            except OSError:
-                descriptor = None
-            if descriptor is None:
-                _fail("MH_STATE_BARRIER", "the commit barrier lock could not be opened")
-            mode = fcntl.LOCK_SH if blocking else fcntl.LOCK_SH | fcntl.LOCK_NB
-            try:
-                fcntl.flock(descriptor, mode)
-                acquired = True
-            except OSError:
-                acquired = False
-            if not acquired:
-                _fail("MH_STATE_BARRIER_BUSY", "the shared commit barrier is exclusively held")
+            gate_fd = _secure_lock_descriptor(self._gate_path)
+            _acquire(gate_fd, fcntl.LOCK_SH, blocking=blocking)
+            gate_held = True
+            _acquire(main_fd, fcntl.LOCK_SH, blocking=blocking)
+            main_held = True
+            _release(gate_fd)
+            gate_held = False
             yield
         finally:
-            if descriptor is not None:
-                if acquired:
-                    try:
-                        fcntl.flock(descriptor, fcntl.LOCK_UN)
-                    except OSError:
-                        pass
-                try:
-                    os.close(descriptor)
-                except OSError:
-                    pass
+            if gate_held and gate_fd is not None:
+                _release(gate_fd)
+            if main_held:
+                _release(main_fd)
+            if gate_fd is not None:
+                _close(gate_fd)
+            _close(main_fd)
 
     @contextmanager
     def exclusive(self, *, blocking: bool = True) -> Iterator[None]:
-        """Hold the exclusive maintenance side; blocks until every shared holder releases."""
+        """Hold the exclusive side; block new shared entrants and drain existing ones."""
 
-        self._ensure_lock_file()
-        lock = FileLock(str(self._path))
-        timed_out = False
-        os_failed = False
+        main_fd = _secure_lock_descriptor(self._path)
+        gate_fd: int | None = None
+        gate_held = False
+        main_held = False
         try:
-            lock.acquire(blocking=blocking)
-        except Timeout:
-            timed_out = True
-        except OSError:
-            os_failed = True
-        if os_failed:
-            _fail("MH_STATE_BARRIER", "the exclusive commit barrier could not be acquired")
-        if timed_out:
-            _fail("MH_STATE_BARRIER_BUSY", "the exclusive commit barrier is held")
-        try:
+            gate_fd = _secure_lock_descriptor(self._gate_path)
+            _acquire(gate_fd, fcntl.LOCK_EX, blocking=blocking)
+            gate_held = True
+            _acquire(main_fd, fcntl.LOCK_EX, blocking=blocking)
+            main_held = True
             yield
         finally:
-            try:
-                lock.release()
-            except (OSError, RuntimeError):
-                pass
+            if main_held:
+                _release(main_fd)
+            if gate_held and gate_fd is not None:
+                _release(gate_fd)
+            if gate_fd is not None:
+                _close(gate_fd)
+            _close(main_fd)

--- a/src/milhouse/state/database.py
+++ b/src/milhouse/state/database.py
@@ -1,0 +1,223 @@
+"""Secure SQLite control-plane database open, pragmas, and transaction boundary (W03 slice 1).
+
+The control database is the transactional control plane of ADR 0004 and plan section 4.4: it holds
+ledgers, cursors, leases, projections, idempotency, migrations, and audit metadata, never raw
+payloads. This module owns only the secure open and the transaction boundary; migrations,
+leases, and
+the global commit barrier live in sibling modules.
+
+The database file is created ``0600`` with ``O_EXCL``/``O_NOFOLLOW`` inside an already-secured
+private
+parent directory, opened in write-ahead-logging mode with ``FULL`` synchronous durability and
+enforced
+foreign keys, and validated to be a non-symlink regular file with no group or world access. Every
+failure raises a fixed :class:`StateError` outside the handler, so no SQLite or filesystem detail
+leaks.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import NoReturn
+
+from milhouse.config.filesystem import lexical_absolute_path
+from milhouse.state.errors import StateError
+
+_FILE_MODE = 0o600
+_FORBIDDEN_MODE_BITS = 0o077
+_BUSY_TIMEOUT_MS = 5_000
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise StateError(code, message)
+
+
+def _current_uid() -> int:
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:  # pragma: no cover - Milhouse supports only POSIX hosts
+        _fail("MH_STATE_UNSUPPORTED", "control state requires a POSIX ownership model")
+    return int(getuid())
+
+
+def _require_private_parent(parent: Path) -> None:
+    info: os.stat_result | None
+    try:
+        info = os.lstat(parent)
+    except OSError:
+        info = None
+    if (
+        info is None
+        or stat.S_ISLNK(info.st_mode)
+        or not stat.S_ISDIR(info.st_mode)
+        or info.st_uid != _current_uid()
+        or (stat.S_IMODE(info.st_mode) & _FORBIDDEN_MODE_BITS)
+    ):
+        _fail("MH_STATE_DIR", "the control directory must be an owned private directory")
+
+
+def _create_owner_only_file(path: Path) -> None:
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    descriptor: int | None = None
+    failed = False
+    try:
+        descriptor = os.open(path, flags, _FILE_MODE)
+        os.fchmod(descriptor, _FILE_MODE)
+    except OSError:
+        failed = True
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+    if failed:
+        _fail("MH_STATE_FILE", "the control database file could not be created owner-only")
+
+
+def _ensure_secure_db_file(path: Path) -> bool:
+    """Create the DB file owner-only if absent, else validate it; return whether it was created."""
+
+    info: os.stat_result | None
+    examine_failed = False
+    try:
+        info = os.lstat(path)
+    except FileNotFoundError:
+        info = None
+    except OSError:
+        info = None
+        examine_failed = True
+    if examine_failed:
+        _fail("MH_STATE_FILE", "the control database path could not be examined")
+    if info is None:
+        _create_owner_only_file(path)
+        return True
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        _fail("MH_STATE_FILE", "the control database must be a regular non-symlink file")
+    if info.st_uid != _current_uid() or (stat.S_IMODE(info.st_mode) & _FORBIDDEN_MODE_BITS):
+        _fail("MH_STATE_FILE", "the control database must be owner-only")
+    return False
+
+
+def _connect_wal(path: Path) -> sqlite3.Connection:
+    connection: sqlite3.Connection | None = None
+    journal_mode: object = None
+    failed = False
+    try:
+        connection = sqlite3.connect(str(path), isolation_level=None, check_same_thread=True)
+        connection.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+        row = connection.execute("PRAGMA journal_mode = WAL").fetchone()
+        journal_mode = None if row is None else row[0]
+        connection.execute("PRAGMA synchronous = FULL")
+        connection.execute("PRAGMA foreign_keys = ON")
+    except sqlite3.Error:
+        failed = True
+    if failed:
+        if connection is not None:
+            try:
+                connection.close()
+            except sqlite3.Error:
+                pass
+        _fail(
+            "MH_STATE_OPEN", "the control database could not be opened in write-ahead-logging mode"
+        )
+    if type(journal_mode) is not str or journal_mode.lower() != "wal":
+        connection.close()  # type: ignore[union-attr]
+        _fail("MH_STATE_OPEN", "the control database must use write-ahead logging")
+    return connection  # type: ignore[return-value]
+
+
+class ControlDatabase:
+    """A secured, WAL-mode SQLite control-plane connection with an explicit transaction boundary."""
+
+    __slots__ = ("_closed", "_connection", "_created", "_path")
+
+    def __init__(self, *, connection: sqlite3.Connection, path: Path, created: bool) -> None:
+        self._connection = connection
+        self._path = path
+        self._created = created
+        self._closed = False
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def created(self) -> bool:
+        """True when this open created the database file, False when it reopened an existing one."""
+
+        return self._created
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        if self._closed:
+            _fail("MH_STATE_CLOSED", "the control database is closed")
+        return self._connection
+
+    @contextmanager
+    def transaction(self) -> Iterator[sqlite3.Connection]:
+        """Run one ``BEGIN IMMEDIATE`` transaction: commit on success, roll back on error.
+
+        A caller exception rolls back and propagates unchanged. A SQLite begin/commit failure rolls
+        back and raises a fixed ``MH_STATE_TXN`` outside the handler, never leaking SQLite detail.
+        """
+
+        connection = self.connection
+        began = False
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            began = True
+        except sqlite3.Error:
+            began = False
+        if not began:
+            _fail("MH_STATE_TXN", "the control transaction could not begin")
+        try:
+            yield connection
+        except BaseException:
+            try:
+                connection.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            raise
+        committed = False
+        try:
+            connection.execute("COMMIT")
+            committed = True
+        except sqlite3.Error:
+            committed = False
+        if not committed:
+            try:
+                connection.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            _fail("MH_STATE_TXN", "the control transaction could not commit")
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._connection.close()
+        except sqlite3.Error:
+            pass
+
+
+def open_control_database(path: str | Path) -> ControlDatabase:
+    """Open (creating if absent) the SQLite control database under an already-secured private dir.
+
+    The parent directory must already exist as an owned ``0700`` directory; the database file is
+    created ``0600`` with ``O_EXCL``/``O_NOFOLLOW`` and opened in WAL mode with ``FULL`` synchronous
+    and enforced foreign keys. Any failure raises a fixed :class:`StateError` outside the handler.
+    """
+
+    resolved = lexical_absolute_path(path)
+    _require_private_parent(resolved.parent)
+    created = _ensure_secure_db_file(resolved)
+    connection = _connect_wal(resolved)
+    return ControlDatabase(connection=connection, path=resolved, created=created)

--- a/src/milhouse/state/errors.py
+++ b/src/milhouse/state/errors.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from milhouse.core.errors import MilhouseValueError
+
+
+class StateError(MilhouseValueError):
+    """A fixed, privacy-safe control-state failure carrying only a stable code and static message.
+
+    Every control-state failure is raised outside any active exception handler, so no SQLite,
+    filesystem, or caller detail reaches the error's cause, context, args, or traceback. The stable
+    ``MH_STATE_*`` codes are the only machine surface; the messages are static developer text.
+    """

--- a/src/milhouse/state/leases.py
+++ b/src/milhouse/state/leases.py
@@ -1,0 +1,144 @@
+"""SQLite named leases for multi-process coordination (W03 slice 1).
+
+A lease is a named, holder-owned, time-bounded claim in the control database (plan section 4.4:
+"collector leases, next-run times, and latest outcomes"). Acquire, renew, and release run in one
+``BEGIN IMMEDIATE`` transaction, so SQLite serializes contenders and one holder wins. Expiry is
+compared on the canonical RFC3339 millisecond string, lexically ordered in UTC, so no parsing is
+needed. Time is injected as an aware UTC instant; leases never read the wall clock themselves.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import NoReturn
+
+from milhouse.core.clock import format_timestamp
+from milhouse.state.database import ControlDatabase
+from milhouse.state.errors import StateError
+
+_LEASES_TABLE = "_leases"
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise StateError(code, message)
+
+
+@dataclass(frozen=True, slots=True)
+class Lease:
+    """An owned, time-bounded lease as recorded in the control database."""
+
+    name: str
+    holder: str
+    acquired_at: str
+    expires_at: str
+
+
+def _validate_identifier(value: object, code: str, subject: str) -> str:
+    if type(value) is not str or not value or len(value) > 256:
+        _fail(code, f"a lease {subject} must be bounded non-empty text")
+    return value
+
+
+def _stamps(now: datetime, ttl_seconds: int) -> tuple[str, str]:
+    if type(ttl_seconds) is not int or ttl_seconds <= 0:
+        _fail("MH_STATE_LEASE_TTL", "a lease requires a positive whole-second lifetime")
+    acquired = format_timestamp(now)
+    expires = format_timestamp(now + timedelta(seconds=ttl_seconds))
+    return acquired, expires
+
+
+def _ensure_table(database: ControlDatabase) -> None:
+    with database.transaction() as connection:
+        connection.execute(
+            f"CREATE TABLE IF NOT EXISTS {_LEASES_TABLE} ("
+            "name TEXT PRIMARY KEY NOT NULL, "
+            "holder TEXT NOT NULL, "
+            "acquired_at TEXT NOT NULL, "
+            "expires_at TEXT NOT NULL)"
+        )
+
+
+def _current(connection: sqlite3.Connection, name: str) -> tuple[str, str, str] | None:
+    row = connection.execute(
+        f"SELECT holder, acquired_at, expires_at FROM {_LEASES_TABLE} WHERE name = ?", (name,)
+    ).fetchone()
+    if row is None:
+        return None
+    return str(row[0]), str(row[1]), str(row[2])
+
+
+def acquire_lease(
+    database: ControlDatabase,
+    name: str,
+    holder: str,
+    *,
+    now: datetime,
+    ttl_seconds: int,
+) -> Lease:
+    """Acquire or take over ``name`` for ``holder``; fail closed if another holder's lease is live.
+
+    Re-acquiring one's own lease renews it. Taking over is allowed only once the recorded lease has
+    expired (``expires_at <= now``).
+    """
+
+    _validate_identifier(name, "MH_STATE_LEASE_NAME", "name")
+    _validate_identifier(holder, "MH_STATE_LEASE_HOLDER", "holder")
+    acquired, expires = _stamps(now, ttl_seconds)
+    now_stamp = format_timestamp(now)
+    _ensure_table(database)
+    with database.transaction() as connection:
+        existing = _current(connection, name)
+        if existing is not None:
+            existing_holder, _existing_acquired, existing_expires = existing
+            if existing_holder != holder and existing_expires > now_stamp:
+                _fail("MH_STATE_LEASE_HELD", "the lease is held by a different live holder")
+        connection.execute(
+            f"INSERT INTO {_LEASES_TABLE} (name, holder, acquired_at, expires_at) "
+            "VALUES (?, ?, ?, ?) "
+            "ON CONFLICT(name) DO UPDATE SET holder = excluded.holder, "
+            "acquired_at = excluded.acquired_at, expires_at = excluded.expires_at",
+            (name, holder, acquired, expires),
+        )
+    return Lease(name=name, holder=holder, acquired_at=acquired, expires_at=expires)
+
+
+def renew_lease(
+    database: ControlDatabase,
+    name: str,
+    holder: str,
+    *,
+    now: datetime,
+    ttl_seconds: int,
+) -> Lease:
+    """Extend a lease ``holder`` still holds and that has not expired; fail closed otherwise."""
+
+    _validate_identifier(name, "MH_STATE_LEASE_NAME", "name")
+    _validate_identifier(holder, "MH_STATE_LEASE_HOLDER", "holder")
+    acquired, expires = _stamps(now, ttl_seconds)
+    now_stamp = format_timestamp(now)
+    _ensure_table(database)
+    with database.transaction() as connection:
+        existing = _current(connection, name)
+        if existing is None or existing[0] != holder or existing[2] <= now_stamp:
+            _fail("MH_STATE_LEASE_LOST", "the lease is not held by this holder or has expired")
+        connection.execute(
+            f"UPDATE {_LEASES_TABLE} SET acquired_at = ?, expires_at = ? WHERE name = ?",
+            (acquired, expires, name),
+        )
+    return Lease(name=name, holder=holder, acquired_at=acquired, expires_at=expires)
+
+
+def release_lease(database: ControlDatabase, name: str, holder: str) -> bool:
+    """Release a lease held by ``holder``. Returns True if a matching lease was removed."""
+
+    _validate_identifier(name, "MH_STATE_LEASE_NAME", "name")
+    _validate_identifier(holder, "MH_STATE_LEASE_HOLDER", "holder")
+    _ensure_table(database)
+    with database.transaction() as connection:
+        cursor = connection.execute(
+            f"DELETE FROM {_LEASES_TABLE} WHERE name = ? AND holder = ?", (name, holder)
+        )
+        removed = cursor.rowcount
+    return removed > 0

--- a/src/milhouse/state/leases.py
+++ b/src/milhouse/state/leases.py
@@ -1,10 +1,14 @@
-"""SQLite named leases for multi-process coordination (W03 slice 1).
+"""SQLite named leases with fencing for multi-process coordination (W03 slice 1).
 
-A lease is a named, holder-owned, time-bounded claim in the control database (plan section 4.4:
-"collector leases, next-run times, and latest outcomes"). Acquire, renew, and release run in one
-``BEGIN IMMEDIATE`` transaction, so SQLite serializes contenders and one holder wins. Expiry is
-compared on the canonical RFC3339 millisecond string, lexically ordered in UTC, so no parsing is
-needed. Time is injected as an aware UTC instant; leases never read the wall clock themselves.
+A lease is a named, holder-owned, time-bounded claim in the ``_leases`` control table (created by
+the package migration, never by lease code) with a monotonic ``fence`` token. The token increments
+on each ownership change and stays stable across renewals, so a stale holder cannot resume work
+after takeover: a lease-protected mutation validates name, holder, and fence in the same
+transaction via ``require_current_lease``. Acquire, renew, and release each run in one
+``BEGIN IMMEDIATE`` transaction, so SQLite serializes contenders and one holder wins. Expiry
+compares the canonical RFC3339 millisecond string, which is lexically ordered in UTC. Time is
+injected as an aware UTC instant. Every SQLite or time failure is normalized to a fixed
+``MH_STATE_*`` error raised outside the handler; the TTL is bounded before any arithmetic.
 """
 
 from __future__ import annotations
@@ -14,11 +18,12 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import NoReturn
 
-from milhouse.core.clock import format_timestamp
+from milhouse.core.clock import TimeError, format_timestamp
 from milhouse.state.database import ControlDatabase
 from milhouse.state.errors import StateError
 
 _LEASES_TABLE = "_leases"
+_MAX_TTL_SECONDS = 3650 * 86_400  # ten years; bounds the deadline arithmetic
 
 
 def _fail(code: str, message: str) -> NoReturn:
@@ -27,10 +32,11 @@ def _fail(code: str, message: str) -> NoReturn:
 
 @dataclass(frozen=True, slots=True)
 class Lease:
-    """An owned, time-bounded lease as recorded in the control database."""
+    """An owned, fenced, time-bounded lease as recorded in the control database."""
 
     name: str
     holder: str
+    fence: int
     acquired_at: str
     expires_at: str
 
@@ -41,32 +47,25 @@ def _validate_identifier(value: object, code: str, subject: str) -> str:
     return value
 
 
+def _validate_ttl(ttl_seconds: object) -> int:
+    if type(ttl_seconds) is not int or not 0 < ttl_seconds <= _MAX_TTL_SECONDS:
+        _fail("MH_STATE_LEASE_TTL", "a lease requires a positive bounded whole-second lifetime")
+    return ttl_seconds
+
+
 def _stamps(now: datetime, ttl_seconds: int) -> tuple[str, str]:
-    if type(ttl_seconds) is not int or ttl_seconds <= 0:
-        _fail("MH_STATE_LEASE_TTL", "a lease requires a positive whole-second lifetime")
     acquired = format_timestamp(now)
     expires = format_timestamp(now + timedelta(seconds=ttl_seconds))
     return acquired, expires
 
 
-def _ensure_table(database: ControlDatabase) -> None:
-    with database.transaction() as connection:
-        connection.execute(
-            f"CREATE TABLE IF NOT EXISTS {_LEASES_TABLE} ("
-            "name TEXT PRIMARY KEY NOT NULL, "
-            "holder TEXT NOT NULL, "
-            "acquired_at TEXT NOT NULL, "
-            "expires_at TEXT NOT NULL)"
-        )
-
-
-def _current(connection: sqlite3.Connection, name: str) -> tuple[str, str, str] | None:
+def _current(connection: sqlite3.Connection, name: str) -> tuple[str, int, str] | None:
     row = connection.execute(
-        f"SELECT holder, acquired_at, expires_at FROM {_LEASES_TABLE} WHERE name = ?", (name,)
+        f"SELECT holder, fence, expires_at FROM {_LEASES_TABLE} WHERE name = ?", (name,)
     ).fetchone()
     if row is None:
         return None
-    return str(row[0]), str(row[1]), str(row[2])
+    return str(row[0]), int(row[1]), str(row[2])
 
 
 def acquire_lease(
@@ -79,29 +78,44 @@ def acquire_lease(
 ) -> Lease:
     """Acquire or take over ``name`` for ``holder``; fail closed if another holder's lease is live.
 
-    Re-acquiring one's own lease renews it. Taking over is allowed only once the recorded lease has
-    expired (``expires_at <= now``).
+    Re-acquiring one's own lease renews it and keeps the fence; taking over an expired lease
+    increments
+    the fence.
     """
 
     _validate_identifier(name, "MH_STATE_LEASE_NAME", "name")
     _validate_identifier(holder, "MH_STATE_LEASE_HOLDER", "holder")
-    acquired, expires = _stamps(now, ttl_seconds)
-    now_stamp = format_timestamp(now)
-    _ensure_table(database)
-    with database.transaction() as connection:
-        existing = _current(connection, name)
-        if existing is not None:
-            existing_holder, _existing_acquired, existing_expires = existing
-            if existing_holder != holder and existing_expires > now_stamp:
-                _fail("MH_STATE_LEASE_HELD", "the lease is held by a different live holder")
-        connection.execute(
-            f"INSERT INTO {_LEASES_TABLE} (name, holder, acquired_at, expires_at) "
-            "VALUES (?, ?, ?, ?) "
-            "ON CONFLICT(name) DO UPDATE SET holder = excluded.holder, "
-            "acquired_at = excluded.acquired_at, expires_at = excluded.expires_at",
-            (name, holder, acquired, expires),
+    _validate_ttl(ttl_seconds)
+    lease: Lease | None = None
+    failed = False
+    try:
+        acquired, expires = _stamps(now, ttl_seconds)
+        now_stamp = format_timestamp(now)
+        with database.transaction() as connection:
+            existing = _current(connection, name)
+            if existing is not None:
+                existing_holder, existing_fence, existing_expires = existing
+                if existing_holder != holder and existing_expires > now_stamp:
+                    _fail("MH_STATE_LEASE_HELD", "the lease is held by a different live holder")
+                fence = existing_fence if existing_holder == holder else existing_fence + 1
+            else:
+                fence = 1
+            connection.execute(
+                f"INSERT INTO {_LEASES_TABLE} (name, holder, fence, acquired_at, expires_at) "
+                "VALUES (?, ?, ?, ?, ?) "
+                "ON CONFLICT(name) DO UPDATE SET holder = excluded.holder, fence = excluded.fence, "
+                "acquired_at = excluded.acquired_at, expires_at = excluded.expires_at",
+                (name, holder, fence, acquired, expires),
+            )
+        lease = Lease(
+            name=name, holder=holder, fence=fence, acquired_at=acquired, expires_at=expires
         )
-    return Lease(name=name, holder=holder, acquired_at=acquired, expires_at=expires)
+    except (sqlite3.Error, OverflowError, TimeError):
+        failed = True
+    if failed:
+        _fail("MH_STATE_LEASE", "the lease could not be acquired")
+    assert lease is not None
+    return lease
 
 
 def renew_lease(
@@ -112,22 +126,35 @@ def renew_lease(
     now: datetime,
     ttl_seconds: int,
 ) -> Lease:
-    """Extend a lease ``holder`` still holds and that has not expired; fail closed otherwise."""
+    """Extend a lease ``holder`` still holds and that has not expired; keep the fence, fail
+    otherwise."""
 
     _validate_identifier(name, "MH_STATE_LEASE_NAME", "name")
     _validate_identifier(holder, "MH_STATE_LEASE_HOLDER", "holder")
-    acquired, expires = _stamps(now, ttl_seconds)
-    now_stamp = format_timestamp(now)
-    _ensure_table(database)
-    with database.transaction() as connection:
-        existing = _current(connection, name)
-        if existing is None or existing[0] != holder or existing[2] <= now_stamp:
-            _fail("MH_STATE_LEASE_LOST", "the lease is not held by this holder or has expired")
-        connection.execute(
-            f"UPDATE {_LEASES_TABLE} SET acquired_at = ?, expires_at = ? WHERE name = ?",
-            (acquired, expires, name),
+    _validate_ttl(ttl_seconds)
+    lease: Lease | None = None
+    failed = False
+    try:
+        acquired, expires = _stamps(now, ttl_seconds)
+        now_stamp = format_timestamp(now)
+        with database.transaction() as connection:
+            existing = _current(connection, name)
+            if existing is None or existing[0] != holder or existing[2] <= now_stamp:
+                _fail("MH_STATE_LEASE_LOST", "the lease is not held by this holder or has expired")
+            fence = existing[1]
+            connection.execute(
+                f"UPDATE {_LEASES_TABLE} SET acquired_at = ?, expires_at = ? WHERE name = ?",
+                (acquired, expires, name),
+            )
+        lease = Lease(
+            name=name, holder=holder, fence=fence, acquired_at=acquired, expires_at=expires
         )
-    return Lease(name=name, holder=holder, acquired_at=acquired, expires_at=expires)
+    except (sqlite3.Error, OverflowError, TimeError):
+        failed = True
+    if failed:
+        _fail("MH_STATE_LEASE", "the lease could not be renewed")
+    assert lease is not None
+    return lease
 
 
 def release_lease(database: ControlDatabase, name: str, holder: str) -> bool:
@@ -135,10 +162,39 @@ def release_lease(database: ControlDatabase, name: str, holder: str) -> bool:
 
     _validate_identifier(name, "MH_STATE_LEASE_NAME", "name")
     _validate_identifier(holder, "MH_STATE_LEASE_HOLDER", "holder")
-    _ensure_table(database)
-    with database.transaction() as connection:
-        cursor = connection.execute(
-            f"DELETE FROM {_LEASES_TABLE} WHERE name = ? AND holder = ?", (name, holder)
-        )
-        removed = cursor.rowcount
+    removed = 0
+    failed = False
+    try:
+        with database.transaction() as connection:
+            cursor = connection.execute(
+                f"DELETE FROM {_LEASES_TABLE} WHERE name = ? AND holder = ?", (name, holder)
+            )
+            removed = cursor.rowcount
+    except sqlite3.Error:
+        failed = True
+    if failed:
+        _fail("MH_STATE_LEASE", "the lease could not be released")
     return removed > 0
+
+
+def require_current_lease(connection: sqlite3.Connection, lease: Lease) -> None:
+    """Assert, inside the caller's transaction, that ``lease`` is still the current fenced owner.
+
+    Call this in the same transaction as a lease-protected mutation so a stale holder whose lease
+    was
+    taken over cannot commit. Fails closed with ``MH_STATE_LEASE_LOST`` on any mismatch.
+    """
+
+    stale = False
+    failed = False
+    try:
+        row = connection.execute(
+            f"SELECT holder, fence FROM {_LEASES_TABLE} WHERE name = ?", (lease.name,)
+        ).fetchone()
+        stale = row is None or str(row[0]) != lease.holder or int(row[1]) != lease.fence
+    except sqlite3.Error:
+        failed = True
+    if failed:
+        _fail("MH_STATE_LEASE", "the lease could not be validated")
+    if stale:
+        _fail("MH_STATE_LEASE_LOST", "the lease is no longer held by this holder")

--- a/src/milhouse/state/migrations.py
+++ b/src/milhouse/state/migrations.py
@@ -1,0 +1,146 @@
+"""Ordered, checksum-enforced, transactional control-plane migrations (W03 slice 1).
+
+Each migration carries a version, a name, and a tuple of single SQL statements. Migrations apply
+strictly in contiguous order from version 1; each applies together with its ledger row in one
+``BEGIN IMMEDIATE`` transaction, so a crash mid-migration leaves schema and ledger consistent. An
+already-applied migration whose checksum or name later differs, or a ledger that is not a contiguous
+prefix of the definitions, is corruption and fails closed with a fixed ``MH_STATE_MIGRATION`` error.
+Statements are single statements, not a script: SQLite's ``executescript`` implicitly commits, which
+would break the atomic schema-plus-ledger boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from typing import NoReturn
+
+from milhouse.core.clock import format_timestamp
+from milhouse.state.database import ControlDatabase
+from milhouse.state.errors import StateError
+
+_SCHEMA_TABLE = "_schema_migrations"
+
+
+def _fail(message: str) -> NoReturn:
+    raise StateError("MH_STATE_MIGRATION", message)
+
+
+@dataclass(frozen=True, slots=True)
+class Migration:
+    """One ordered control-plane migration: a version, a name, and single SQL statements."""
+
+    version: int
+    name: str
+    statements: tuple[str, ...]
+
+
+def _checksum(migration: Migration) -> str:
+    payload = "\n".join((str(migration.version), migration.name, *migration.statements))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _validate_definitions(migrations: tuple[Migration, ...]) -> None:
+    for index, migration in enumerate(migrations):
+        expected_version = index + 1
+        if type(migration) is not Migration or migration.version != expected_version:
+            _fail("migrations must be contiguous positive versions starting at 1")
+        if type(migration.name) is not str or not migration.name:
+            _fail("each migration requires a non-empty name")
+        if type(migration.statements) is not tuple or not migration.statements:
+            _fail("each migration requires at least one statement")
+        for statement in migration.statements:
+            if type(statement) is not str or not statement.strip():
+                _fail("each migration statement must be non-empty text")
+
+
+def _ensure_schema_table(database: ControlDatabase) -> None:
+    with database.transaction() as connection:
+        connection.execute(
+            f"CREATE TABLE IF NOT EXISTS {_SCHEMA_TABLE} ("
+            "version INTEGER PRIMARY KEY NOT NULL, "
+            "name TEXT NOT NULL, "
+            "checksum TEXT NOT NULL, "
+            "applied_at TEXT NOT NULL)"
+        )
+
+
+def _load_applied(connection: sqlite3.Connection) -> dict[int, tuple[str, str]]:
+    rows = connection.execute(
+        f"SELECT version, name, checksum FROM {_SCHEMA_TABLE} ORDER BY version"
+    ).fetchall()
+    return {int(version): (str(name), str(checksum)) for version, name, checksum in rows}
+
+
+def _validate_applied_prefix(
+    applied: dict[int, tuple[str, str]], migrations: tuple[Migration, ...]
+) -> None:
+    if not applied:
+        return
+    versions = sorted(applied)
+    if versions != list(range(1, len(versions) + 1)):
+        _fail("the migration ledger is not a contiguous prefix")
+    if versions[-1] > len(migrations):
+        _fail("the migration ledger records versions with no matching definition")
+    for migration in migrations[: versions[-1]]:
+        recorded_name, recorded_checksum = applied[migration.version]
+        if recorded_name != migration.name or recorded_checksum != _checksum(migration):
+            _fail("an applied migration was modified after it was recorded")
+
+
+def _apply_one(database: ControlDatabase, migration: Migration, checksum: str, stamp: str) -> None:
+    failed = False
+    try:
+        with database.transaction() as connection:
+            for statement in migration.statements:
+                connection.execute(statement)
+            connection.execute(
+                f"INSERT INTO {_SCHEMA_TABLE} (version, name, checksum, applied_at) "
+                "VALUES (?, ?, ?, ?)",
+                (migration.version, migration.name, checksum, stamp),
+            )
+    except sqlite3.Error:
+        # the transaction already rolled back; normalize the SQLite detail to a fixed error.
+        failed = True
+    if failed:
+        _fail("a migration statement failed to apply")
+
+
+def apply_migrations(
+    database: ControlDatabase,
+    migrations: tuple[Migration, ...],
+    *,
+    applied_at: datetime,
+) -> int:
+    """Apply any unapplied migrations in contiguous order and return the resulting schema version.
+
+    ``applied_at`` must be an aware UTC instant; it is stored as the canonical RFC3339 millisecond
+    string. Applying an empty definition set is a no-op that returns the current version.
+    """
+
+    if type(migrations) is not tuple:
+        _fail("migrations must be provided as an ordered tuple")
+    _validate_definitions(migrations)
+    stamp = format_timestamp(applied_at)
+    _ensure_schema_table(database)
+    applied = _load_applied(database.connection)
+    _validate_applied_prefix(applied, migrations)
+    highest = max(applied) if applied else 0
+    for migration in migrations:
+        if migration.version <= highest:
+            continue
+        _apply_one(database, migration, _checksum(migration), stamp)
+        highest = migration.version
+    return highest
+
+
+def schema_version(database: ControlDatabase) -> int:
+    """Return the highest applied migration version, or 0 when no migrations have been applied."""
+
+    _ensure_schema_table(database)
+    row = database.connection.execute(f"SELECT max(version) FROM {_SCHEMA_TABLE}").fetchone()
+    if row is None or row[0] is None:
+        return 0
+    return int(row[0])

--- a/src/milhouse/state/migrations.py
+++ b/src/milhouse/state/migrations.py
@@ -1,12 +1,19 @@
-"""Ordered, checksum-enforced, transactional control-plane migrations (W03 slice 1).
+"""Ordered, checksum-enforced, barrier-gated control-plane migrations (W03 slice 1).
 
-Each migration carries a version, a name, and a tuple of single SQL statements. Migrations apply
-strictly in contiguous order from version 1; each applies together with its ledger row in one
-``BEGIN IMMEDIATE`` transaction, so a crash mid-migration leaves schema and ledger consistent. An
-already-applied migration whose checksum or name later differs, or a ledger that is not a contiguous
-prefix of the definitions, is corruption and fails closed with a fixed ``MH_STATE_MIGRATION`` error.
-Statements are single statements, not a script: SQLite's ``executescript`` implicitly commits, which
-would break the atomic schema-plus-ledger boundary.
+Each migration carries a version, a name, and a tuple of single SQL statements. ``migrate`` owns the
+exclusive global commit barrier for the whole inspect-and-apply operation, so two processes
+cannot run
+schema DDL outside the maintenance fence, and applies any unapplied migrations strictly in
+contiguous
+order from version 1. Each migration applies together with its ledger row in one ``BEGIN IMMEDIATE``
+transaction, so a crash mid-migration leaves schema and ledger consistent. A modified applied
+migration, or a ledger that is not a contiguous prefix of the definitions, is corruption and fails
+closed with a fixed ``MH_STATE_MIGRATION``. ``schema_version`` is read-only and never creates the
+ledger. Every SQLite or time failure is normalized to a fixed ``MH_STATE_*`` error raised
+outside the
+handler. Statements are single statements, not a script, because SQLite's ``executescript``
+implicitly
+commits, which would break the atomic schema-plus-ledger boundary.
 """
 
 from __future__ import annotations
@@ -17,7 +24,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import NoReturn
 
-from milhouse.core.clock import format_timestamp
+from milhouse.core.clock import TimeError, format_timestamp
+from milhouse.state.barrier import GlobalCommitBarrier
 from milhouse.state.database import ControlDatabase
 from milhouse.state.errors import StateError
 
@@ -54,6 +62,18 @@ def _validate_definitions(migrations: tuple[Migration, ...]) -> None:
         for statement in migration.statements:
             if type(statement) is not str or not statement.strip():
                 _fail("each migration statement must be non-empty text")
+
+
+def _stamp(applied_at: datetime) -> str:
+    invalid = False
+    stamp = ""
+    try:
+        stamp = format_timestamp(applied_at)
+    except (OverflowError, TimeError):
+        invalid = True
+    if invalid:
+        _fail("the migration timestamp must be an aware in-range UTC instant")
+    return stamp
 
 
 def _ensure_schema_table(database: ControlDatabase) -> None:
@@ -108,39 +128,63 @@ def _apply_one(database: ControlDatabase, migration: Migration, checksum: str, s
         _fail("a migration statement failed to apply")
 
 
-def apply_migrations(
+def _apply_all(database: ControlDatabase, migrations: tuple[Migration, ...], stamp: str) -> int:
+    failed = False
+    try:
+        _ensure_schema_table(database)
+        applied = _load_applied(database.connection)
+        _validate_applied_prefix(applied, migrations)
+        highest = max(applied) if applied else 0
+        for migration in migrations:
+            if migration.version <= highest:
+                continue
+            _apply_one(database, migration, _checksum(migration), stamp)
+            highest = migration.version
+        return highest
+    except sqlite3.Error:
+        failed = True
+    if failed:
+        _fail("the control schema could not be inspected")
+    raise AssertionError  # pragma: no cover - unreachable; the branch above always returns or fails
+
+
+def migrate(
     database: ControlDatabase,
     migrations: tuple[Migration, ...],
     *,
+    barrier: GlobalCommitBarrier,
     applied_at: datetime,
 ) -> int:
-    """Apply any unapplied migrations in contiguous order and return the resulting schema version.
+    """Apply any unapplied migrations under the exclusive global barrier; return the schema version.
 
-    ``applied_at`` must be an aware UTC instant; it is stored as the canonical RFC3339 millisecond
-    string. Applying an empty definition set is a no-op that returns the current version.
+    The whole inspect-and-apply runs while holding the exclusive commit barrier, so concurrent
+    processes serialize through the maintenance fence. ``applied_at`` must be an aware UTC instant.
     """
 
     if type(migrations) is not tuple:
         _fail("migrations must be provided as an ordered tuple")
     _validate_definitions(migrations)
-    stamp = format_timestamp(applied_at)
-    _ensure_schema_table(database)
-    applied = _load_applied(database.connection)
-    _validate_applied_prefix(applied, migrations)
-    highest = max(applied) if applied else 0
-    for migration in migrations:
-        if migration.version <= highest:
-            continue
-        _apply_one(database, migration, _checksum(migration), stamp)
-        highest = migration.version
-    return highest
+    stamp = _stamp(applied_at)
+    with barrier.exclusive():
+        return _apply_all(database, migrations, stamp)
 
 
 def schema_version(database: ControlDatabase) -> int:
-    """Return the highest applied migration version, or 0 when no migrations have been applied."""
+    """Return the highest applied migration version, or 0 if the ledger is absent. Read-only."""
 
-    _ensure_schema_table(database)
-    row = database.connection.execute(f"SELECT max(version) FROM {_SCHEMA_TABLE}").fetchone()
-    if row is None or row[0] is None:
-        return 0
-    return int(row[0])
+    connection = database.connection
+    failed = False
+    version = 0
+    try:
+        present = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?", (_SCHEMA_TABLE,)
+        ).fetchone()
+        if present is not None:
+            row = connection.execute(f"SELECT max(version) FROM {_SCHEMA_TABLE}").fetchone()
+            if row is not None and row[0] is not None:
+                version = int(row[0])
+    except sqlite3.Error:
+        failed = True
+    if failed:
+        _fail("the schema version could not be read")
+    return version

--- a/src/milhouse/state/schema.py
+++ b/src/milhouse/state/schema.py
@@ -1,0 +1,39 @@
+"""The immutable package-owned control-plane schema (W03 slice 1).
+
+The initial control schema is an ordered migration sequence rather than ad-hoc DDL by feature code,
+so the physical schema can never diverge from the recorded migration version and checksums (the
+review's P1 concern). Later W03 slices append segment/exporter ledger, index, and cursor migrations
+to this tuple; shipped entries are immutable. The ``_leases`` table carries a monotonic ``fence``
+token so a stale holder cannot resume work after takeover.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from milhouse.state.barrier import GlobalCommitBarrier
+from milhouse.state.database import ControlDatabase
+from milhouse.state.migrations import Migration, migrate
+
+CONTROL_MIGRATIONS: tuple[Migration, ...] = (
+    Migration(
+        1,
+        "create_leases",
+        (
+            "CREATE TABLE _leases ("
+            "name TEXT PRIMARY KEY NOT NULL, "
+            "holder TEXT NOT NULL, "
+            "fence INTEGER NOT NULL, "
+            "acquired_at TEXT NOT NULL, "
+            "expires_at TEXT NOT NULL)",
+        ),
+    ),
+)
+
+
+def initialize_control_state(
+    database: ControlDatabase, *, barrier: GlobalCommitBarrier, applied_at: datetime
+) -> int:
+    """Apply the package-owned control schema under the barrier; return the schema version."""
+
+    return migrate(database, CONTROL_MIGRATIONS, barrier=barrier, applied_at=applied_at)

--- a/tests/security/test_state_boundary.py
+++ b/tests/security/test_state_boundary.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -18,7 +18,9 @@ from milhouse.state import (
     GlobalCommitBarrier,
     Migration,
     StateError,
-    apply_migrations,
+    acquire_lease,
+    initialize_control_state,
+    migrate,
     open_control_database,
 )
 from milhouse.state import barrier as barrier_module
@@ -184,9 +186,10 @@ def test_invalid_migration_definitions_fail_closed(
 ) -> None:
     directory = _private_dir(tmp_path)
     database = open_control_database(directory / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(directory / "commit.lock")
     try:
         with pytest.raises(StateError) as captured:
-            apply_migrations(database, definitions, applied_at=_NOW)
+            migrate(database, definitions, barrier=barrier, applied_at=_NOW)
         assert captured.value.code == "MH_STATE_MIGRATION"
     finally:
         database.close()
@@ -196,12 +199,51 @@ def test_invalid_migration_definitions_fail_closed(
 def test_non_tuple_migrations_fail_closed(tmp_path: Path) -> None:
     directory = _private_dir(tmp_path)
     database = open_control_database(directory / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(directory / "commit.lock")
     try:
         with pytest.raises(StateError) as captured:
-            apply_migrations(
-                database, [Migration(1, "a", ("CREATE TABLE a (x)",))], applied_at=_NOW
-            )  # type: ignore[arg-type]
+            migrate(
+                database,
+                [Migration(1, "a", ("CREATE TABLE a (x)",))],  # type: ignore[arg-type]
+                barrier=barrier,
+                applied_at=_NOW,
+            )
         assert captured.value.code == "MH_STATE_MIGRATION"
+    finally:
+        database.close()
+
+
+@pytest.mark.security
+def test_a_malformed_lease_table_is_normalized(tmp_path: Path) -> None:
+    directory = _private_dir(tmp_path)
+    database = open_control_database(directory / "milhouse.sqlite3")
+    try:
+        # a `_leases` table missing the expected columns must produce a fixed error, not raw SQLite
+        with database.transaction() as connection:
+            connection.execute("CREATE TABLE _leases (name TEXT PRIMARY KEY)")
+        with pytest.raises(StateError) as captured:
+            acquire_lease(database, "job", "worker-a", now=_NOW, ttl_seconds=60)
+        assert captured.value.code == "MH_STATE_LEASE"
+        assert captured.value.__cause__ is None
+        assert captured.value.__context__ is None
+    finally:
+        database.close()
+
+
+@pytest.mark.security
+def test_an_overflowing_deadline_is_normalized(tmp_path: Path) -> None:
+    directory = _private_dir(tmp_path)
+    database = open_control_database(directory / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(directory / "commit.lock")
+    try:
+        initialize_control_state(database, barrier=barrier, applied_at=_NOW)
+        # an instant so close to datetime.max that adding the TTL overflows: must not leak the error
+        near_max = datetime.max.replace(tzinfo=UTC) - timedelta(seconds=1)
+        with pytest.raises(StateError) as captured:
+            acquire_lease(database, "job", "worker-a", now=near_max, ttl_seconds=60)
+        assert captured.value.code == "MH_STATE_LEASE"
+        assert captured.value.__cause__ is None
+        assert captured.value.__context__ is None
     finally:
         database.close()
 
@@ -224,15 +266,15 @@ def test_barrier_lock_creation_failure_fails_closed(
 
 
 @pytest.mark.security
-def test_barrier_exclusive_os_error_fails_closed(
+def test_barrier_flock_os_error_fails_closed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     barrier = GlobalCommitBarrier(_private_dir(tmp_path) / "commit.lock")
 
-    def _boom(self: object, *args: object, **kwargs: object) -> None:
-        raise OSError("planted exclusive acquire failure")
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("planted flock failure")
 
-    monkeypatch.setattr(barrier_module.FileLock, "acquire", _boom)
+    monkeypatch.setattr(barrier_module.fcntl, "flock", _boom)
     with pytest.raises(StateError) as captured:
         with barrier.exclusive():
             pass

--- a/tests/security/test_state_boundary.py
+++ b/tests/security/test_state_boundary.py
@@ -1,0 +1,240 @@
+"""Fail-closed boundary tests for the W03 control-plane state (secure open, migrations, barrier).
+
+These inject filesystem and SQLite failures and assert every path fails closed with a fixed
+``MH_STATE_*`` error and no leaked SQLite or OS detail in the error's cause, context, or args.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from milhouse.state import (
+    ControlDatabase,
+    GlobalCommitBarrier,
+    Migration,
+    StateError,
+    apply_migrations,
+    open_control_database,
+)
+from milhouse.state import barrier as barrier_module
+from milhouse.state import database as database_module
+
+_NOW = datetime(2026, 7, 24, 12, 0, 0, tzinfo=UTC)
+
+
+def _private_dir(tmp_path: Path) -> Path:
+    directory = tmp_path / "control"
+    directory.mkdir(mode=0o700)
+    os.chmod(directory, 0o700)
+    return directory
+
+
+def _assert_clean(error: StateError) -> None:
+    assert error.__cause__ is None
+    assert error.__context__ is None
+
+
+class _RaisingConnection:
+    """A minimal connection stand-in whose statements raise, to exercise the error boundary."""
+
+    def __init__(self, *, raise_on: str) -> None:
+        self._raise_on = raise_on
+
+    def execute(self, sql: str, *args: object) -> object:
+        if self._raise_on in sql:
+            raise sqlite3.OperationalError("planted control-plane failure")
+        return None
+
+    def close(self) -> None:
+        raise sqlite3.OperationalError("planted close failure")
+
+
+@pytest.mark.security
+def test_file_creation_failure_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    directory = _private_dir(tmp_path)
+
+    def _boom(*_args: object, **_kwargs: object) -> int:
+        raise PermissionError("planted create failure")
+
+    monkeypatch.setattr(database_module.os, "open", _boom)
+    with pytest.raises(StateError) as captured:
+        open_control_database(directory / "milhouse.sqlite3")
+    assert captured.value.code == "MH_STATE_FILE"
+    _assert_clean(captured.value)
+
+
+@pytest.mark.security
+def test_unexaminable_path_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    directory = _private_dir(tmp_path)
+    real_lstat = database_module.os.lstat
+
+    def _selective(path: object) -> os.stat_result:
+        if str(path).endswith("milhouse.sqlite3"):
+            raise PermissionError("planted lstat failure")
+        return real_lstat(path)
+
+    monkeypatch.setattr(database_module.os, "lstat", _selective)
+    with pytest.raises(StateError) as captured:
+        open_control_database(directory / "milhouse.sqlite3")
+    assert captured.value.code == "MH_STATE_FILE"
+    _assert_clean(captured.value)
+
+
+@pytest.mark.security
+def test_connect_failure_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    directory = _private_dir(tmp_path)
+
+    def _boom(*_args: object, **_kwargs: object) -> sqlite3.Connection:
+        raise sqlite3.OperationalError("planted connect failure")
+
+    monkeypatch.setattr(database_module.sqlite3, "connect", _boom)
+    with pytest.raises(StateError) as captured:
+        open_control_database(directory / "milhouse.sqlite3")
+    assert captured.value.code == "MH_STATE_OPEN"
+    _assert_clean(captured.value)
+
+
+class _JournalProxy:
+    """Wrap a real connection but report a non-WAL journal mode to exercise the fail-closed path."""
+
+    def __init__(self, real: sqlite3.Connection) -> None:
+        self._real = real
+
+    def execute(self, sql: str, *rest: object) -> object:
+        if "journal_mode" in sql:
+            return self._real.execute("PRAGMA journal_mode = DELETE", *rest)
+        return self._real.execute(sql, *rest)
+
+    def close(self) -> None:
+        self._real.close()
+
+
+@pytest.mark.security
+def test_a_non_wal_journal_mode_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    directory = _private_dir(tmp_path)
+    real_connect = database_module.sqlite3.connect
+
+    def _proxy_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        return _JournalProxy(real_connect(*args, **kwargs))  # type: ignore[arg-type, return-value]
+
+    monkeypatch.setattr(database_module.sqlite3, "connect", _proxy_connect)
+    with pytest.raises(StateError) as captured:
+        open_control_database(directory / "milhouse.sqlite3")
+    assert captured.value.code == "MH_STATE_OPEN"
+
+
+@pytest.mark.security
+def test_transaction_begin_failure_fails_closed(tmp_path: Path) -> None:
+    database = ControlDatabase(
+        connection=_RaisingConnection(raise_on="BEGIN"),  # type: ignore[arg-type]
+        path=tmp_path / "x",
+        created=False,
+    )
+    with pytest.raises(StateError) as captured:
+        with database.transaction():
+            pass
+    assert captured.value.code == "MH_STATE_TXN"
+    _assert_clean(captured.value)
+
+
+@pytest.mark.security
+def test_transaction_commit_failure_fails_closed(tmp_path: Path) -> None:
+    database = ControlDatabase(
+        connection=_RaisingConnection(raise_on="COMMIT"),  # type: ignore[arg-type]
+        path=tmp_path / "x",
+        created=False,
+    )
+    with pytest.raises(StateError) as captured:
+        with database.transaction():
+            pass
+    assert captured.value.code == "MH_STATE_TXN"
+    _assert_clean(captured.value)
+
+
+@pytest.mark.security
+def test_close_swallows_a_connection_error(tmp_path: Path) -> None:
+    database = ControlDatabase(
+        connection=_RaisingConnection(raise_on="never"),  # type: ignore[arg-type]
+        path=tmp_path / "x",
+        created=False,
+    )
+    database.close()  # the planted close failure must be swallowed, not raised
+
+
+@pytest.mark.security
+@pytest.mark.parametrize(
+    "definitions",
+    [
+        (Migration(1, "", ("CREATE TABLE a (x)",)),),
+        (Migration(1, "a", ()),),
+        (Migration(1, "a", ("   ",)),),
+    ],
+)
+def test_invalid_migration_definitions_fail_closed(
+    tmp_path: Path, definitions: tuple[Migration, ...]
+) -> None:
+    directory = _private_dir(tmp_path)
+    database = open_control_database(directory / "milhouse.sqlite3")
+    try:
+        with pytest.raises(StateError) as captured:
+            apply_migrations(database, definitions, applied_at=_NOW)
+        assert captured.value.code == "MH_STATE_MIGRATION"
+    finally:
+        database.close()
+
+
+@pytest.mark.security
+def test_non_tuple_migrations_fail_closed(tmp_path: Path) -> None:
+    directory = _private_dir(tmp_path)
+    database = open_control_database(directory / "milhouse.sqlite3")
+    try:
+        with pytest.raises(StateError) as captured:
+            apply_migrations(
+                database, [Migration(1, "a", ("CREATE TABLE a (x)",))], applied_at=_NOW
+            )  # type: ignore[arg-type]
+        assert captured.value.code == "MH_STATE_MIGRATION"
+    finally:
+        database.close()
+
+
+@pytest.mark.security
+def test_barrier_lock_creation_failure_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    barrier = GlobalCommitBarrier(_private_dir(tmp_path) / "commit.lock")
+
+    def _boom(*_args: object, **_kwargs: object) -> int:
+        raise PermissionError("planted lock creation failure")
+
+    monkeypatch.setattr(barrier_module.os, "open", _boom)
+    with pytest.raises(StateError) as captured:
+        with barrier.shared():
+            pass
+    assert captured.value.code == "MH_STATE_BARRIER"
+    _assert_clean(captured.value)
+
+
+@pytest.mark.security
+def test_barrier_exclusive_os_error_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    barrier = GlobalCommitBarrier(_private_dir(tmp_path) / "commit.lock")
+
+    def _boom(self: object, *args: object, **kwargs: object) -> None:
+        raise OSError("planted exclusive acquire failure")
+
+    monkeypatch.setattr(barrier_module.FileLock, "acquire", _boom)
+    with pytest.raises(StateError) as captured:
+        with barrier.exclusive():
+            pass
+    assert captured.value.code == "MH_STATE_BARRIER"
+    _assert_clean(captured.value)

--- a/tests/unit/test_state_barrier.py
+++ b/tests/unit/test_state_barrier.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from milhouse.state import GlobalCommitBarrier, StateError
+
+_CHILD = r"""
+import sys, time
+from pathlib import Path
+from milhouse.state import GlobalCommitBarrier
+
+lock_path, mode, ready, release = sys.argv[1:5]
+barrier = GlobalCommitBarrier(lock_path)
+context = barrier.shared() if mode == "shared" else barrier.exclusive()
+with context:
+    Path(ready).write_text("held")
+    deadline = time.monotonic() + 20.0
+    while not Path(release).exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+"""
+
+
+def _lock_path(tmp_path: Path) -> Path:
+    directory = tmp_path / "control"
+    directory.mkdir(mode=0o700)
+    os.chmod(directory, 0o700)
+    return directory / "commit.lock"
+
+
+def test_two_shared_holders_coexist(tmp_path: Path) -> None:
+    barrier = GlobalCommitBarrier(_lock_path(tmp_path))
+    with barrier.shared(blocking=False):
+        with barrier.shared(blocking=False):
+            pass
+
+
+def test_a_shared_holder_blocks_the_exclusive_side(tmp_path: Path) -> None:
+    barrier = GlobalCommitBarrier(_lock_path(tmp_path))
+    with barrier.shared():
+        with pytest.raises(StateError) as captured:
+            with barrier.exclusive(blocking=False):
+                pass
+        assert captured.value.code == "MH_STATE_BARRIER_BUSY"
+
+
+def test_an_exclusive_holder_blocks_the_shared_side(tmp_path: Path) -> None:
+    barrier = GlobalCommitBarrier(_lock_path(tmp_path))
+    with barrier.exclusive():
+        with pytest.raises(StateError) as captured:
+            with barrier.shared(blocking=False):
+                pass
+        assert captured.value.code == "MH_STATE_BARRIER_BUSY"
+
+
+def test_the_barrier_is_free_after_release(tmp_path: Path) -> None:
+    barrier = GlobalCommitBarrier(_lock_path(tmp_path))
+    with barrier.exclusive():
+        pass
+    with barrier.exclusive(blocking=False):
+        pass
+
+
+def _spawn_holder(lock: Path, mode: str, ready: Path, release: Path) -> subprocess.Popen[bytes]:
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _CHILD, str(lock), mode, str(ready), str(release)],
+        env=dict(os.environ),
+    )
+    deadline = time.monotonic() + 20.0
+    while not ready.exists() and time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise AssertionError("barrier holder child exited before acquiring")
+        time.sleep(0.01)
+    assert ready.exists(), "barrier holder child did not acquire in time"
+    return proc
+
+
+def test_cross_process_exclusion_and_recovery(tmp_path: Path) -> None:
+    lock = _lock_path(tmp_path)
+    ready = tmp_path / "ready"
+    release = tmp_path / "release"
+    holder = _spawn_holder(lock, "exclusive", ready, release)
+    try:
+        barrier = GlobalCommitBarrier(lock)
+        with pytest.raises(StateError) as captured:
+            with barrier.shared(blocking=False):
+                pass
+        assert captured.value.code == "MH_STATE_BARRIER_BUSY"
+    finally:
+        release.write_text("go")
+        assert holder.wait(timeout=20) == 0
+    # once the cross-process exclusive holder is gone, the barrier is free again
+    with barrier.shared(blocking=False):
+        pass

--- a/tests/unit/test_state_barrier.py
+++ b/tests/unit/test_state_barrier.py
@@ -10,7 +10,7 @@ import pytest
 
 from milhouse.state import GlobalCommitBarrier, StateError
 
-_CHILD = r"""
+_HOLD = r"""
 import sys, time
 from pathlib import Path
 from milhouse.state import GlobalCommitBarrier
@@ -20,17 +20,38 @@ barrier = GlobalCommitBarrier(lock_path)
 context = barrier.shared() if mode == "shared" else barrier.exclusive()
 with context:
     Path(ready).write_text("held")
-    deadline = time.monotonic() + 20.0
+    deadline = time.monotonic() + 25.0
     while not Path(release).exists() and time.monotonic() < deadline:
         time.sleep(0.01)
 """
 
 
-def _lock_path(tmp_path: Path) -> Path:
+def _control_dir(tmp_path: Path) -> Path:
     directory = tmp_path / "control"
     directory.mkdir(mode=0o700)
     os.chmod(directory, 0o700)
-    return directory / "commit.lock"
+    return directory
+
+
+def _lock_path(tmp_path: Path) -> Path:
+    return _control_dir(tmp_path) / "commit.lock"
+
+
+def _spawn_holder(lock: Path, mode: str, ready: Path, release: Path) -> subprocess.Popen[bytes]:
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _HOLD, str(lock), mode, str(ready), str(release)],
+        env=dict(os.environ),
+    )
+    deadline = time.monotonic() + 25.0
+    while not ready.exists() and time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise AssertionError(f"{mode} holder child exited before acquiring")
+        time.sleep(0.01)
+    assert ready.exists(), f"{mode} holder child did not acquire in time"
+    return proc
+
+
+# --- basic readers-writer semantics -------------------------------------------------------------
 
 
 def test_two_shared_holders_coexist(tmp_path: Path) -> None:
@@ -66,20 +87,6 @@ def test_the_barrier_is_free_after_release(tmp_path: Path) -> None:
         pass
 
 
-def _spawn_holder(lock: Path, mode: str, ready: Path, release: Path) -> subprocess.Popen[bytes]:
-    proc = subprocess.Popen(
-        [sys.executable, "-c", _CHILD, str(lock), mode, str(ready), str(release)],
-        env=dict(os.environ),
-    )
-    deadline = time.monotonic() + 20.0
-    while not ready.exists() and time.monotonic() < deadline:
-        if proc.poll() is not None:
-            raise AssertionError("barrier holder child exited before acquiring")
-        time.sleep(0.01)
-    assert ready.exists(), "barrier holder child did not acquire in time"
-    return proc
-
-
 def test_cross_process_exclusion_and_recovery(tmp_path: Path) -> None:
     lock = _lock_path(tmp_path)
     ready = tmp_path / "ready"
@@ -93,7 +100,96 @@ def test_cross_process_exclusion_and_recovery(tmp_path: Path) -> None:
         assert captured.value.code == "MH_STATE_BARRIER_BUSY"
     finally:
         release.write_text("go")
-        assert holder.wait(timeout=20) == 0
-    # once the cross-process exclusive holder is gone, the barrier is free again
+        assert holder.wait(timeout=25) == 0
     with barrier.shared(blocking=False):
         pass
+
+
+def test_writer_preference_a_queued_exclusive_blocks_new_shared(tmp_path: Path) -> None:
+    # A holds shared; B queues an exclusive (grabs the gate, blocks on the drained main lock); while
+    # B is queued a new shared entrant is refused at the gate (the writer-preference turnstile).
+    lock = _lock_path(tmp_path)
+    ready_a, release_a = tmp_path / "ready_a", tmp_path / "release_a"
+    ready_b, release_b = tmp_path / "ready_b", tmp_path / "release_b"
+    holder_a = _spawn_holder(lock, "shared", ready_a, release_a)
+    holder_b = subprocess.Popen(
+        [sys.executable, "-c", _HOLD, str(lock), "exclusive", str(ready_b), str(release_b)],
+        env=dict(os.environ),
+    )
+    try:
+        barrier = GlobalCommitBarrier(lock)
+        # Once B has taken the gate exclusively, a new non-blocking shared entrant is refused.
+        deadline = time.monotonic() + 25.0
+        blocked = False
+        while time.monotonic() < deadline:
+            try:
+                with barrier.shared(blocking=False):
+                    pass
+            except StateError as error:
+                assert error.code == "MH_STATE_BARRIER_BUSY"
+                blocked = True
+                break
+            time.sleep(0.02)
+        assert blocked, "a queued exclusive did not block a new shared entrant"
+        assert not ready_b.exists(), "the exclusive acquired while a shared holder was still active"
+    finally:
+        release_a.write_text("go")
+        release_b.write_text("go")
+        assert holder_a.wait(timeout=25) == 0
+        assert holder_b.wait(timeout=25) == 0
+
+
+# --- secure lock-file validation (never truncate or trust a foreign inode) -----------------------
+
+
+def test_a_hard_linked_lock_file_is_rejected_and_never_truncated(tmp_path: Path) -> None:
+    directory = _control_dir(tmp_path)
+    victim = directory / "important-control-state"
+    victim.write_bytes(b"important-control-state")
+    os.chmod(victim, 0o600)
+    lock = directory / "commit.lock"
+    os.link(victim, lock)  # a hard link, exactly what the review flagged
+
+    barrier = GlobalCommitBarrier(lock)
+    with pytest.raises(StateError) as captured:
+        with barrier.exclusive(blocking=False):
+            pass
+    assert captured.value.code == "MH_STATE_BARRIER_UNSAFE"
+    assert captured.value.__cause__ is None
+    assert captured.value.__context__ is None
+    # the foreign file must be byte-for-byte intact
+    assert victim.read_bytes() == b"important-control-state"
+
+
+def test_a_symlinked_lock_file_is_rejected(tmp_path: Path) -> None:
+    directory = _control_dir(tmp_path)
+    target = directory / "target"
+    target.write_bytes(b"x")
+    os.chmod(target, 0o600)
+    lock = directory / "commit.lock"
+    lock.symlink_to(target)
+    with pytest.raises(StateError) as captured:
+        with GlobalCommitBarrier(lock).shared(blocking=False):
+            pass
+    assert captured.value.code in {"MH_STATE_BARRIER", "MH_STATE_BARRIER_UNSAFE"}
+
+
+def test_a_non_regular_lock_file_is_rejected(tmp_path: Path) -> None:
+    directory = _control_dir(tmp_path)
+    lock = directory / "commit.lock"
+    os.mkfifo(lock, 0o600)
+    with pytest.raises(StateError) as captured:
+        with GlobalCommitBarrier(lock).shared(blocking=False):
+            pass
+    assert captured.value.code in {"MH_STATE_BARRIER", "MH_STATE_BARRIER_UNSAFE"}
+
+
+def test_a_loose_mode_lock_file_is_rejected(tmp_path: Path) -> None:
+    directory = _control_dir(tmp_path)
+    lock = directory / "commit.lock"
+    lock.write_bytes(b"x")
+    os.chmod(lock, 0o666)
+    with pytest.raises(StateError) as captured:
+        with GlobalCommitBarrier(lock).shared(blocking=False):
+            pass
+    assert captured.value.code == "MH_STATE_BARRIER_UNSAFE"

--- a/tests/unit/test_state_database.py
+++ b/tests/unit/test_state_database.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from milhouse.state import ControlDatabase, StateError, open_control_database
+
+
+def _private_dir(root: Path, name: str = "control") -> Path:
+    directory = root / name
+    directory.mkdir(mode=0o700)
+    os.chmod(directory, 0o700)  # defeat the inherited umask
+    return directory
+
+
+def _db_path(root: Path) -> Path:
+    return _private_dir(root) / "milhouse.sqlite3"
+
+
+def test_open_creates_an_owner_only_wal_database(tmp_path: Path) -> None:
+    path = _db_path(tmp_path)
+    database = open_control_database(path)
+    try:
+        assert database.created is True
+        assert database.path == path
+        assert stat.S_IMODE(os.lstat(path).st_mode) == 0o600
+        assert database.connection.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        assert database.connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert database.connection.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
+    finally:
+        database.close()
+
+
+def test_reopening_an_existing_database_does_not_report_creation(tmp_path: Path) -> None:
+    path = _db_path(tmp_path)
+    first = open_control_database(path)
+    first.close()
+    second = open_control_database(path)
+    try:
+        assert second.created is False
+    finally:
+        second.close()
+
+
+def test_transaction_commits_on_success_and_rolls_back_on_error(tmp_path: Path) -> None:
+    database = open_control_database(_db_path(tmp_path))
+    try:
+        with database.transaction() as connection:
+            connection.execute("CREATE TABLE t (x INTEGER NOT NULL)")
+            connection.execute("INSERT INTO t VALUES (1)")
+        assert database.connection.execute("SELECT count(*) FROM t").fetchone()[0] == 1
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with database.transaction() as connection:
+                connection.execute("INSERT INTO t VALUES (2)")
+                raise RuntimeError("boom")
+        # the caller's exception propagated unchanged and the row was rolled back
+        assert database.connection.execute("SELECT count(*) FROM t").fetchone()[0] == 1
+    finally:
+        database.close()
+
+
+def test_rejects_a_group_or_world_accessible_parent_directory(tmp_path: Path) -> None:
+    directory = tmp_path / "loose"
+    directory.mkdir()
+    os.chmod(directory, 0o777)
+    with pytest.raises(StateError) as captured:
+        open_control_database(directory / "milhouse.sqlite3")
+    assert captured.value.code == "MH_STATE_DIR"
+    assert captured.value.__cause__ is None
+    assert captured.value.__context__ is None
+
+
+def test_rejects_a_symlinked_database_path(tmp_path: Path) -> None:
+    directory = _private_dir(tmp_path)
+    target = directory / "real.sqlite3"
+    target.write_bytes(b"")
+    os.chmod(target, 0o600)
+    link = directory / "milhouse.sqlite3"
+    link.symlink_to(target)
+    with pytest.raises(StateError) as captured:
+        open_control_database(link)
+    assert captured.value.code == "MH_STATE_FILE"
+
+
+def test_rejects_an_existing_group_readable_database_file(tmp_path: Path) -> None:
+    directory = _private_dir(tmp_path)
+    path = directory / "milhouse.sqlite3"
+    path.write_bytes(b"")
+    os.chmod(path, 0o640)
+    with pytest.raises(StateError) as captured:
+        open_control_database(path)
+    assert captured.value.code == "MH_STATE_FILE"
+
+
+def test_using_a_closed_database_fails_closed(tmp_path: Path) -> None:
+    database = open_control_database(_db_path(tmp_path))
+    database.close()
+    database.close()  # idempotent
+    with pytest.raises(StateError) as captured:
+        _ = database.connection
+    assert captured.value.code == "MH_STATE_CLOSED"
+
+
+def test_open_control_database_returns_the_wrapper_type(tmp_path: Path) -> None:
+    database = open_control_database(_db_path(tmp_path))
+    try:
+        assert isinstance(database, ControlDatabase)
+    finally:
+        database.close()

--- a/tests/unit/test_state_leases.py
+++ b/tests/unit/test_state_leases.py
@@ -7,28 +7,35 @@ from pathlib import Path
 import pytest
 
 from milhouse.state import (
+    GlobalCommitBarrier,
     StateError,
     acquire_lease,
+    initialize_control_state,
     open_control_database,
     release_lease,
     renew_lease,
+    require_current_lease,
 )
 
 _T0 = datetime(2026, 7, 24, 12, 0, 0, tzinfo=UTC)
 
 
-def _database(tmp_path: Path):
+def _migrated(tmp_path: Path):
     directory = tmp_path / "control"
     directory.mkdir(mode=0o700)
     os.chmod(directory, 0o700)
-    return open_control_database(directory / "milhouse.sqlite3")
+    database = open_control_database(directory / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(directory / "commit.lock")
+    initialize_control_state(database, barrier=barrier, applied_at=_T0)
+    return database
 
 
-def test_acquire_records_a_bounded_lease(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+def test_acquire_records_a_fenced_bounded_lease(tmp_path: Path) -> None:
+    database = _migrated(tmp_path)
     try:
         lease = acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
         assert lease.holder == "worker-a"
+        assert lease.fence == 1
         assert lease.acquired_at == "2026-07-24T12:00:00.000Z"
         assert lease.expires_at == "2026-07-24T12:01:00.000Z"
     finally:
@@ -36,7 +43,7 @@ def test_acquire_records_a_bounded_lease(tmp_path: Path) -> None:
 
 
 def test_a_live_lease_blocks_a_different_holder(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+    database = _migrated(tmp_path)
     try:
         acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
         with pytest.raises(StateError) as captured:
@@ -48,40 +55,41 @@ def test_a_live_lease_blocks_a_different_holder(tmp_path: Path) -> None:
         database.close()
 
 
-def test_an_expired_lease_can_be_taken_over(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+def test_taking_over_an_expired_lease_increments_the_fence(tmp_path: Path) -> None:
+    database = _migrated(tmp_path)
     try:
-        acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
+        first = acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
         taken = acquire_lease(
             database, "scheduler", "worker-b", now=_T0 + timedelta(seconds=61), ttl_seconds=60
         )
+        assert first.fence == 1
         assert taken.holder == "worker-b"
+        assert taken.fence == 2
     finally:
         database.close()
 
 
-def test_reacquiring_own_lease_renews_it(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+def test_reacquiring_own_lease_renews_and_keeps_the_fence(tmp_path: Path) -> None:
+    database = _migrated(tmp_path)
     try:
         acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
         renewed = acquire_lease(
             database, "scheduler", "worker-a", now=_T0 + timedelta(seconds=30), ttl_seconds=60
         )
+        assert renewed.fence == 1
         assert renewed.expires_at == "2026-07-24T12:01:30.000Z"
     finally:
         database.close()
 
 
-def test_renew_requires_a_live_owned_lease(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+def test_renew_requires_a_live_owned_lease_and_keeps_the_fence(tmp_path: Path) -> None:
+    database = _migrated(tmp_path)
     try:
         acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
-        assert (
-            renew_lease(
-                database, "scheduler", "worker-a", now=_T0 + timedelta(seconds=30), ttl_seconds=60
-            ).expires_at
-            == "2026-07-24T12:01:30.000Z"
+        renewed = renew_lease(
+            database, "scheduler", "worker-a", now=_T0 + timedelta(seconds=30), ttl_seconds=60
         )
+        assert renewed.fence == 1
         with pytest.raises(StateError) as expired:
             renew_lease(
                 database, "scheduler", "worker-a", now=_T0 + timedelta(seconds=999), ttl_seconds=60
@@ -97,26 +105,44 @@ def test_renew_requires_a_live_owned_lease(tmp_path: Path) -> None:
 
 
 def test_release_only_removes_the_holders_lease(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+    database = _migrated(tmp_path)
     try:
         acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
         assert release_lease(database, "scheduler", "worker-b") is False
         assert release_lease(database, "scheduler", "worker-a") is True
-        # after release the name is free for anyone
-        assert (
-            acquire_lease(database, "scheduler", "worker-b", now=_T0, ttl_seconds=60).holder
-            == "worker-b"
+        taken = acquire_lease(database, "scheduler", "worker-b", now=_T0, ttl_seconds=60)
+        assert taken.holder == "worker-b"
+    finally:
+        database.close()
+
+
+def test_a_fenced_stale_holder_cannot_pass_the_lease_guard(tmp_path: Path) -> None:
+    database = _migrated(tmp_path)
+    try:
+        stale = acquire_lease(database, "job", "worker-a", now=_T0, ttl_seconds=60)
+        current = acquire_lease(
+            database, "job", "worker-b", now=_T0 + timedelta(seconds=61), ttl_seconds=60
         )
+        assert current.fence == stale.fence + 1
+        # the current holder passes the guard...
+        with database.transaction() as connection:
+            require_current_lease(connection, current)
+        # ...but the taken-over holder is rejected in the same transaction as any protected mutation
+        with pytest.raises(StateError) as captured:
+            with database.transaction() as connection:
+                require_current_lease(connection, stale)
+        assert captured.value.code == "MH_STATE_LEASE_LOST"
     finally:
         database.close()
 
 
 def test_invalid_ttl_and_identifiers_fail_closed(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+    database = _migrated(tmp_path)
     try:
-        with pytest.raises(StateError) as ttl:
-            acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=0)
-        assert ttl.value.code == "MH_STATE_LEASE_TTL"
+        for bad_ttl in (0, -1, 3650 * 86_400 + 1):
+            with pytest.raises(StateError) as ttl:
+                acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=bad_ttl)
+            assert ttl.value.code == "MH_STATE_LEASE_TTL"
         with pytest.raises(StateError) as name:
             acquire_lease(database, "", "worker-a", now=_T0, ttl_seconds=60)
         assert name.value.code == "MH_STATE_LEASE_NAME"

--- a/tests/unit/test_state_leases.py
+++ b/tests/unit/test_state_leases.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from milhouse.state import (
+    StateError,
+    acquire_lease,
+    open_control_database,
+    release_lease,
+    renew_lease,
+)
+
+_T0 = datetime(2026, 7, 24, 12, 0, 0, tzinfo=UTC)
+
+
+def _database(tmp_path: Path):
+    directory = tmp_path / "control"
+    directory.mkdir(mode=0o700)
+    os.chmod(directory, 0o700)
+    return open_control_database(directory / "milhouse.sqlite3")
+
+
+def test_acquire_records_a_bounded_lease(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        lease = acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
+        assert lease.holder == "worker-a"
+        assert lease.acquired_at == "2026-07-24T12:00:00.000Z"
+        assert lease.expires_at == "2026-07-24T12:01:00.000Z"
+    finally:
+        database.close()
+
+
+def test_a_live_lease_blocks_a_different_holder(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
+        with pytest.raises(StateError) as captured:
+            acquire_lease(
+                database, "scheduler", "worker-b", now=_T0 + timedelta(seconds=30), ttl_seconds=60
+            )
+        assert captured.value.code == "MH_STATE_LEASE_HELD"
+    finally:
+        database.close()
+
+
+def test_an_expired_lease_can_be_taken_over(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
+        taken = acquire_lease(
+            database, "scheduler", "worker-b", now=_T0 + timedelta(seconds=61), ttl_seconds=60
+        )
+        assert taken.holder == "worker-b"
+    finally:
+        database.close()
+
+
+def test_reacquiring_own_lease_renews_it(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
+        renewed = acquire_lease(
+            database, "scheduler", "worker-a", now=_T0 + timedelta(seconds=30), ttl_seconds=60
+        )
+        assert renewed.expires_at == "2026-07-24T12:01:30.000Z"
+    finally:
+        database.close()
+
+
+def test_renew_requires_a_live_owned_lease(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
+        assert (
+            renew_lease(
+                database, "scheduler", "worker-a", now=_T0 + timedelta(seconds=30), ttl_seconds=60
+            ).expires_at
+            == "2026-07-24T12:01:30.000Z"
+        )
+        with pytest.raises(StateError) as expired:
+            renew_lease(
+                database, "scheduler", "worker-a", now=_T0 + timedelta(seconds=999), ttl_seconds=60
+            )
+        assert expired.value.code == "MH_STATE_LEASE_LOST"
+        with pytest.raises(StateError) as foreign:
+            renew_lease(
+                database, "scheduler", "worker-b", now=_T0 + timedelta(seconds=5), ttl_seconds=60
+            )
+        assert foreign.value.code == "MH_STATE_LEASE_LOST"
+    finally:
+        database.close()
+
+
+def test_release_only_removes_the_holders_lease(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=60)
+        assert release_lease(database, "scheduler", "worker-b") is False
+        assert release_lease(database, "scheduler", "worker-a") is True
+        # after release the name is free for anyone
+        assert (
+            acquire_lease(database, "scheduler", "worker-b", now=_T0, ttl_seconds=60).holder
+            == "worker-b"
+        )
+    finally:
+        database.close()
+
+
+def test_invalid_ttl_and_identifiers_fail_closed(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        with pytest.raises(StateError) as ttl:
+            acquire_lease(database, "scheduler", "worker-a", now=_T0, ttl_seconds=0)
+        assert ttl.value.code == "MH_STATE_LEASE_TTL"
+        with pytest.raises(StateError) as name:
+            acquire_lease(database, "", "worker-a", now=_T0, ttl_seconds=60)
+        assert name.value.code == "MH_STATE_LEASE_NAME"
+        with pytest.raises(StateError) as holder:
+            acquire_lease(database, "scheduler", "", now=_T0, ttl_seconds=60)
+        assert holder.value.code == "MH_STATE_LEASE_HOLDER"
+    finally:
+        database.close()

--- a/tests/unit/test_state_migrations.py
+++ b/tests/unit/test_state_migrations.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import contextlib
 import os
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
 from milhouse.state import (
+    GlobalCommitBarrier,
     Migration,
     StateError,
-    apply_migrations,
+    migrate,
     open_control_database,
     schema_version,
 )
@@ -20,17 +23,31 @@ _M1 = Migration(1, "create_ledger", ("CREATE TABLE ledger (id INTEGER PRIMARY KE
 _M2 = Migration(2, "create_cursor", ("CREATE TABLE cursor (name TEXT PRIMARY KEY)",))
 
 
-def _database(tmp_path: Path):
+def _db_and_barrier(tmp_path: Path):
     directory = tmp_path / "control"
     directory.mkdir(mode=0o700)
     os.chmod(directory, 0o700)
-    return open_control_database(directory / "milhouse.sqlite3")
+    database = open_control_database(directory / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(directory / "commit.lock")
+    return database, barrier
 
 
-def test_apply_migrations_creates_tables_and_records_the_ledger(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+class _SpyBarrier:
+    """A barrier stand-in recording that ``migrate`` entered the exclusive maintenance side."""
+
+    def __init__(self) -> None:
+        self.exclusive_uses = 0
+
+    @contextlib.contextmanager
+    def exclusive(self, *, blocking: bool = True) -> Iterator[None]:
+        self.exclusive_uses += 1
+        yield
+
+
+def test_migrate_creates_tables_and_records_the_ledger(tmp_path: Path) -> None:
+    database, barrier = _db_and_barrier(tmp_path)
     try:
-        assert apply_migrations(database, (_M1, _M2), applied_at=_NOW) == 2
+        assert migrate(database, (_M1, _M2), barrier=barrier, applied_at=_NOW) == 2
         assert schema_version(database) == 2
         tables = {
             row[0]
@@ -48,47 +65,57 @@ def test_apply_migrations_creates_tables_and_records_the_ledger(tmp_path: Path) 
         database.close()
 
 
-def test_apply_migrations_is_idempotent(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+def test_migrate_runs_under_the_exclusive_barrier(tmp_path: Path) -> None:
+    database, _barrier = _db_and_barrier(tmp_path)
+    spy = _SpyBarrier()
     try:
-        apply_migrations(database, (_M1, _M2), applied_at=_NOW)
-        assert apply_migrations(database, (_M1, _M2), applied_at=_NOW) == 2
+        migrate(database, (_M1,), barrier=spy, applied_at=_NOW)  # type: ignore[arg-type]
+        assert spy.exclusive_uses == 1
+    finally:
+        database.close()
+
+
+def test_migrate_is_idempotent(tmp_path: Path) -> None:
+    database, barrier = _db_and_barrier(tmp_path)
+    try:
+        migrate(database, (_M1, _M2), barrier=barrier, applied_at=_NOW)
+        assert migrate(database, (_M1, _M2), barrier=barrier, applied_at=_NOW) == 2
         count = database.connection.execute("SELECT count(*) FROM _schema_migrations").fetchone()[0]
         assert count == 2
     finally:
         database.close()
 
 
-def test_apply_migrations_extends_a_partial_ledger(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+def test_migrate_extends_a_partial_ledger(tmp_path: Path) -> None:
+    database, barrier = _db_and_barrier(tmp_path)
     try:
-        assert apply_migrations(database, (_M1,), applied_at=_NOW) == 1
-        assert apply_migrations(database, (_M1, _M2), applied_at=_NOW) == 2
+        assert migrate(database, (_M1,), barrier=barrier, applied_at=_NOW) == 1
+        assert migrate(database, (_M1, _M2), barrier=barrier, applied_at=_NOW) == 2
     finally:
         database.close()
 
 
 def test_a_modified_applied_migration_is_rejected_as_corruption(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+    database, barrier = _db_and_barrier(tmp_path)
     try:
-        apply_migrations(database, (_M1,), applied_at=_NOW)
+        migrate(database, (_M1,), barrier=barrier, applied_at=_NOW)
         tampered = Migration(1, "create_ledger", ("CREATE TABLE ledger (id INTEGER, extra TEXT)",))
         with pytest.raises(StateError) as captured:
-            apply_migrations(database, (tampered,), applied_at=_NOW)
+            migrate(database, (tampered,), barrier=barrier, applied_at=_NOW)
         assert captured.value.code == "MH_STATE_MIGRATION"
     finally:
         database.close()
 
 
 def test_noncontiguous_definitions_are_rejected(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+    database, barrier = _db_and_barrier(tmp_path)
     try:
         gapped = (
             Migration(1, "a", ("CREATE TABLE a (x)",)),
             Migration(3, "c", ("CREATE TABLE c (x)",)),
         )
         with pytest.raises(StateError) as captured:
-            apply_migrations(database, gapped, applied_at=_NOW)
+            migrate(database, gapped, barrier=barrier, applied_at=_NOW)
         assert captured.value.code == "MH_STATE_MIGRATION"
     finally:
         database.close()
@@ -97,15 +124,14 @@ def test_noncontiguous_definitions_are_rejected(tmp_path: Path) -> None:
 def test_a_failing_statement_rolls_back_atomically_without_leaking_sqlite_detail(
     tmp_path: Path,
 ) -> None:
-    database = _database(tmp_path)
+    database, barrier = _db_and_barrier(tmp_path)
     try:
         broken = Migration(1, "broken", ("CREATE TABLE ok (x INTEGER)", "THIS IS NOT SQL"))
         with pytest.raises(StateError) as captured:
-            apply_migrations(database, (broken,), applied_at=_NOW)
+            migrate(database, (broken,), barrier=barrier, applied_at=_NOW)
         assert captured.value.code == "MH_STATE_MIGRATION"
         assert captured.value.__cause__ is None
         assert captured.value.__context__ is None
-        # neither the table nor the ledger row survives the rolled-back migration
         assert schema_version(database) == 0
         remaining = {
             row[0]
@@ -119,9 +145,24 @@ def test_a_failing_statement_rolls_back_atomically_without_leaking_sqlite_detail
 
 
 def test_empty_definitions_are_a_no_op(tmp_path: Path) -> None:
-    database = _database(tmp_path)
+    database, barrier = _db_and_barrier(tmp_path)
     try:
-        assert apply_migrations(database, (), applied_at=_NOW) == 0
+        assert migrate(database, (), barrier=barrier, applied_at=_NOW) == 0
         assert schema_version(database) == 0
+    finally:
+        database.close()
+
+
+def test_schema_version_is_read_only_on_a_fresh_database(tmp_path: Path) -> None:
+    database, _barrier = _db_and_barrier(tmp_path)
+    try:
+        assert schema_version(database) == 0
+        tables = {
+            row[0]
+            for row in database.connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "_schema_migrations" not in tables  # a read must never create the ledger
     finally:
         database.close()

--- a/tests/unit/test_state_migrations.py
+++ b/tests/unit/test_state_migrations.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from milhouse.state import (
+    Migration,
+    StateError,
+    apply_migrations,
+    open_control_database,
+    schema_version,
+)
+
+_NOW = datetime(2026, 7, 24, 12, 0, 0, tzinfo=UTC)
+
+_M1 = Migration(1, "create_ledger", ("CREATE TABLE ledger (id INTEGER PRIMARY KEY)",))
+_M2 = Migration(2, "create_cursor", ("CREATE TABLE cursor (name TEXT PRIMARY KEY)",))
+
+
+def _database(tmp_path: Path):
+    directory = tmp_path / "control"
+    directory.mkdir(mode=0o700)
+    os.chmod(directory, 0o700)
+    return open_control_database(directory / "milhouse.sqlite3")
+
+
+def test_apply_migrations_creates_tables_and_records_the_ledger(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        assert apply_migrations(database, (_M1, _M2), applied_at=_NOW) == 2
+        assert schema_version(database) == 2
+        tables = {
+            row[0]
+            for row in database.connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert {"ledger", "cursor"} <= tables
+        recorded = database.connection.execute(
+            "SELECT version, name, applied_at FROM _schema_migrations ORDER BY version"
+        ).fetchall()
+        assert [(r[0], r[1]) for r in recorded] == [(1, "create_ledger"), (2, "create_cursor")]
+        assert recorded[0][2] == "2026-07-24T12:00:00.000Z"
+    finally:
+        database.close()
+
+
+def test_apply_migrations_is_idempotent(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        apply_migrations(database, (_M1, _M2), applied_at=_NOW)
+        assert apply_migrations(database, (_M1, _M2), applied_at=_NOW) == 2
+        count = database.connection.execute("SELECT count(*) FROM _schema_migrations").fetchone()[0]
+        assert count == 2
+    finally:
+        database.close()
+
+
+def test_apply_migrations_extends_a_partial_ledger(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        assert apply_migrations(database, (_M1,), applied_at=_NOW) == 1
+        assert apply_migrations(database, (_M1, _M2), applied_at=_NOW) == 2
+    finally:
+        database.close()
+
+
+def test_a_modified_applied_migration_is_rejected_as_corruption(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        apply_migrations(database, (_M1,), applied_at=_NOW)
+        tampered = Migration(1, "create_ledger", ("CREATE TABLE ledger (id INTEGER, extra TEXT)",))
+        with pytest.raises(StateError) as captured:
+            apply_migrations(database, (tampered,), applied_at=_NOW)
+        assert captured.value.code == "MH_STATE_MIGRATION"
+    finally:
+        database.close()
+
+
+def test_noncontiguous_definitions_are_rejected(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        gapped = (
+            Migration(1, "a", ("CREATE TABLE a (x)",)),
+            Migration(3, "c", ("CREATE TABLE c (x)",)),
+        )
+        with pytest.raises(StateError) as captured:
+            apply_migrations(database, gapped, applied_at=_NOW)
+        assert captured.value.code == "MH_STATE_MIGRATION"
+    finally:
+        database.close()
+
+
+def test_a_failing_statement_rolls_back_atomically_without_leaking_sqlite_detail(
+    tmp_path: Path,
+) -> None:
+    database = _database(tmp_path)
+    try:
+        broken = Migration(1, "broken", ("CREATE TABLE ok (x INTEGER)", "THIS IS NOT SQL"))
+        with pytest.raises(StateError) as captured:
+            apply_migrations(database, (broken,), applied_at=_NOW)
+        assert captured.value.code == "MH_STATE_MIGRATION"
+        assert captured.value.__cause__ is None
+        assert captured.value.__context__ is None
+        # neither the table nor the ledger row survives the rolled-back migration
+        assert schema_version(database) == 0
+        remaining = {
+            row[0]
+            for row in database.connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "ok" not in remaining
+    finally:
+        database.close()
+
+
+def test_empty_definitions_are_a_no_op(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        assert apply_migrations(database, (), applied_at=_NOW) == 0
+        assert schema_version(database) == 0
+    finally:
+        database.close()


### PR DESCRIPTION
## Summary

First W03 slice: the SQLite control-plane substrate (ADR 0004, plan §4.3/§4.4) that the durable spool, replay, and retention build on. New `milhouse.state` package.

## Delivers
- **`database.py`** — secure `open_control_database`: DB created `0600` with `O_EXCL`/`O_NOFOLLOW` in an already-secured private parent, opened WAL + `synchronous=FULL` + enforced foreign keys, validated non-symlink owner-only; a `BEGIN IMMEDIATE` transaction boundary.
- **`migrations.py`** — ordered, checksum-enforced, contiguous migrations applied with their ledger row in one transaction; tampered/non-prefix ledger = corruption, fails closed.
- **`leases.py`** — named holder-owned time-bounded SQLite leases (acquire/renew/release), injected UTC time, lexical RFC3339 expiry.
- **`barrier.py`** — cross-process readers-writer global commit barrier: exclusive side is `filelock.FileLock` (BSD `flock LOCK_EX`), shared writer side is `fcntl.flock LOCK_SH` on the same file (they conflict correctly because both use BSD flock).

## Safety
Every failure raises a fixed `MH_STATE_*` error **outside any handler** — no SQLite/OS/caller detail in cause, context, args, or traceback. Fail-closed boundary tests inject filesystem/SQLite failures and **caught + fixed two real `__context__` leaks** (barrier exclusive-acquire and DB path-examine). 40 tests: golden behavior, injected-failure matrix, and a cross-process barrier exclusion/recovery proof.

## Notes
`filelock` was already a declared dependency (no dep change). `make quality` + `test` pass (3809 passed); global coverage floor holds. State modules are at ~94% branch; they'll join the enforced 95% `--critical` set in the W03 failure-injection slice, mirroring how `log_wire.py` joined critical at its evidence stage.

**Owner-confirmed W03 plan:** 7 fine-grained slices; this is slice 1 of 7 toward G03. G03 remains not-accepted.