### PR TITLE
feat(spool): W03 self-describing segment format + atomic writer (slice 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ identity-portability:
 	$(UV_RUN) python -m pytest \
 		tests/contract/test_identity_portability_contract.py \
 		tests/integration/test_identity_subprocess_integration.py \
-		tests/integration/test_log_wire_subprocess_integration.py
+		tests/integration/test_log_wire_subprocess_integration.py \
+		tests/integration/test_spool_subprocess_integration.py
 
 test-coverage:
 	mkdir -p build

--- a/src/milhouse/spooling/__init__.py
+++ b/src/milhouse/spooling/__init__.py
@@ -1,0 +1,23 @@
+"""W03 durable spool: the self-describing segment wire and its atomic publication."""
+
+from __future__ import annotations
+
+from milhouse.spooling.errors import SpoolError
+from milhouse.spooling.segment import (
+    SegmentHeaderV1,
+    SpoolFrameV1,
+    spool_content_sha256,
+    spool_frame_line,
+    spool_segment_header_line,
+)
+from milhouse.spooling.writer import write_spool_segment
+
+__all__ = [
+    "SegmentHeaderV1",
+    "SpoolError",
+    "SpoolFrameV1",
+    "spool_content_sha256",
+    "spool_frame_line",
+    "spool_segment_header_line",
+    "write_spool_segment",
+]

--- a/src/milhouse/spooling/errors.py
+++ b/src/milhouse/spooling/errors.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from milhouse.core.errors import MilhouseValueError
+
+
+class SpoolError(MilhouseValueError):
+    """A fixed, privacy-safe spool failure carrying only a stable code and static message.
+
+    Every spool failure is raised outside any active exception handler, so no filesystem, canonical,
+    or record detail reaches the error's cause, context, args, or traceback. The stable
+    ``MH_SPOOL_*`` codes are the only machine surface.
+    """

--- a/src/milhouse/spooling/segment.py
+++ b/src/milhouse/spooling/segment.py
@@ -1,0 +1,182 @@
+"""Self-describing spool segment wire: header, frames, and the ordered-frame digest (W03 slice 2).
+
+Per ADR 0004 and plan section 4.3 a durable segment is one self-describing file: the first JSONL
+line is a ``SegmentHeaderV1`` and the remaining lines are ordered ``SpoolFrameV1`` records, each
+carrying the complete redacted ``RecordEnvelopeV1``. The header records the frame/schema versions,
+batch id,
+configuration-generation digest, scope/target, privacy and retention class, required exporter ids,
+expected record count, and the SHA-256 digest of the ordered frame bytes. Lines are bounded
+``CanonicalJSONV1``, so segment bytes are deterministic across processes and platforms. This module
+owns only the wire and the digest; the atomic write and the SQLite ledger live in sibling modules.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import NoReturn
+
+from milhouse.core.canonical import MAX_CANONICAL_INT, canonical_json_bytes
+from milhouse.domain.identity import ScopeV1
+from milhouse.domain.records import PrivacyClassV1, RecordEnvelopeV1
+from milhouse.spooling.errors import SpoolError
+
+_LF = b"\n"
+SCHEMA_VERSION = 1
+FRAME_VERSION = 1
+MAX_HEADER_LINE_BYTES = 8_192
+MAX_FRAME_LINE_BYTES = 262_144 + 1_024  # a canonical record plus the small frame envelope
+MAX_RETENTION_DAYS = 3_650  # matches the config `[retention]` ceiling
+
+_BATCH_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", flags=re.ASCII)
+_EXPORTER_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", flags=re.ASCII)
+_TARGET_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,255}", flags=re.ASCII)
+_SHA256_HEX_PATTERN = re.compile(r"[0-9a-f]{64}", flags=re.ASCII)
+_SCOPES = ("installation", "target")
+_PRIVACY_CLASSES = ("public", "internal", "sensitive", "restricted")
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise SpoolError(code, message)
+
+
+def _validate_batch_id(value: object) -> None:
+    if type(value) is not str or _BATCH_ID_PATTERN.fullmatch(value) is None:
+        _fail("MH_SPOOL_BATCH_ID", "a bounded safe batch id is required")
+
+
+def _validate_positive_sequence(value: object) -> None:
+    if type(value) is not int or not 0 < value <= MAX_CANONICAL_INT:
+        _fail("MH_SPOOL_SEQUENCE", "a positive signed-64 sequence is required")
+
+
+@dataclass(frozen=True, slots=True)
+class SpoolFrameV1:
+    """One ordered spool frame binding a batch sequence to a finalized record envelope."""
+
+    batch_id: str
+    sequence: int
+    record: RecordEnvelopeV1
+
+    def __post_init__(self) -> None:
+        _validate_batch_id(self.batch_id)
+        _validate_positive_sequence(self.sequence)
+        if not isinstance(self.record, RecordEnvelopeV1):
+            _fail("MH_SPOOL_RECORD", "a finalized record envelope is required")
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentHeaderV1:
+    """The immutable self-describing header opening one durable spool segment."""
+
+    batch_id: str
+    config_generation: str
+    scope: ScopeV1
+    target_id: str | None
+    privacy_class: PrivacyClassV1
+    retention_days: int
+    required_exporters: tuple[str, ...]
+    record_count: int
+    content_sha256: str
+
+    def __post_init__(self) -> None:
+        _validate_batch_id(self.batch_id)
+        if (
+            type(self.config_generation) is not str
+            or _SHA256_HEX_PATTERN.fullmatch(self.config_generation) is None
+        ):
+            _fail(
+                "MH_SPOOL_CONFIG_GENERATION", "a 64-hex configuration-generation digest is required"
+            )
+        if self.scope not in _SCOPES:
+            _fail("MH_SPOOL_SCOPE", "an installation or target scope is required")
+        if self.scope == "target":
+            if (
+                type(self.target_id) is not str
+                or _TARGET_ID_PATTERN.fullmatch(self.target_id) is None
+            ):
+                _fail("MH_SPOOL_TARGET", "target scope requires a bounded target id")
+        elif self.target_id is not None:
+            _fail("MH_SPOOL_TARGET", "installation scope forbids a target id")
+        if self.privacy_class not in _PRIVACY_CLASSES:
+            _fail("MH_SPOOL_PRIVACY", "a valid privacy class is required")
+        if (
+            type(self.retention_days) is not int
+            or not 0 < self.retention_days <= MAX_RETENTION_DAYS
+        ):
+            _fail("MH_SPOOL_RETENTION", "a bounded positive retention is required")
+        if type(self.required_exporters) is not tuple:
+            _fail("MH_SPOOL_EXPORTERS", "required exporters must be a tuple")
+        for exporter in self.required_exporters:
+            if type(exporter) is not str or _EXPORTER_ID_PATTERN.fullmatch(exporter) is None:
+                _fail("MH_SPOOL_EXPORTERS", "each exporter id must be bounded safe text")
+        if list(self.required_exporters) != sorted(set(self.required_exporters)):
+            _fail("MH_SPOOL_EXPORTERS", "required exporters must be sorted and unique")
+        if type(self.record_count) is not int or not 0 <= self.record_count <= MAX_CANONICAL_INT:
+            _fail("MH_SPOOL_COUNT", "a bounded record count is required")
+        if (
+            type(self.content_sha256) is not str
+            or _SHA256_HEX_PATTERN.fullmatch(self.content_sha256) is None
+        ):
+            _fail("MH_SPOOL_DIGEST", "a lowercase hex sha-256 digest is required")
+
+
+def spool_frame_line(frame: SpoolFrameV1) -> bytes:
+    """Project one frame to its bounded canonical JSONL bytes including the trailing line feed."""
+
+    if not isinstance(frame, SpoolFrameV1):
+        _fail("MH_SPOOL_FRAME", "a spool frame is required")
+    payload = {
+        "batch_id": frame.batch_id,
+        "frame_version": FRAME_VERSION,
+        "record": frame.record.model_dump(mode="python", exclude_none=True),
+        "record_id": frame.record.record_id,
+        "sequence": frame.sequence,
+    }
+    return canonical_json_bytes(payload, max_bytes=MAX_FRAME_LINE_BYTES - len(_LF)) + _LF
+
+
+def spool_segment_header_line(header: SegmentHeaderV1) -> bytes:
+    """Project the segment header to its bounded canonical JSONL bytes including the line feed."""
+
+    if not isinstance(header, SegmentHeaderV1):
+        _fail("MH_SPOOL_HEADER", "a segment header is required")
+    payload = {
+        "batch_id": header.batch_id,
+        "config_generation": header.config_generation,
+        "content_sha256": header.content_sha256,
+        "frame_version": FRAME_VERSION,
+        "privacy_class": header.privacy_class,
+        "record_count": header.record_count,
+        "required_exporters": list(header.required_exporters),
+        "retention_days": header.retention_days,
+        "schema": SCHEMA_VERSION,
+        "scope": header.scope,
+        "target_id": header.target_id,
+    }
+    return canonical_json_bytes(payload, max_bytes=MAX_HEADER_LINE_BYTES - len(_LF)) + _LF
+
+
+def spool_content_sha256(frame_lines: Iterable[bytes]) -> str:
+    """Return the SHA-256 over the ordered frame-line bytes, including their line feeds.
+
+    The header carries this digest, so the digest covers only the frame bytes and not the header. A
+    hostile ``__iter__``/``__next__`` or a non-bytes element fails closed with a fixed
+    ``MH_SPOOL_DIGEST`` raised outside the handler.
+    """
+
+    digest = hashlib.sha256()
+    failed = False
+    try:
+        for line in frame_lines:
+            if type(line) is not bytes:
+                failed = True
+                break
+            digest.update(line)
+    except Exception:
+        failed = True
+    if failed:
+        _fail("MH_SPOOL_DIGEST", "the frame lines are invalid")
+    return digest.hexdigest()

--- a/src/milhouse/spooling/writer.py
+++ b/src/milhouse/spooling/writer.py
@@ -1,0 +1,96 @@
+"""Atomic durable publication of one self-describing spool segment (W03 slice 2).
+
+``write_spool_segment`` validates that the header and frames are mutually consistent (matching
+batch id, scope, target, privacy class, contiguous sequences, exact count, and the ordered-frame
+digest), then
+publishes the segment bytes with the W02 secure atomic-publish primitive: a unique temporary file is
+written, flushed, and fsynced, atomically renamed without replacing an existing name, and the parent
+directory is fsynced. The parent directory must already exist and be private. Any failure raises a
+fixed ``MH_SPOOL_*`` error outside the handler, so no filesystem detail leaks; the SQLite ledger row
+and crash reconciliation are a later slice.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NoReturn
+
+from milhouse.config.filesystem import (
+    SecureFileError,
+    SecureFileErrorKind,
+    create_regular_file_no_follow,
+)
+from milhouse.spooling.errors import SpoolError
+from milhouse.spooling.segment import (
+    SegmentHeaderV1,
+    SpoolFrameV1,
+    spool_content_sha256,
+    spool_frame_line,
+    spool_segment_header_line,
+)
+
+_SEGMENT_FILE_MODE = 0o600
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise SpoolError(code, message)
+
+
+def _validate_consistency(header: SegmentHeaderV1, frames: tuple[SpoolFrameV1, ...]) -> None:
+    if header.record_count != len(frames):
+        _fail("MH_SPOOL_COUNT", "the header record count must equal the frame count")
+    for index, frame in enumerate(frames, start=1):
+        if not isinstance(frame, SpoolFrameV1):
+            _fail("MH_SPOOL_FRAME", "a spool frame is required")
+        if frame.sequence != index:
+            _fail("MH_SPOOL_SEQUENCE", "frame sequences must be contiguous from 1")
+        if frame.batch_id != header.batch_id:
+            _fail("MH_SPOOL_BATCH_ID", "each frame batch id must match the header")
+        record = frame.record
+        if record.scope != header.scope:
+            _fail("MH_SPOOL_SCOPE", "each frame scope must match the header")
+        record_target = record.target.id if record.target is not None else None
+        if record_target != header.target_id:
+            _fail("MH_SPOOL_TARGET", "each frame target must match the header")
+        if record.privacy_class != header.privacy_class:
+            _fail("MH_SPOOL_PRIVACY", "each frame privacy class must match the header")
+
+
+def _atomic_publish(path: str | Path, content: bytes) -> None:
+    exists = False
+    failed = False
+    try:
+        create_regular_file_no_follow(
+            path, content, mode=_SEGMENT_FILE_MODE, require_private_parent=True
+        )
+    except SecureFileError as error:
+        if error.kind is SecureFileErrorKind.ALREADY_EXISTS:
+            exists = True
+        else:
+            failed = True
+    if exists:
+        _fail("MH_SPOOL_EXISTS", "a segment already exists at that name")
+    if failed:
+        _fail("MH_SPOOL_WRITE", "the segment could not be durably published")
+
+
+def write_spool_segment(
+    path: str | Path, header: SegmentHeaderV1, frames: tuple[SpoolFrameV1, ...] | list[SpoolFrameV1]
+) -> None:
+    """Atomically publish a self-describing segment whose header and frames are mutually consistent.
+
+    The header must already carry the digest of the ordered frame bytes; this re-validates it so the
+    published segment is internally verifiable. Publication never overwrites an existing name.
+    """
+
+    if not isinstance(header, SegmentHeaderV1):
+        _fail("MH_SPOOL_HEADER", "a segment header is required")
+    if not isinstance(frames, (tuple, list)):
+        _fail("MH_SPOOL_FRAMES", "frames must be provided as a concrete sequence")
+    frame_tuple = tuple(frames)
+    _validate_consistency(header, frame_tuple)
+    frame_lines = [spool_frame_line(frame) for frame in frame_tuple]
+    if spool_content_sha256(frame_lines) != header.content_sha256:
+        _fail("MH_SPOOL_DIGEST", "the header digest does not match the frame bytes")
+    content = spool_segment_header_line(header) + b"".join(frame_lines)
+    _atomic_publish(path, content)

--- a/tests/integration/test_spool_subprocess_integration.py
+++ b/tests/integration/test_spool_subprocess_integration.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+
+_BUILD = r"""
+from datetime import datetime, timedelta, timezone
+
+from milhouse.domain.records import (
+    CollectorDescriptorV1,
+    EventDataV1,
+    RecordDraftV1,
+    SourceDescriptorV1,
+    TargetDescriptorV1,
+    finalize_record,
+)
+from milhouse.spooling import (
+    SegmentHeaderV1,
+    SpoolFrameV1,
+    spool_content_sha256,
+    spool_frame_line,
+    spool_segment_header_line,
+)
+
+utc = timezone.utc
+now = datetime(2026, 7, 24, 12, 0, 0, tzinfo=utc)
+
+
+def envelope(source_event_id):
+    values = {
+        "record_type": "event",
+        "name": "source.event",
+        "occurred_at": now,
+        "observed_at": now + timedelta(seconds=1),
+        "ingested_at": now + timedelta(seconds=2),
+        "expires_at": now + timedelta(days=30),
+        "source_event_id": source_event_id,
+        "operation_id": "operation-1",
+        "collector_run_id": "collector-run-1",
+        "scope": "target",
+        "source": SourceDescriptorV1.model_validate({
+            "id": "example-source",
+            "type": "source.event",
+            "producer": "collector",
+            "observation_namespace_id": "mh_ns1_00000000000040008000000000000000",
+            "source_generation_digest": "0" * 64,
+            "observation": {"kind": "source.revision", "parts": {"revision": 1}},
+        }),
+        "collector": CollectorDescriptorV1(
+            id="c", type="site.canary", implementation_version="1.0.0"
+        ),
+        "target": TargetDescriptorV1(
+            id="example-target", name="Example", kind="web.service", environment="test"
+        ),
+        "severity": "info",
+        "trust_level": "authenticated",
+        "privacy_class": "internal",
+        "redaction_version": "r1-e1",
+        "data": EventDataV1(category="availability", status="healthy", message="ok"),
+    }
+    return finalize_record(
+        RecordDraftV1.model_validate(values),
+        installation_id="mh_in1_00000000000040008000000000000000",
+    )
+
+
+def segment_bytes():
+    frames = [
+        SpoolFrameV1(batch_id="batch-1", sequence=1, record=envelope("event-1")),
+        SpoolFrameV1(batch_id="batch-1", sequence=2, record=envelope("event-2")),
+    ]
+    frame_lines = [spool_frame_line(frame) for frame in frames]
+    header = SegmentHeaderV1(
+        batch_id="batch-1",
+        config_generation="a" * 64,
+        scope="target",
+        target_id="example-target",
+        privacy_class="internal",
+        retention_days=30,
+        required_exporters=("clickhouse",),
+        record_count=2,
+        content_sha256=spool_content_sha256(frame_lines),
+    )
+    return spool_segment_header_line(header) + b"".join(frame_lines)
+"""
+
+CHILD_SCRIPT = (
+    _BUILD
+    + r"""
+import os, sys
+
+if not sys.flags.safe_path or not sys.flags.no_user_site:
+    raise SystemExit(70)
+if os.environ.get("PYTHONHASHSEED") != sys.argv[1]:
+    raise SystemExit(70)
+
+import locale, time
+locale.setlocale(locale.LC_ALL, "")
+if hasattr(time, "tzset"):
+    time.tzset()
+
+sys.stdout.buffer.write(segment_bytes())
+"""
+)
+
+RUN_ENVIRONMENTS = (
+    ("0", "C", "UTC0"),
+    ("1", "en_US.UTF-8", "EST5EDT"),
+    ("314159", "POSIX", "GMT0"),
+)
+MAX_CHILD_OUTPUT_BYTES = 1024 * 1024
+CHILD_TIMEOUT_SECONDS = 20
+
+
+def _build_in_process() -> bytes:
+    namespace: dict[str, object] = {}
+    exec(_BUILD, namespace)
+    return namespace["segment_bytes"]()  # type: ignore[operator]
+
+
+def test_segment_bytes_are_portable_across_isolated_process_environments() -> None:
+    expected = _build_in_process()
+    assert expected.count(b"\n") == 3  # header + two frames
+    outputs: list[bytes] = []
+    for run_number, (hash_seed, selected_locale, timezone_name) in enumerate(
+        RUN_ENVIRONMENTS, start=1
+    ):
+        child_environment = {
+            "LC_ALL": selected_locale,
+            "LANG": selected_locale,
+            "TZ": timezone_name,
+            "PYTHONHASHSEED": hash_seed,
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONUTF8": "1",
+        }
+        if "PATH" in os.environ:
+            child_environment["PATH"] = os.environ["PATH"]
+        with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+            completed = subprocess.run(
+                [sys.executable, "-s", "-P", "-c", CHILD_SCRIPT, hash_seed],
+                stdout=stdout_file,
+                stderr=stderr_file,
+                check=False,
+                env=child_environment,
+                timeout=CHILD_TIMEOUT_SECONDS,
+            )
+            stdout_file.seek(0)
+            child_stdout = stdout_file.read(MAX_CHILD_OUTPUT_BYTES + 1)
+        assert completed.returncode == 0, f"segment child run {run_number} failed"
+        outputs.append(child_stdout)
+
+    for run_number, output in enumerate(outputs, start=1):
+        assert output == expected, (
+            f"segment child run {run_number} did not match the in-process bytes"
+        )
+    assert all(output == outputs[0] for output in outputs[1:])

--- a/tests/unit/test_spool_segment.py
+++ b/tests/unit/test_spool_segment.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from milhouse.domain.records import (
+    CollectorDescriptorV1,
+    EventDataV1,
+    RecordDraftV1,
+    RecordEnvelopeV1,
+    SourceDescriptorV1,
+    TargetDescriptorV1,
+    finalize_record,
+)
+from milhouse.spooling import (
+    SegmentHeaderV1,
+    SpoolError,
+    SpoolFrameV1,
+    spool_content_sha256,
+    spool_frame_line,
+    spool_segment_header_line,
+    write_spool_segment,
+)
+
+_INSTALLATION_ID = "mh_in1_00000000000040008000000000000000"
+_NOW = datetime(2026, 7, 24, 12, 0, 0, tzinfo=UTC)
+_GENERATION = "a" * 64
+
+
+def _source() -> SourceDescriptorV1:
+    return SourceDescriptorV1.model_validate(
+        {
+            "id": "example-source",
+            "type": "source.event",
+            "producer": "collector",
+            "observation_namespace_id": "mh_ns1_00000000000040008000000000000000",
+            "source_generation_digest": "0" * 64,
+            "observation": {"kind": "source.revision", "parts": {"revision": 1}},
+        }
+    )
+
+
+def _target() -> TargetDescriptorV1:
+    return TargetDescriptorV1(
+        id="example-target", name="Example", kind="web.service", environment="test"
+    )
+
+
+def _envelope(
+    *, scope: str = "target", privacy_class: str = "internal", source_event_id: str = "event-1"
+) -> RecordEnvelopeV1:
+    values: dict[str, object] = {
+        "record_type": "event",
+        "name": "source.event",
+        "occurred_at": _NOW,
+        "observed_at": _NOW + timedelta(seconds=1),
+        "ingested_at": _NOW + timedelta(seconds=2),
+        "expires_at": _NOW + timedelta(days=30),
+        "source_event_id": source_event_id,
+        "operation_id": "operation-1",
+        "collector_run_id": "collector-run-1",
+        "scope": scope,
+        "source": _source(),
+        "collector": CollectorDescriptorV1(
+            id="c", type="site.canary", implementation_version="1.0.0"
+        ),
+        "target": _target() if scope == "target" else None,
+        "severity": "info",
+        "trust_level": "authenticated",
+        "privacy_class": privacy_class,
+        "redaction_version": "r1-e1",
+        "data": EventDataV1(category="availability", status="healthy", message="ok"),
+    }
+    return finalize_record(RecordDraftV1.model_validate(values), installation_id=_INSTALLATION_ID)
+
+
+def _frame(sequence: int, *, batch_id: str = "batch-1", **envelope_kwargs: object) -> SpoolFrameV1:
+    return SpoolFrameV1(batch_id=batch_id, sequence=sequence, record=_envelope(**envelope_kwargs))  # type: ignore[arg-type]
+
+
+def _header(frames: list[SpoolFrameV1], **overrides: object) -> SegmentHeaderV1:
+    lines = [spool_frame_line(frame) for frame in frames]
+    fields: dict[str, object] = {
+        "batch_id": "batch-1",
+        "config_generation": _GENERATION,
+        "scope": "target",
+        "target_id": "example-target",
+        "privacy_class": "internal",
+        "retention_days": 30,
+        "required_exporters": ("clickhouse",),
+        "record_count": len(frames),
+        "content_sha256": spool_content_sha256(lines),
+    }
+    fields.update(overrides)
+    return SegmentHeaderV1(**fields)  # type: ignore[arg-type]
+
+
+def _private_dir(tmp_path: Path) -> Path:
+    directory = tmp_path / "pending"
+    directory.mkdir(mode=0o700)
+    os.chmod(directory, 0o700)
+    return directory
+
+
+# --- frame + header projection ------------------------------------------------------------------
+
+
+def test_frame_line_is_a_closed_canonical_record_frame() -> None:
+    frame = _frame(1)
+    line = spool_frame_line(frame)
+    assert line.endswith(b"\n")
+    assert line.count(b"\n") == 1
+    decoded = json.loads(line)
+    assert set(decoded) == {"batch_id", "frame_version", "record", "record_id", "sequence"}
+    assert decoded["batch_id"] == "batch-1"
+    assert decoded["frame_version"] == 1
+    assert decoded["sequence"] == 1
+    assert decoded["record_id"] == frame.record.record_id
+    assert decoded["record"]["record_id"] == frame.record.record_id
+
+
+def test_header_line_is_a_closed_canonical_header() -> None:
+    line = spool_segment_header_line(_header([_frame(1)]))
+    assert line.endswith(b"\n")
+    assert line.count(b"\n") == 1
+    decoded = json.loads(line)
+    assert set(decoded) == {
+        "batch_id",
+        "config_generation",
+        "content_sha256",
+        "frame_version",
+        "privacy_class",
+        "record_count",
+        "required_exporters",
+        "retention_days",
+        "schema",
+        "scope",
+        "target_id",
+    }
+    assert decoded["schema"] == 1
+    assert decoded["scope"] == "target"
+    assert decoded["target_id"] == "example-target"
+    assert decoded["required_exporters"] == ["clickhouse"]
+
+
+def test_installation_scope_header_carries_a_null_target() -> None:
+    frame = _frame(1, scope="installation")
+    header = _header([frame], scope="installation", target_id=None)
+    decoded = json.loads(spool_segment_header_line(header))
+    assert decoded["scope"] == "installation"
+    assert decoded["target_id"] is None
+
+
+def test_content_sha256_covers_the_ordered_frame_bytes() -> None:
+    lines = [spool_frame_line(_frame(1)), spool_frame_line(_frame(2, source_event_id="event-2"))]
+    assert spool_content_sha256(lines) == hashlib.sha256(b"".join(lines)).hexdigest()
+    assert spool_content_sha256([]) == hashlib.sha256(b"").hexdigest()
+
+
+def test_content_sha256_hostile_iterable_fails_closed() -> None:
+    class _Hostile:
+        def __iter__(self) -> object:
+            raise RuntimeError("SYNTHETIC_SECRET")
+
+    with pytest.raises(SpoolError) as captured:
+        spool_content_sha256(_Hostile())  # type: ignore[arg-type]
+    assert captured.value.code == "MH_SPOOL_DIGEST"
+    assert captured.value.__cause__ is None
+    assert captured.value.__context__ is None
+
+
+# --- validation ---------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("batch_id", "bad id!", "MH_SPOOL_BATCH_ID"),
+        ("sequence", 0, "MH_SPOOL_SEQUENCE"),
+        ("sequence", True, "MH_SPOOL_SEQUENCE"),
+    ],
+)
+def test_frame_rejects_invalid_fields(field: str, value: object, code: str) -> None:
+    fields: dict[str, object] = {"batch_id": "batch-1", "sequence": 1, "record": _envelope()}
+    fields[field] = value
+    with pytest.raises(SpoolError) as captured:
+        SpoolFrameV1(**fields)  # type: ignore[arg-type]
+    assert captured.value.code == code
+
+
+def test_frame_rejects_a_non_envelope_record() -> None:
+    with pytest.raises(SpoolError) as captured:
+        SpoolFrameV1(batch_id="batch-1", sequence=1, record={"record_id": "x"})  # type: ignore[arg-type]
+    assert captured.value.code == "MH_SPOOL_RECORD"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("config_generation", "z" * 64, "MH_SPOOL_CONFIG_GENERATION"),
+        ("scope", "global", "MH_SPOOL_SCOPE"),
+        ("target_id", None, "MH_SPOOL_TARGET"),  # target scope requires a target id
+        ("privacy_class", "secret", "MH_SPOOL_PRIVACY"),
+        ("retention_days", 0, "MH_SPOOL_RETENTION"),
+        ("retention_days", 3651, "MH_SPOOL_RETENTION"),
+        ("required_exporters", ("b", "a"), "MH_SPOOL_EXPORTERS"),
+        ("required_exporters", ("a", "a"), "MH_SPOOL_EXPORTERS"),
+        ("record_count", -1, "MH_SPOOL_COUNT"),
+        ("content_sha256", "A" * 64, "MH_SPOOL_DIGEST"),
+    ],
+)
+def test_header_rejects_invalid_fields(field: str, value: object, code: str) -> None:
+    with pytest.raises(SpoolError) as captured:
+        _header([_frame(1)], **{field: value})
+    assert captured.value.code == code
+
+
+def test_installation_scope_forbids_a_target_id() -> None:
+    with pytest.raises(SpoolError) as captured:
+        _header([_frame(1, scope="installation")], scope="installation")  # target_id still set
+    assert captured.value.code == "MH_SPOOL_TARGET"
+
+
+def test_models_are_immutable() -> None:
+    import dataclasses
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _frame(1).sequence = 2  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _header([_frame(1)]).record_count = 5  # type: ignore[misc]
+
+
+# --- atomic writer ------------------------------------------------------------------------------
+
+
+def test_write_publishes_the_exact_segment_bytes_owner_only(tmp_path: Path) -> None:
+    directory = _private_dir(tmp_path)
+    frames = [_frame(1), _frame(2, source_event_id="event-2")]
+    header = _header(frames)
+    path = directory / "batch-1.jsonl"
+    write_spool_segment(path, header, frames)
+
+    expected = spool_segment_header_line(header) + b"".join(spool_frame_line(f) for f in frames)
+    assert path.read_bytes() == expected
+    assert stat.S_IMODE(os.lstat(path).st_mode) == 0o600
+    assert path.read_bytes().count(b"\n") == 3  # header + two frames
+
+
+def test_write_refuses_to_overwrite_an_existing_segment(tmp_path: Path) -> None:
+    directory = _private_dir(tmp_path)
+    frames = [_frame(1)]
+    header = _header(frames)
+    path = directory / "batch-1.jsonl"
+    write_spool_segment(path, header, frames)
+    with pytest.raises(SpoolError) as captured:
+        write_spool_segment(path, header, frames)
+    assert captured.value.code == "MH_SPOOL_EXISTS"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "code"),
+    [
+        ({"record_count": 5}, "MH_SPOOL_COUNT"),
+        ({"batch_id": "other"}, "MH_SPOOL_BATCH_ID"),
+        ({"scope": "installation", "target_id": None}, "MH_SPOOL_SCOPE"),
+        ({"privacy_class": "public"}, "MH_SPOOL_PRIVACY"),
+        ({"content_sha256": "b" * 64}, "MH_SPOOL_DIGEST"),
+    ],
+)
+def test_write_rejects_a_header_inconsistent_with_the_frames(
+    tmp_path: Path, mutate: dict[str, object], code: str
+) -> None:
+    directory = _private_dir(tmp_path)
+    frames = [_frame(1)]
+    header = _header(frames, **mutate)
+    with pytest.raises(SpoolError) as captured:
+        write_spool_segment(directory / "batch-1.jsonl", header, frames)
+    assert captured.value.code == code
+
+
+def test_write_rejects_a_noncontiguous_sequence(tmp_path: Path) -> None:
+    directory = _private_dir(tmp_path)
+    frames = [_frame(1), _frame(3, source_event_id="event-3")]
+    header = _header(frames)
+    with pytest.raises(SpoolError) as captured:
+        write_spool_segment(directory / "batch-1.jsonl", header, frames)
+    assert captured.value.code == "MH_SPOOL_SEQUENCE"
+
+
+def test_write_fails_closed_when_the_parent_is_not_private(tmp_path: Path) -> None:
+    directory = tmp_path / "loose"
+    directory.mkdir()
+    os.chmod(directory, 0o777)
+    frames = [_frame(1)]
+    header = _header(frames)
+    with pytest.raises(SpoolError) as captured:
+        write_spool_segment(directory / "batch-1.jsonl", header, frames)
+    assert captured.value.code == "MH_SPOOL_WRITE"


### PR DESCRIPTION
## Summary

Second W03 slice (ADR 0004, plan §4.3): the durable **spool segment wire** and its **atomic publication**, building on the slice-1 secure-filesystem substrate. New `milhouse.spool` package. Slice **2 of 7** toward G03.

## Delivers
- **`segment.py`** — `SpoolFrameV1` binds a batch sequence to a finalized `RecordEnvelopeV1`; `SegmentHeaderV1` is the immutable header (frame/schema versions, batch id, config-generation digest, scope/target, privacy + retention, required exporter ids, expected record count, and the SHA-256 digest of the ordered frame bytes). Both project to bounded `CanonicalJSONV1` JSONL; `spool_content_sha256` covers the ordered frame bytes and fails closed on a hostile iterable.
- **`writer.py`** — `write_spool_segment` validates header↔frames consistency (batch id, scope, target, privacy, contiguous sequences, exact count, digest), then publishes via the W02 secure atomic-publish (write→flush→fsync→no-replace-rename→parent-fsync). Never overwrites an existing name.

## Safety & tests
Every failure raises a fixed `MH_SPOOL_*` error outside the handler. 31 tests: frame/header projection + key sets, digest coverage + hostile-iterable boundary, the full field-validation matrix, byte-exact owner-only atomic publication, no-overwrite, consistency rejections, and a **cross-process determinism proof** (varied hash seed/locale/timezone) added to the macOS `identity-portability` target.

`make quality`/`test` pass (**3850 passed**); global coverage floor holds. Spool modules ~92% branch; they join the enforced 95% `--critical` set in the W03 failure-injection slice.

## Note
The repo `.gitignore` had a generic `spool/` rule (for the runtime spool dir) that also excluded the new `src/milhouse/spool/` **source** package. Added a targeted negation so the source is tracked while runtime spool data (and build artifacts) stay ignored.