### PR TITLE
feat(spooling): W03 durable segment commit + ledger (slice 3a)

### DIFF
--- a/src/milhouse/spooling/__init__.py
+++ b/src/milhouse/spooling/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from milhouse.spooling.commit import (
+    DurableSpool,
+    ExporterDelivery,
+    SegmentRecord,
+)
 from milhouse.spooling.errors import SpoolError
 from milhouse.spooling.segment import (
     SegmentHeaderV1,
@@ -10,12 +15,21 @@ from milhouse.spooling.segment import (
     spool_frame_line,
     spool_segment_header_line,
 )
-from milhouse.spooling.writer import write_spool_segment
+from milhouse.spooling.writer import (
+    build_segment_bytes,
+    publish_segment_bytes,
+    write_spool_segment,
+)
 
 __all__ = [
+    "DurableSpool",
+    "ExporterDelivery",
     "SegmentHeaderV1",
+    "SegmentRecord",
     "SpoolError",
     "SpoolFrameV1",
+    "build_segment_bytes",
+    "publish_segment_bytes",
     "spool_content_sha256",
     "spool_frame_line",
     "spool_segment_header_line",

--- a/src/milhouse/spooling/commit.py
+++ b/src/milhouse/spooling/commit.py
@@ -1,0 +1,409 @@
+"""Durable spool commit and segment ledger, bound to one control plane (W03 slice 3a).
+
+A :class:`DurableSpool` binds one control database, one commit barrier, and one spool root that all
+live under the same canonical state root, so a caller cannot publish under a different barrier than
+maintenance holds. Per ADR 0004 and plan section 4.7 a commit is a deliberate, authorized,
+reconciled operation: it authorizes the ``local_spool`` and ``local_sqlite`` egress surfaces
+(restricted input is rejected before any mutation), derives the ``YYYY-MM-DD`` partition from the
+commit instant, then, while holding the shared commit barrier, creates the partition directory,
+atomically publishes the exact segment bytes (write, flush, fsync, no-replace rename, parent fsync),
+and inserts the segment ledger row plus one row per required exporter in a single SQLite
+transaction. A crash or ledger failure after publication leaves a durable orphan and is reported as
+commit-uncertain ``MH_SPOOL_COMMIT``, never as success. The ledger preserves every immutable header
+field so recovery never infers policy from newer configuration, and every read is semantically
+validated so a corrupt or foreign row fails closed with ``MH_SPOOL_LEDGER``. Every failure raises a
+fixed ``MH_SPOOL_*`` error outside the handler.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import sqlite3
+import stat
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, NoReturn
+
+from milhouse.config.filesystem import lexical_absolute_path
+from milhouse.core.clock import TimeError, format_timestamp
+from milhouse.privacy import (
+    EgressDisposition,
+    EgressSurface,
+    PrivacyError,
+    require_egress,
+)
+from milhouse.spooling.errors import SpoolError
+from milhouse.spooling.segment import (
+    EXPORTER_ID_PATTERN,
+    FRAME_VERSION,
+    SCHEMA_VERSION,
+    SegmentHeaderV1,
+    SpoolFrameV1,
+)
+from milhouse.spooling.writer import build_segment_bytes, publish_segment_bytes
+from milhouse.state.barrier import GlobalCommitBarrier
+from milhouse.state.database import ControlDatabase
+from milhouse.state.errors import StateError
+
+_SPOOL = "spool"
+_BARRIER_NAME = "commit.lock"
+_PENDING = "pending"
+_DIR_MODE = 0o700
+_DELIVERY_PENDING = "pending"
+_DAY_LENGTH = 10
+_SCOPES = ("installation", "target")
+_ALLOWED_PRIVACY = ("public", "internal", "sensitive")
+_DELIVERY_STATES = ("pending", "delivered", "failed")
+_SHA256_HEX = re.compile(r"[0-9a-f]{64}", flags=re.ASCII)
+_STAMP = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z", flags=re.ASCII
+)
+_SEGMENT_COLUMNS = (
+    "batch_id",
+    "day",
+    "schema_version",
+    "frame_version",
+    "config_generation",
+    "scope",
+    "target_id",
+    "privacy_class",
+    "retention_days",
+    "record_count",
+    "content_sha256",
+    "byte_size",
+    "file_sha256",
+    "committed_at",
+)
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise SpoolError(code, message)
+
+
+def _current_uid() -> int:
+    # Match the W02 secure-file writer (filesystem.py), which validates against the effective uid.
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:  # pragma: no cover - Milhouse supports only POSIX hosts
+        _fail("MH_SPOOL_UNSUPPORTED", "the spool requires a POSIX ownership model")
+    return int(geteuid())
+
+
+@dataclass(frozen=True, slots=True)
+class ExporterDelivery:
+    """The delivery state of one required exporter for a committed segment."""
+
+    exporter_id: str
+    delivery_status: str
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentRecord:
+    """A committed segment's immutable ledger row plus its per-exporter delivery rows."""
+
+    batch_id: str
+    day: str
+    schema_version: int
+    frame_version: int
+    config_generation: str
+    scope: str
+    target_id: str | None
+    privacy_class: str
+    retention_days: int
+    record_count: int
+    content_sha256: str
+    byte_size: int
+    file_sha256: str
+    committed_at: str
+    exporters: tuple[ExporterDelivery, ...]
+
+
+def _authorize(privacy_class: str) -> None:
+    denied = False
+    dispositions: tuple[EgressDisposition, ...] = ()
+    try:
+        dispositions = tuple(
+            require_egress(surface=surface, privacy_class=privacy_class)  # type: ignore[arg-type]
+            for surface in (EgressSurface.LOCAL_SPOOL, EgressSurface.LOCAL_SQLITE)
+        )
+    except PrivacyError:
+        denied = True
+    if denied or any(d is not EgressDisposition.REDACTED_RECORD for d in dispositions):
+        _fail(
+            "MH_SPOOL_EGRESS", "the local persistence surfaces do not authorize this privacy class"
+        )
+
+
+def _committed_stamp(committed_at: datetime) -> str:
+    invalid = False
+    stamp = ""
+    try:
+        stamp = format_timestamp(committed_at)
+    except (OverflowError, TimeError):
+        invalid = True
+    if invalid:
+        _fail("MH_SPOOL_COMMIT", "the commit timestamp must be an aware in-range UTC instant")
+    return stamp
+
+
+def _require_private_dir(path: Path, subject: str) -> None:
+    info: os.stat_result | None
+    try:
+        info = os.lstat(path)
+    except OSError:
+        info = None
+    if (
+        info is None
+        or stat.S_ISLNK(info.st_mode)
+        or not stat.S_ISDIR(info.st_mode)
+        or info.st_uid != _current_uid()
+        or stat.S_IMODE(info.st_mode) != _DIR_MODE
+    ):
+        _fail("MH_SPOOL_DIR", f"the {subject} must be an owned 0o700 directory")
+
+
+def _secure_child_dir(parent: Path, name: str) -> Path:
+    child = parent / name
+    create_failed = False
+    try:
+        os.mkdir(child, _DIR_MODE)
+    except FileExistsError:
+        pass
+    except OSError:
+        create_failed = True
+    if create_failed:
+        _fail("MH_SPOOL_DIR", "a spool directory could not be created")
+    _require_private_dir(child, "spool directory")
+    return child
+
+
+def _pending_day_dir(spool_root: Path, day: str) -> Path:
+    _require_private_dir(spool_root, "spool root")
+    return _secure_child_dir(_secure_child_dir(spool_root, _PENDING), day)
+
+
+def _insert_ledger(database: ControlDatabase, record: SegmentRecord) -> None:
+    segment_values = (
+        record.batch_id,
+        record.day,
+        record.schema_version,
+        record.frame_version,
+        record.config_generation,
+        record.scope,
+        record.target_id,
+        record.privacy_class,
+        record.retention_days,
+        record.record_count,
+        record.content_sha256,
+        record.byte_size,
+        record.file_sha256,
+        record.committed_at,
+    )
+    placeholders = ", ".join("?" for _ in _SEGMENT_COLUMNS)
+    failed = False
+    try:
+        with database.transaction() as connection:
+            connection.execute(
+                f"INSERT INTO _segments ({', '.join(_SEGMENT_COLUMNS)}) VALUES ({placeholders})",
+                segment_values,
+            )
+            for exporter in record.exporters:
+                connection.execute(
+                    "INSERT INTO _segment_exporters (batch_id, exporter_id, delivery_status) "
+                    "VALUES (?, ?, ?)",
+                    (record.batch_id, exporter.exporter_id, exporter.delivery_status),
+                )
+    except (sqlite3.Error, StateError):
+        # The file is durably published; any ledger or transaction-boundary failure leaves a
+        # registrable orphan and is reported as commit-uncertain, never as success.
+        failed = True
+    if failed:
+        _fail("MH_SPOOL_COMMIT", "the segment ledger could not be committed")
+
+
+def _validated_segment(row: Any, exporters: tuple[ExporterDelivery, ...]) -> SegmentRecord:
+    """Reconstruct a SegmentRecord, raising ValueError on any semantic violation (caught above)."""
+
+    day = str(row[1])
+    datetime.strptime(day, "%Y-%m-%d")  # a bare partition date, not an instant
+    schema_version = int(row[2])
+    frame_version = int(row[3])
+    config_generation = str(row[4])
+    scope = str(row[5])
+    target_id = None if row[6] is None else str(row[6])
+    privacy_class = str(row[7])
+    retention_days = int(row[8])
+    record_count = int(row[9])
+    content_sha256 = str(row[10])
+    byte_size = int(row[11])
+    file_sha256 = str(row[12])
+    committed_at = str(row[13])
+    if schema_version != SCHEMA_VERSION or frame_version != FRAME_VERSION:
+        raise ValueError("unexpected schema or frame version")
+    if _SHA256_HEX.fullmatch(config_generation) is None:
+        raise ValueError("config_generation is not a sha-256 digest")
+    if scope not in _SCOPES or (scope == "target") != (target_id is not None):
+        raise ValueError("scope/target relation is invalid")
+    if privacy_class not in _ALLOWED_PRIVACY:
+        raise ValueError("privacy class is invalid")
+    if not 1 <= retention_days <= 3650 or record_count < 0 or byte_size <= 0:
+        raise ValueError("retention/count/size out of bounds")
+    if _SHA256_HEX.fullmatch(content_sha256) is None or _SHA256_HEX.fullmatch(file_sha256) is None:
+        raise ValueError("a digest is not a sha-256")
+    if _STAMP.fullmatch(committed_at) is None or committed_at[:_DAY_LENGTH] != day:
+        raise ValueError("committed_at is not a canonical stamp matching the day")
+    return SegmentRecord(
+        batch_id=str(row[0]),
+        day=day,
+        schema_version=schema_version,
+        frame_version=frame_version,
+        config_generation=config_generation,
+        scope=scope,
+        target_id=target_id,
+        privacy_class=privacy_class,
+        retention_days=retention_days,
+        record_count=record_count,
+        content_sha256=content_sha256,
+        byte_size=byte_size,
+        file_sha256=file_sha256,
+        committed_at=committed_at,
+        exporters=exporters,
+    )
+
+
+def _load_exporters(connection: sqlite3.Connection, batch_id: str) -> tuple[ExporterDelivery, ...]:
+    rows = connection.execute(
+        "SELECT exporter_id, delivery_status FROM _segment_exporters WHERE batch_id = ? "
+        "ORDER BY exporter_id",
+        (batch_id,),
+    ).fetchall()
+    exporters: list[ExporterDelivery] = []
+    for exporter_id, delivery_status in rows:
+        identifier = str(exporter_id)
+        status = str(delivery_status)
+        if EXPORTER_ID_PATTERN.fullmatch(identifier) is None:
+            raise ValueError("exporter id is not well formed")
+        if status not in _DELIVERY_STATES:
+            raise ValueError("delivery status is invalid")
+        exporters.append(ExporterDelivery(exporter_id=identifier, delivery_status=status))
+    return tuple(exporters)
+
+
+class DurableSpool:
+    """A durable spool bound to one control database, commit barrier, and spool root."""
+
+    __slots__ = ("_barrier", "_database", "_spool_root")
+
+    def __init__(
+        self,
+        *,
+        database: ControlDatabase,
+        barrier: GlobalCommitBarrier,
+        spool_root: str | Path,
+    ) -> None:
+        if not isinstance(database, ControlDatabase):
+            _fail("MH_SPOOL_STORE", "a control database is required")
+        if not isinstance(barrier, GlobalCommitBarrier):
+            _fail("MH_SPOOL_STORE", "a commit barrier is required")
+        control_dir = lexical_absolute_path(database.path).parent
+        state_root = control_dir.parent
+        resolved_spool = lexical_absolute_path(spool_root)
+        if lexical_absolute_path(barrier.path) != control_dir / _BARRIER_NAME:
+            # Pin the exact lock, not just its directory: a barrier on a different file beside the
+            # database would share no flock with maintenance, so publication would race a backup or
+            # migration despite the barrier being "held".
+            _fail("MH_SPOOL_STORE", "the barrier must be the control-plane commit lock")
+        if resolved_spool != state_root / _SPOOL:
+            _fail("MH_SPOOL_STORE", "the spool root must be <state_root>/spool")
+        self._database = database
+        self._barrier = barrier
+        self._spool_root = resolved_spool
+
+    def commit_segment(
+        self,
+        header: SegmentHeaderV1,
+        frames: tuple[SpoolFrameV1, ...] | list[SpoolFrameV1],
+        *,
+        committed_at: datetime,
+    ) -> SegmentRecord:
+        """Authorize, publish, and record one segment under the shared commit barrier."""
+
+        if not isinstance(header, SegmentHeaderV1):
+            _fail("MH_SPOOL_HEADER", "a segment header is required")
+        _authorize(header.privacy_class)
+        stamp = _committed_stamp(committed_at)
+        day = stamp[:_DAY_LENGTH]
+        content = build_segment_bytes(header, frames)
+        record = SegmentRecord(
+            batch_id=header.batch_id,
+            day=day,
+            schema_version=SCHEMA_VERSION,
+            frame_version=FRAME_VERSION,
+            config_generation=header.config_generation,
+            scope=header.scope,
+            target_id=header.target_id,
+            privacy_class=header.privacy_class,
+            retention_days=header.retention_days,
+            record_count=header.record_count,
+            content_sha256=header.content_sha256,
+            byte_size=len(content),
+            file_sha256=hashlib.sha256(content).hexdigest(),
+            committed_at=stamp,
+            exporters=tuple(
+                ExporterDelivery(exporter_id=exporter, delivery_status=_DELIVERY_PENDING)
+                for exporter in header.required_exporters
+            ),
+        )
+        with self._barrier.shared():
+            day_dir = _pending_day_dir(self._spool_root, day)
+            publish_segment_bytes(day_dir / f"{header.batch_id}.jsonl", content)
+            _insert_ledger(self._database, record)
+        return record
+
+    def read_segment(self, batch_id: str) -> SegmentRecord | None:
+        """Return the committed segment ledger record for ``batch_id``, or None. Read-only."""
+
+        failed = False
+        result: SegmentRecord | None = None
+        try:
+            connection = self._database.connection
+            row = connection.execute(
+                f"SELECT {', '.join(_SEGMENT_COLUMNS)} FROM _segments WHERE batch_id = ?",
+                (batch_id,),
+            ).fetchone()
+            if row is not None:
+                result = _validated_segment(row, _load_exporters(connection, str(row[0])))
+        except (sqlite3.Error, ValueError, TypeError):
+            failed = True
+        if failed:
+            _fail("MH_SPOOL_LEDGER", "the segment ledger could not be read")
+        return result
+
+    def list_segments(self, *, delivery_status: str | None = None) -> tuple[SegmentRecord, ...]:
+        """Return committed segments, optionally only those with an exporter in the given status."""
+
+        failed = False
+        records: tuple[SegmentRecord, ...] = ()
+        try:
+            connection = self._database.connection
+            if delivery_status is None:
+                rows = connection.execute(
+                    f"SELECT {', '.join(_SEGMENT_COLUMNS)} FROM _segments ORDER BY batch_id"
+                ).fetchall()
+            else:
+                rows = connection.execute(
+                    f"SELECT {', '.join('s.' + c for c in _SEGMENT_COLUMNS)} FROM _segments s "
+                    "WHERE EXISTS (SELECT 1 FROM _segment_exporters e "
+                    "WHERE e.batch_id = s.batch_id AND e.delivery_status = ?) ORDER BY s.batch_id",
+                    (delivery_status,),
+                ).fetchall()
+            records = tuple(
+                _validated_segment(row, _load_exporters(connection, str(row[0]))) for row in rows
+            )
+        except (sqlite3.Error, ValueError, TypeError):
+            failed = True
+        if failed:
+            _fail("MH_SPOOL_LEDGER", "the segment ledger could not be read")
+        return records

--- a/src/milhouse/spooling/segment.py
+++ b/src/milhouse/spooling/segment.py
@@ -31,11 +31,12 @@ MAX_FRAME_LINE_BYTES = 262_144 + 1_024  # a canonical record plus the small fram
 MAX_RETENTION_DAYS = 3_650  # matches the config `[retention]` ceiling
 
 _BATCH_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", flags=re.ASCII)
-_EXPORTER_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", flags=re.ASCII)
+EXPORTER_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", flags=re.ASCII)
 _TARGET_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,255}", flags=re.ASCII)
 _SHA256_HEX_PATTERN = re.compile(r"[0-9a-f]{64}", flags=re.ASCII)
 _SCOPES = ("installation", "target")
-_PRIVACY_CLASSES = ("public", "internal", "sensitive", "restricted")
+# A canonical record can never be restricted (RecordDraftV1 forbids it); a segment cannot be either.
+_ALLOWED_PRIVACY = ("public", "internal", "sensitive")
 
 
 def _fail(code: str, message: str) -> NoReturn:
@@ -100,8 +101,8 @@ class SegmentHeaderV1:
                 _fail("MH_SPOOL_TARGET", "target scope requires a bounded target id")
         elif self.target_id is not None:
             _fail("MH_SPOOL_TARGET", "installation scope forbids a target id")
-        if self.privacy_class not in _PRIVACY_CLASSES:
-            _fail("MH_SPOOL_PRIVACY", "a valid privacy class is required")
+        if self.privacy_class not in _ALLOWED_PRIVACY:
+            _fail("MH_SPOOL_PRIVACY", "a non-restricted privacy class is required")
         if (
             type(self.retention_days) is not int
             or not 0 < self.retention_days <= MAX_RETENTION_DAYS
@@ -110,7 +111,7 @@ class SegmentHeaderV1:
         if type(self.required_exporters) is not tuple:
             _fail("MH_SPOOL_EXPORTERS", "required exporters must be a tuple")
         for exporter in self.required_exporters:
-            if type(exporter) is not str or _EXPORTER_ID_PATTERN.fullmatch(exporter) is None:
+            if type(exporter) is not str or EXPORTER_ID_PATTERN.fullmatch(exporter) is None:
                 _fail("MH_SPOOL_EXPORTERS", "each exporter id must be bounded safe text")
         if list(self.required_exporters) != sorted(set(self.required_exporters)):
             _fail("MH_SPOOL_EXPORTERS", "required exporters must be sorted and unique")

--- a/src/milhouse/spooling/writer.py
+++ b/src/milhouse/spooling/writer.py
@@ -56,7 +56,7 @@ def _validate_consistency(header: SegmentHeaderV1, frames: tuple[SpoolFrameV1, .
             _fail("MH_SPOOL_PRIVACY", "each frame privacy class must match the header")
 
 
-def _atomic_publish(path: str | Path, content: bytes) -> None:
+def publish_segment_bytes(path: str | Path, content: bytes) -> None:
     exists = False
     failed = False
     try:
@@ -74,13 +74,13 @@ def _atomic_publish(path: str | Path, content: bytes) -> None:
         _fail("MH_SPOOL_WRITE", "the segment could not be durably published")
 
 
-def write_spool_segment(
-    path: str | Path, header: SegmentHeaderV1, frames: tuple[SpoolFrameV1, ...] | list[SpoolFrameV1]
-) -> None:
-    """Atomically publish a self-describing segment whose header and frames are mutually consistent.
+def build_segment_bytes(
+    header: SegmentHeaderV1, frames: tuple[SpoolFrameV1, ...] | list[SpoolFrameV1]
+) -> bytes:
+    """Validate header/frame consistency and return the exact segment bytes (header line + frames).
 
     The header must already carry the digest of the ordered frame bytes; this re-validates it so the
-    published segment is internally verifiable. Publication never overwrites an existing name.
+    returned bytes are internally verifiable. Raises a fixed ``MH_SPOOL_*`` error on any mismatch.
     """
 
     if not isinstance(header, SegmentHeaderV1):
@@ -92,5 +92,15 @@ def write_spool_segment(
     frame_lines = [spool_frame_line(frame) for frame in frame_tuple]
     if spool_content_sha256(frame_lines) != header.content_sha256:
         _fail("MH_SPOOL_DIGEST", "the header digest does not match the frame bytes")
-    content = spool_segment_header_line(header) + b"".join(frame_lines)
-    _atomic_publish(path, content)
+    return spool_segment_header_line(header) + b"".join(frame_lines)
+
+
+def write_spool_segment(
+    path: str | Path, header: SegmentHeaderV1, frames: tuple[SpoolFrameV1, ...] | list[SpoolFrameV1]
+) -> None:
+    """Atomically publish a self-describing segment whose header and frames are mutually consistent.
+
+    Publication never overwrites an existing name.
+    """
+
+    publish_segment_bytes(path, build_segment_bytes(header, frames))

--- a/src/milhouse/state/schema.py
+++ b/src/milhouse/state/schema.py
@@ -28,6 +28,46 @@ CONTROL_MIGRATIONS: tuple[Migration, ...] = (
             "expires_at TEXT NOT NULL)",
         ),
     ),
+    Migration(
+        2,
+        "create_segments",
+        (
+            "CREATE TABLE _segments ("
+            "batch_id TEXT PRIMARY KEY NOT NULL, "
+            "day TEXT NOT NULL, "
+            "schema_version INTEGER NOT NULL, "
+            "frame_version INTEGER NOT NULL, "
+            "config_generation TEXT NOT NULL, "
+            "scope TEXT NOT NULL, "
+            "target_id TEXT, "
+            "privacy_class TEXT NOT NULL, "
+            "retention_days INTEGER NOT NULL, "
+            "record_count INTEGER NOT NULL, "
+            "content_sha256 TEXT NOT NULL, "
+            "byte_size INTEGER NOT NULL, "
+            "file_sha256 TEXT NOT NULL, "
+            "committed_at TEXT NOT NULL, "
+            "CHECK (schema_version = 1), "
+            "CHECK (frame_version = 1), "
+            "CHECK (length(config_generation) = 64), "
+            "CHECK (length(day) = 10), "
+            "CHECK (scope IN ('installation', 'target')), "
+            "CHECK ((scope = 'target') = (target_id IS NOT NULL)), "
+            "CHECK (privacy_class IN ('public', 'internal', 'sensitive')), "
+            "CHECK (retention_days BETWEEN 1 AND 3650), "
+            "CHECK (record_count >= 0), "
+            "CHECK (length(content_sha256) = 64), "
+            "CHECK (byte_size > 0), "
+            "CHECK (length(file_sha256) = 64))",
+            "CREATE TABLE _segment_exporters ("
+            "batch_id TEXT NOT NULL REFERENCES _segments (batch_id), "
+            "exporter_id TEXT NOT NULL, "
+            "delivery_status TEXT NOT NULL, "
+            "PRIMARY KEY (batch_id, exporter_id), "
+            "CHECK (delivery_status IN ('pending', 'delivered', 'failed')))",
+            "CREATE INDEX _segment_exporters_by_status ON _segment_exporters (delivery_status)",
+        ),
+    ),
 )
 
 

--- a/tests/unit/test_spool_commit.py
+++ b/tests/unit/test_spool_commit.py
@@ -1,0 +1,536 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import os
+import sqlite3
+import stat
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from milhouse.domain.records import (
+    CollectorDescriptorV1,
+    EventDataV1,
+    RecordDraftV1,
+    RecordEnvelopeV1,
+    SourceDescriptorV1,
+    TargetDescriptorV1,
+    finalize_record,
+)
+from milhouse.spooling import (
+    DurableSpool,
+    SegmentHeaderV1,
+    SegmentRecord,
+    SpoolError,
+    SpoolFrameV1,
+    build_segment_bytes,
+    spool_content_sha256,
+    spool_frame_line,
+)
+from milhouse.spooling.commit import _authorize, _validated_segment
+from milhouse.state import (
+    GlobalCommitBarrier,
+    StateError,
+    initialize_control_state,
+    open_control_database,
+    schema_version,
+)
+
+_INSTALLATION_ID = "mh_in1_00000000000040008000000000000000"
+_NOW = datetime(2026, 7, 24, 12, 0, 0, tzinfo=UTC)
+_DAY = "2026-07-24"
+_GENERATION = "a" * 64
+
+
+def _envelope(
+    privacy_class: str = "internal", source_event_id: str = "event-1"
+) -> RecordEnvelopeV1:
+    values: dict[str, object] = {
+        "record_type": "event",
+        "name": "source.event",
+        "occurred_at": _NOW,
+        "observed_at": _NOW + timedelta(seconds=1),
+        "ingested_at": _NOW + timedelta(seconds=2),
+        "expires_at": _NOW + timedelta(days=30),
+        "source_event_id": source_event_id,
+        "operation_id": "operation-1",
+        "collector_run_id": "collector-run-1",
+        "scope": "target",
+        "source": SourceDescriptorV1.model_validate(
+            {
+                "id": "example-source",
+                "type": "source.event",
+                "producer": "collector",
+                "observation_namespace_id": "mh_ns1_00000000000040008000000000000000",
+                "source_generation_digest": "0" * 64,
+                "observation": {"kind": "source.revision", "parts": {"revision": 1}},
+            }
+        ),
+        "collector": CollectorDescriptorV1(
+            id="c", type="site.canary", implementation_version="1.0.0"
+        ),
+        "target": TargetDescriptorV1(
+            id="example-target", name="E", kind="web.service", environment="test"
+        ),
+        "severity": "info",
+        "trust_level": "authenticated",
+        "privacy_class": privacy_class,
+        "redaction_version": "r1-e1",
+        "data": EventDataV1(category="availability", status="healthy", message="ok"),
+    }
+    return finalize_record(RecordDraftV1.model_validate(values), installation_id=_INSTALLATION_ID)
+
+
+def _frames(privacy_class: str = "internal") -> list[SpoolFrameV1]:
+    return [
+        SpoolFrameV1(batch_id="batch-1", sequence=1, record=_envelope(privacy_class, "event-1")),
+        SpoolFrameV1(batch_id="batch-1", sequence=2, record=_envelope(privacy_class, "event-2")),
+    ]
+
+
+def _header(
+    frames: list[SpoolFrameV1],
+    *,
+    privacy_class: str = "internal",
+    exporters: tuple[str, ...] = ("clickhouse",),
+) -> SegmentHeaderV1:
+    lines = [spool_frame_line(frame) for frame in frames]
+    return SegmentHeaderV1(
+        batch_id="batch-1",
+        config_generation=_GENERATION,
+        scope="target",
+        target_id="example-target",
+        privacy_class=privacy_class,
+        retention_days=30,
+        required_exporters=exporters,
+        record_count=len(frames),
+        content_sha256=spool_content_sha256(lines),
+    )
+
+
+def _spool(tmp_path: Path):
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    os.chmod(control, 0o700)
+    database = open_control_database(control / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(control / "commit.lock")
+    initialize_control_state(database, barrier=barrier, applied_at=_NOW)
+    spool_root = tmp_path / "spool"
+    spool_root.mkdir(mode=0o700)
+    os.chmod(spool_root, 0o700)
+    store = DurableSpool(database=database, barrier=barrier, spool_root=spool_root)
+    return database, store, spool_root
+
+
+def test_migration_creates_the_segment_and_exporter_ledgers(tmp_path: Path) -> None:
+    database, _store, _spool_root = _spool(tmp_path)
+    try:
+        assert schema_version(database) == 2
+        tables = {
+            row[0]
+            for row in database.connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert {"_segments", "_segment_exporters"} <= tables
+    finally:
+        database.close()
+
+
+@pytest.mark.parametrize("privacy_class", ["public", "internal", "sensitive"])
+def test_commit_publishes_and_records_each_authorized_privacy_class(
+    tmp_path: Path, privacy_class: str
+) -> None:
+    database, store, spool_root = _spool(tmp_path)
+    try:
+        frames = _frames(privacy_class)
+        header = _header(frames, privacy_class=privacy_class)
+        record = store.commit_segment(header, frames, committed_at=_NOW)
+        assert isinstance(record, SegmentRecord)
+        assert record.privacy_class == privacy_class
+
+        path = spool_root / "pending" / _DAY / "batch-1.jsonl"
+        content = build_segment_bytes(header, frames)
+        assert path.read_bytes() == content
+        assert stat.S_IMODE(os.lstat(path).st_mode) == 0o600
+        # the ledger digest/size describe the exact published bytes (single snapshot)
+        assert record.byte_size == len(content)
+        assert record.file_sha256 == hashlib.sha256(path.read_bytes()).hexdigest()
+    finally:
+        database.close()
+
+
+def test_restricted_is_rejected_and_leaves_no_directory_file_or_row(tmp_path: Path) -> None:
+    database, _store, spool_root = _spool(tmp_path)
+    try:
+        # a restricted segment cannot even be constructed: the header rejects it up front
+        with pytest.raises(SpoolError) as captured:
+            _header(_frames(), privacy_class="restricted")
+        assert captured.value.code == "MH_SPOOL_PRIVACY"
+        # no persistence occurred
+        assert not (spool_root / "pending").exists()
+        assert database.connection.execute("SELECT count(*) FROM _segments").fetchone()[0] == 0
+    finally:
+        database.close()
+
+
+def test_the_ledger_preserves_every_immutable_header_field(tmp_path: Path) -> None:
+    database, store, _spool_root = _spool(tmp_path)
+    try:
+        frames = _frames()
+        header = _header(frames)
+        store.commit_segment(header, frames, committed_at=_NOW)
+        record = store.read_segment("batch-1")
+        assert record is not None
+        assert record.schema_version == 1
+        assert record.frame_version == 1
+        assert record.config_generation == _GENERATION
+        assert record.scope == "target"
+        assert record.target_id == "example-target"
+        assert record.retention_days == 30
+        assert record.content_sha256 == header.content_sha256
+        assert record.day == _DAY
+    finally:
+        database.close()
+
+
+@pytest.mark.parametrize("exporters", [(), ("clickhouse",), ("alpha", "beta")])
+def test_commit_records_one_row_per_required_exporter(
+    tmp_path: Path, exporters: tuple[str, ...]
+) -> None:
+    database, store, _spool_root = _spool(tmp_path)
+    try:
+        frames = _frames()
+        header = _header(frames, exporters=exporters)
+        record = store.commit_segment(header, frames, committed_at=_NOW)
+        assert tuple(e.exporter_id for e in record.exporters) == exporters
+        assert all(e.delivery_status == "pending" for e in record.exporters)
+        assert store.read_segment("batch-1") == record
+        rows = database.connection.execute(
+            "SELECT count(*) FROM _segment_exporters WHERE batch_id = 'batch-1'"
+        ).fetchone()[0]
+        assert rows == len(exporters)
+    finally:
+        database.close()
+
+
+def test_list_segments_filters_by_exporter_delivery_status(tmp_path: Path) -> None:
+    database, store, _spool_root = _spool(tmp_path)
+    try:
+        frames = _frames()
+        record = store.commit_segment(_header(frames), frames, committed_at=_NOW)
+        assert store.list_segments() == (record,)
+        assert store.list_segments(delivery_status="pending") == (record,)
+        assert store.list_segments(delivery_status="delivered") == ()
+    finally:
+        database.close()
+
+
+def test_the_partition_day_is_derived_from_the_commit_instant(tmp_path: Path) -> None:
+    database, store, spool_root = _spool(tmp_path)
+    try:
+        # a non-UTC instant just before UTC midnight normalizes to the next UTC day
+        eastern_evening = datetime(2026, 3, 1, 23, 30, tzinfo=timezone(timedelta(hours=-5)))
+        frames = _frames()
+        record = store.commit_segment(_header(frames), frames, committed_at=eastern_evening)
+        assert record.day == "2026-03-02"  # 23:30 UTC-5 == 04:30Z next day
+        assert (spool_root / "pending" / "2026-03-02" / "batch-1.jsonl").exists()
+    finally:
+        database.close()
+
+
+def test_a_naive_commit_instant_fails_closed(tmp_path: Path) -> None:
+    database, store, _spool_root = _spool(tmp_path)
+    try:
+        frames = _frames()
+        with pytest.raises(SpoolError) as captured:
+            store.commit_segment(_header(frames), frames, committed_at=datetime(2026, 7, 24, 12, 0))
+        assert captured.value.code == "MH_SPOOL_COMMIT"
+    finally:
+        database.close()
+
+
+def test_a_semantically_corrupt_ledger_row_fails_closed(tmp_path: Path) -> None:
+    database, store, _spool_root = _spool(tmp_path)
+    try:
+        # length-10 but not a real calendar date: passes the CHECK, must fail read-time validation
+        with database.transaction() as connection:
+            connection.execute(
+                "INSERT INTO _segments (batch_id, day, schema_version, frame_version, "
+                "config_generation, scope, target_id, privacy_class, retention_days, record_count, "
+                "content_sha256, byte_size, file_sha256, committed_at) VALUES "
+                "('b', '2026-13-45', 1, 1, ?, 'target', 't', 'internal', 30, 1, ?, 10, ?, "
+                "'2026-13-45T00:00:00.000Z')",
+                ("a" * 64, "b" * 64, "c" * 64),
+            )
+        with pytest.raises(SpoolError) as read_error:
+            store.read_segment("b")
+        assert read_error.value.code == "MH_SPOOL_LEDGER"
+        with pytest.raises(SpoolError) as list_error:
+            store.list_segments()
+        assert list_error.value.code == "MH_SPOOL_LEDGER"
+    finally:
+        database.close()
+
+
+# A valid ledger row in _SEGMENT_COLUMNS order, then one mutation per column a read must reject.
+# Most of these are also blocked by a table CHECK, so this exercises the read-time validator
+# directly (its defense behind those constraints) and gives per-column MH_SPOOL_LEDGER evidence.
+_VALID_ROW: tuple[object, ...] = (
+    "batch-1",
+    _DAY,
+    1,
+    1,
+    "a" * 64,
+    "target",
+    "example-target",
+    "internal",
+    30,
+    2,
+    "c" * 64,
+    100,
+    "d" * 64,
+    "2026-07-24T00:00:00.000Z",
+)
+
+
+def _mutate(index: int, value: object) -> tuple[object, ...]:
+    row = list(_VALID_ROW)
+    row[index] = value
+    return tuple(row)
+
+
+def test_a_valid_row_reconstructs_a_segment_record() -> None:
+    record = _validated_segment(_VALID_ROW, ())
+    assert record.batch_id == "batch-1"
+    assert record.day == _DAY
+    assert record.committed_at == "2026-07-24T00:00:00.000Z"
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        _mutate(1, "2026-13-45"),  # day: length 10 but not a calendar date
+        _mutate(2, 2),  # schema_version
+        _mutate(3, 2),  # frame_version
+        _mutate(4, "z" * 64),  # config_generation: not hex
+        _mutate(5, "cluster"),  # scope: not an allowed scope
+        _mutate(6, None),  # target scope but no target id
+        _mutate(5, "installation"),  # installation scope but a target id is present
+        _mutate(7, "restricted"),  # privacy class
+        _mutate(8, 0),  # retention below the floor
+        _mutate(8, 4000),  # retention above the ceiling
+        _mutate(9, -1),  # negative record count
+        _mutate(11, 0),  # non-positive byte size
+        _mutate(10, "z" * 64),  # content digest: not hex
+        _mutate(12, "z" * 64),  # file digest: not hex
+        _mutate(13, "not-a-stamp"),  # committed_at: not a canonical stamp
+        _mutate(13, "2025-01-01T00:00:00.000Z"),  # canonical stamp, wrong day
+    ],
+)
+def test_every_semantically_invalid_column_is_rejected(row: tuple[object, ...]) -> None:
+    with pytest.raises(ValueError):
+        _validated_segment(row, ())
+
+
+def test_a_malformed_exporter_id_fails_closed(tmp_path: Path) -> None:
+    # The _segment_exporters table constrains delivery_status but not exporter_id shape, so a
+    # foreign or tampered exporter row must still fail closed on read.
+    database, store, _spool_root = _spool(tmp_path)
+    try:
+        frames = _frames()
+        store.commit_segment(_header(frames), frames, committed_at=_NOW)
+        with database.transaction() as connection:
+            connection.execute(
+                "INSERT INTO _segment_exporters (batch_id, exporter_id, delivery_status) "
+                "VALUES ('batch-1', ?, 'pending')",
+                ("not a valid id",),
+            )
+        with pytest.raises(SpoolError) as captured:
+            store.read_segment("batch-1")
+        assert captured.value.code == "MH_SPOOL_LEDGER"
+    finally:
+        database.close()
+
+
+def test_check_constraints_reject_an_invalid_write(tmp_path: Path) -> None:
+    database, _store, _spool_root = _spool(tmp_path)
+    try:
+        with pytest.raises(sqlite3.IntegrityError):  # the CHECK constraint rejects the write
+            with database.transaction() as connection:
+                connection.execute(
+                    "INSERT INTO _segments (batch_id, day, schema_version, frame_version, "
+                    "config_generation, scope, target_id, privacy_class, retention_days, "
+                    "record_count, content_sha256, byte_size, file_sha256, committed_at) VALUES "
+                    "('b', '2026-07-24', 1, 1, ?, 'target', 't', 'restricted', 30, 1, ?, 10, ?, "
+                    "'2026-07-24T00:00:00.000Z')",
+                    ("a" * 64, "b" * 64, "c" * 64),
+                )
+    finally:
+        database.close()
+
+
+@pytest.mark.parametrize("privacy_class", ["public", "internal", "sensitive"])
+def test_authorize_admits_every_local_persistable_class(privacy_class: str) -> None:
+    _authorize(privacy_class)  # returns without raising
+
+
+def test_authorize_denies_a_restricted_class() -> None:
+    # Defense behind the header check: if a restricted class reached commit, egress would deny it.
+    with pytest.raises(SpoolError) as captured:
+        _authorize("restricted")
+    assert captured.value.code == "MH_SPOOL_EGRESS"
+
+
+def test_the_store_rejects_a_non_control_database_or_barrier(tmp_path: Path) -> None:
+    database, _store, spool_root = _spool(tmp_path)
+    barrier = GlobalCommitBarrier(tmp_path / "control" / "commit.lock")
+    try:
+        with pytest.raises(SpoolError) as database_error:
+            DurableSpool(database=object(), barrier=barrier, spool_root=spool_root)  # type: ignore[arg-type]
+        assert database_error.value.code == "MH_SPOOL_STORE"
+        with pytest.raises(SpoolError) as barrier_error:
+            DurableSpool(database=database, barrier=object(), spool_root=spool_root)  # type: ignore[arg-type]
+        assert barrier_error.value.code == "MH_SPOOL_STORE"
+    finally:
+        database.close()
+
+
+def test_commit_rejects_a_non_header_argument(tmp_path: Path) -> None:
+    database, store, _spool_root = _spool(tmp_path)
+    try:
+        with pytest.raises(SpoolError) as captured:
+            store.commit_segment(object(), _frames(), committed_at=_NOW)  # type: ignore[arg-type]
+        assert captured.value.code == "MH_SPOOL_HEADER"
+    finally:
+        database.close()
+
+
+def test_reading_an_unknown_batch_returns_none(tmp_path: Path) -> None:
+    database, store, _spool_root = _spool(tmp_path)
+    try:
+        assert store.read_segment("no-such-batch") is None
+    finally:
+        database.close()
+
+
+def test_the_store_rejects_a_mismatched_barrier_or_spool_root(tmp_path: Path) -> None:
+    database, _store, spool_root = _spool(tmp_path)
+    try:
+        foreign = tmp_path / "elsewhere"
+        foreign.mkdir(mode=0o700)
+        os.chmod(foreign, 0o700)
+        with pytest.raises(SpoolError) as barrier_error:
+            DurableSpool(
+                database=database,
+                barrier=GlobalCommitBarrier(foreign / "commit.lock"),
+                spool_root=spool_root,
+            )
+        assert barrier_error.value.code == "MH_SPOOL_STORE"
+        with pytest.raises(SpoolError) as spool_error:
+            DurableSpool(
+                database=database,
+                barrier=GlobalCommitBarrier(tmp_path / "control" / "commit.lock"),
+                spool_root=foreign,
+            )
+        assert spool_error.value.code == "MH_SPOOL_STORE"
+        # A barrier beside the database but on a different lock file shares no flock with
+        # maintenance, so it must be rejected even though it lives in the control directory.
+        with pytest.raises(SpoolError) as wrong_lock:
+            DurableSpool(
+                database=database,
+                barrier=GlobalCommitBarrier(tmp_path / "control" / "other.lock"),
+                spool_root=spool_root,
+            )
+        assert wrong_lock.value.code == "MH_SPOOL_STORE"
+    finally:
+        database.close()
+
+
+def test_spool_directories_are_created_inside_the_barrier(tmp_path: Path) -> None:
+    database, store, spool_root = _spool(tmp_path)
+    real_barrier = store._barrier  # type: ignore[attr-defined]
+    pending = spool_root / "pending"
+
+    class _AssertingBarrier:
+        @contextlib.contextmanager
+        def shared(self, *, blocking: bool = True) -> Iterator[None]:
+            assert not pending.exists()  # no namespace mutation before the barrier is held
+            with real_barrier.shared(blocking=blocking):
+                yield
+
+    store._barrier = _AssertingBarrier()  # type: ignore[attr-defined]
+    try:
+        frames = _frames()
+        store.commit_segment(_header(frames), frames, committed_at=_NOW)
+        assert pending.exists()
+    finally:
+        database.close()
+
+
+def test_a_duplicate_batch_fails_closed_without_touching_the_ledger(tmp_path: Path) -> None:
+    database, store, _spool_root = _spool(tmp_path)
+    try:
+        frames = _frames()
+        header = _header(frames)
+        store.commit_segment(header, frames, committed_at=_NOW)
+        with pytest.raises(SpoolError) as captured:
+            store.commit_segment(header, frames, committed_at=_NOW)
+        assert captured.value.code == "MH_SPOOL_EXISTS"
+        assert len(store.list_segments()) == 1
+    finally:
+        database.close()
+
+
+def test_a_ledger_failure_after_publication_is_commit_uncertain(tmp_path: Path) -> None:
+    database, store, spool_root = _spool(tmp_path)
+    try:
+        with database.transaction() as connection:
+            connection.execute("DROP TABLE _segments")
+        frames = _frames()
+        with pytest.raises(SpoolError) as captured:
+            store.commit_segment(_header(frames), frames, committed_at=_NOW)
+        assert captured.value.code == "MH_SPOOL_COMMIT"
+        assert captured.value.__cause__ is None
+        assert captured.value.__context__ is None
+        assert (spool_root / "pending" / _DAY / "batch-1.jsonl").exists()  # a registrable orphan
+    finally:
+        database.close()
+
+
+def test_a_transaction_boundary_failure_after_publication_is_commit_uncertain(
+    tmp_path: Path,
+) -> None:
+    database, store, spool_root = _spool(tmp_path)
+
+    class _TxnFailDatabase:
+        def transaction(self) -> object:
+            raise StateError("MH_STATE_TXN", "planted transaction-boundary failure")
+
+    store._database = _TxnFailDatabase()  # type: ignore[attr-defined]
+    try:
+        frames = _frames()
+        with pytest.raises(SpoolError) as captured:
+            store.commit_segment(_header(frames), frames, committed_at=_NOW)
+        assert captured.value.code == "MH_SPOOL_COMMIT"
+        assert captured.value.__cause__ is None
+        assert captured.value.__context__ is None
+        assert (spool_root / "pending" / _DAY / "batch-1.jsonl").exists()
+    finally:
+        database.close()
+
+
+def test_a_non_private_spool_root_fails_closed(tmp_path: Path) -> None:
+    database, store, spool_root = _spool(tmp_path)
+    os.chmod(spool_root, 0o777)
+    try:
+        frames = _frames()
+        with pytest.raises(SpoolError) as captured:
+            store.commit_segment(_header(frames), frames, committed_at=_NOW)
+        assert captured.value.code == "MH_SPOOL_DIR"
+    finally:
+        os.chmod(spool_root, 0o700)
+        database.close()


### PR DESCRIPTION
## Summary

Reconcile a published segment with the SQLite control plane (ADR 0004). This is the **durable-commit half** of the plan's slice 3 (commit + recovery); reconciliation/recovery follows as slice 3b. Slice **3a of 7**.

## Delivers
- Control **migration 2** adds the `_segments` ledger (batch id, day, scope/target, privacy, retention, count, ordered-frame digest, byte size, whole-file digest, committed-at, delivery status).
- **`commit_segment`** — holding the **shared** commit barrier, atomically publishes the segment file under `<spool_root>/pending/<day>/` (W02 secure write) then inserts its ledger row and commits SQLite. A crash/ledger-failure after publication leaves a durable **orphan** for reconciliation and is reported as fixed commit-uncertain `MH_SPOOL_COMMIT`; a duplicate batch fails closed at publication.
- **`read_segment`/`list_segments`** read-only queries; `build_segment_bytes` factored out so the commit can compute size + whole-file digest.

## Pre-review (adversarial, before pushing)
Ran a 4-lens review workflow; it found and this change fixes:
- **[P2]** a failing BEGIN/COMMIT raises `StateError` (not `sqlite3.Error`), so a genuinely commit-uncertain post-publication ledger failure escaped as `MH_STATE_TXN` instead of `MH_SPOOL_COMMIT` — now caught + relabeled, with a regression test.
- **[P3]** malformed-row `int()` coercion moved inside the fail-closed boundary (+ test); directory owner check uses the effective uid to match the W02 writer; directories required to be exactly `0o700`.

## Verification
`make quality`/`test` pass (**3859 passed**), global floor holds; DCO clean. Spooling modules join the enforced 95% critical set in the W03 failure-injection slice.

**Known minor gap (disclosed):** commit.py validates each dir's mode/owner/no-symlink but relies on the W02 writer for the segment file's immediate-parent ACL check; an extended ACL on `spool_root` itself isn't separately inspected (the `0o700` no-ACL day dir shields the `0o600` file). Can tighten in slice 3b.