### PR TITLE
feat(spooling): spool reconciliation scan (W03 slice 3c)

### DIFF
--- a/src/milhouse/spooling/__init__.py
+++ b/src/milhouse/spooling/__init__.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
-from milhouse.spooling.commit import (
-    DurableSpool,
-    ExporterDelivery,
-    SegmentRecord,
-)
+from milhouse.spooling.commit import DurableSpool
 from milhouse.spooling.errors import SpoolError
+from milhouse.spooling.ledger import ExporterDelivery, SegmentRecord
 from milhouse.spooling.reader import (
     ParsedSegment,
     parse_segment_bytes,
     read_trusted_segment,
     read_untrusted_segment,
+)
+from milhouse.spooling.reconcile import (
+    OrphanRegistration,
+    ReconciliationReport,
+    SegmentAnomaly,
+    SpoolReconciler,
+    run_reconciliation_scan,
 )
 from milhouse.spooling.segment import (
     SegmentHeaderV1,
@@ -30,16 +34,21 @@ from milhouse.spooling.writer import (
 __all__ = [
     "DurableSpool",
     "ExporterDelivery",
+    "OrphanRegistration",
     "ParsedSegment",
+    "ReconciliationReport",
+    "SegmentAnomaly",
     "SegmentHeaderV1",
     "SegmentRecord",
     "SpoolError",
     "SpoolFrameV1",
+    "SpoolReconciler",
     "build_segment_bytes",
     "parse_segment_bytes",
     "publish_segment_bytes",
     "read_trusted_segment",
     "read_untrusted_segment",
+    "run_reconciliation_scan",
     "spool_content_sha256",
     "spool_frame_line",
     "spool_segment_header_line",

--- a/src/milhouse/spooling/commit.py
+++ b/src/milhouse/spooling/commit.py
@@ -1,43 +1,49 @@
-"""Durable spool commit and segment ledger, bound to one control plane (W03 slice 3a).
+"""Durable spool commit, bound to one control plane with mandatory recovery (W03 slices 3a/3c).
 
-A :class:`DurableSpool` binds one control database, one commit barrier, and one spool root that all
-live under the same canonical state root, so a caller cannot publish under a different barrier than
-maintenance holds. Per ADR 0004 and plan section 4.7 a commit is a deliberate, authorized,
-reconciled operation: it authorizes the ``local_spool`` and ``local_sqlite`` egress surfaces
-(restricted input is rejected before any mutation), derives the ``YYYY-MM-DD`` partition from the
-commit instant, then, while holding the shared commit barrier, creates the partition directory,
-atomically publishes the exact segment bytes (write, flush, fsync, no-replace rename, parent fsync),
-and inserts the segment ledger row plus one row per required exporter in a single SQLite
-transaction. A crash or ledger failure after publication leaves a durable orphan and is reported as
+A :class:`DurableSpool` binds one control database, one commit barrier, one spool root, and the
+installation identity, all under the same canonical state root, so a caller cannot publish under a
+different barrier than maintenance holds. Acquiring the store is a writer acquisition: per ADR 0004
+and plan sections 3.4/4.3 it performs mandatory spool/ledger reconciliation under the exclusive
+barrier before any commit is possible, so a durably-published but unrecorded orphan is registered
+before this writer proceeds and recovery is never opt-in.
+
+Per ADR 0004 and plan section 4.7 a commit is a deliberate, authorized, reconciled operation: it
+authorizes the ``local_spool`` and ``local_sqlite`` egress surfaces (restricted input is rejected
+before any mutation), derives the ``YYYY-MM-DD`` partition from the commit instant, then, while
+holding the shared commit barrier, creates the partition directory, atomically publishes the exact
+segment bytes (write, flush, fsync, no-replace rename, parent fsync), and inserts the segment ledger
+row (``origin = 'committed'``) plus one row per required exporter in a single SQLite transaction. A
+crash or ledger failure after publication leaves a durable orphan and is reported as the fixed
 commit-uncertain ``MH_SPOOL_COMMIT``, never as success. The ledger preserves every immutable header
-field so recovery never infers policy from newer configuration, and every read is semantically
-validated so a corrupt or foreign row fails closed with ``MH_SPOOL_LEDGER``. Every failure raises a
-fixed ``MH_SPOOL_*`` error outside the handler.
+field so recovery never infers policy from newer configuration, and every read is validated so a
+corrupt row fails closed with ``MH_SPOOL_LEDGER``. Every failure raises a fixed ``MH_SPOOL_*`` error
+outside the handler.
 """
 
 from __future__ import annotations
 
 import hashlib
 import os
-import re
 import sqlite3
 import stat
-from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import TYPE_CHECKING, NoReturn
 
 from milhouse.config.filesystem import lexical_absolute_path
 from milhouse.core.clock import TimeError, format_timestamp
-from milhouse.privacy import (
-    EgressDisposition,
-    EgressSurface,
-    PrivacyError,
-    require_egress,
-)
 from milhouse.spooling.errors import SpoolError
+from milhouse.spooling.ledger import (
+    ORIGIN_COMMITTED,
+    ExporterDelivery,
+    SegmentRecord,
+    authorize_local_persistence,
+    insert_segment_row,
+    list_segment_records,
+    read_segment_record,
+)
+from milhouse.spooling.reader import INSTALLATION_ID_PATTERN
 from milhouse.spooling.segment import (
-    EXPORTER_ID_PATTERN,
     FRAME_VERSION,
     SCHEMA_VERSION,
     SegmentHeaderV1,
@@ -48,35 +54,15 @@ from milhouse.state.barrier import GlobalCommitBarrier
 from milhouse.state.database import ControlDatabase
 from milhouse.state.errors import StateError
 
+if TYPE_CHECKING:
+    from milhouse.spooling.reconcile import ReconciliationReport
+
 _SPOOL = "spool"
 _BARRIER_NAME = "commit.lock"
 _PENDING = "pending"
 _DIR_MODE = 0o700
 _DELIVERY_PENDING = "pending"
 _DAY_LENGTH = 10
-_SCOPES = ("installation", "target")
-_ALLOWED_PRIVACY = ("public", "internal", "sensitive")
-_DELIVERY_STATES = ("pending", "delivered", "failed")
-_SHA256_HEX = re.compile(r"[0-9a-f]{64}", flags=re.ASCII)
-_STAMP = re.compile(
-    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z", flags=re.ASCII
-)
-_SEGMENT_COLUMNS = (
-    "batch_id",
-    "day",
-    "schema_version",
-    "frame_version",
-    "config_generation",
-    "scope",
-    "target_id",
-    "privacy_class",
-    "retention_days",
-    "record_count",
-    "content_sha256",
-    "byte_size",
-    "file_sha256",
-    "committed_at",
-)
 
 
 def _fail(code: str, message: str) -> NoReturn:
@@ -89,51 +75,6 @@ def _current_uid() -> int:
     if geteuid is None:  # pragma: no cover - Milhouse supports only POSIX hosts
         _fail("MH_SPOOL_UNSUPPORTED", "the spool requires a POSIX ownership model")
     return int(geteuid())
-
-
-@dataclass(frozen=True, slots=True)
-class ExporterDelivery:
-    """The delivery state of one required exporter for a committed segment."""
-
-    exporter_id: str
-    delivery_status: str
-
-
-@dataclass(frozen=True, slots=True)
-class SegmentRecord:
-    """A committed segment's immutable ledger row plus its per-exporter delivery rows."""
-
-    batch_id: str
-    day: str
-    schema_version: int
-    frame_version: int
-    config_generation: str
-    scope: str
-    target_id: str | None
-    privacy_class: str
-    retention_days: int
-    record_count: int
-    content_sha256: str
-    byte_size: int
-    file_sha256: str
-    committed_at: str
-    exporters: tuple[ExporterDelivery, ...]
-
-
-def _authorize(privacy_class: str) -> None:
-    denied = False
-    dispositions: tuple[EgressDisposition, ...] = ()
-    try:
-        dispositions = tuple(
-            require_egress(surface=surface, privacy_class=privacy_class)  # type: ignore[arg-type]
-            for surface in (EgressSurface.LOCAL_SPOOL, EgressSurface.LOCAL_SQLITE)
-        )
-    except PrivacyError:
-        denied = True
-    if denied or any(d is not EgressDisposition.REDACTED_RECORD for d in dispositions):
-        _fail(
-            "MH_SPOOL_EGRESS", "the local persistence surfaces do not authorize this privacy class"
-        )
 
 
 def _committed_stamp(committed_at: datetime) -> str:
@@ -184,117 +125,10 @@ def _pending_day_dir(spool_root: Path, day: str) -> Path:
     return _secure_child_dir(_secure_child_dir(spool_root, _PENDING), day)
 
 
-def _insert_ledger(database: ControlDatabase, record: SegmentRecord) -> None:
-    segment_values = (
-        record.batch_id,
-        record.day,
-        record.schema_version,
-        record.frame_version,
-        record.config_generation,
-        record.scope,
-        record.target_id,
-        record.privacy_class,
-        record.retention_days,
-        record.record_count,
-        record.content_sha256,
-        record.byte_size,
-        record.file_sha256,
-        record.committed_at,
-    )
-    placeholders = ", ".join("?" for _ in _SEGMENT_COLUMNS)
-    failed = False
-    try:
-        with database.transaction() as connection:
-            connection.execute(
-                f"INSERT INTO _segments ({', '.join(_SEGMENT_COLUMNS)}) VALUES ({placeholders})",
-                segment_values,
-            )
-            for exporter in record.exporters:
-                connection.execute(
-                    "INSERT INTO _segment_exporters (batch_id, exporter_id, delivery_status) "
-                    "VALUES (?, ?, ?)",
-                    (record.batch_id, exporter.exporter_id, exporter.delivery_status),
-                )
-    except (sqlite3.Error, StateError):
-        # The file is durably published; any ledger or transaction-boundary failure leaves a
-        # registrable orphan and is reported as commit-uncertain, never as success.
-        failed = True
-    if failed:
-        _fail("MH_SPOOL_COMMIT", "the segment ledger could not be committed")
-
-
-def _validated_segment(row: Any, exporters: tuple[ExporterDelivery, ...]) -> SegmentRecord:
-    """Reconstruct a SegmentRecord, raising ValueError on any semantic violation (caught above)."""
-
-    day = str(row[1])
-    datetime.strptime(day, "%Y-%m-%d")  # a bare partition date, not an instant
-    schema_version = int(row[2])
-    frame_version = int(row[3])
-    config_generation = str(row[4])
-    scope = str(row[5])
-    target_id = None if row[6] is None else str(row[6])
-    privacy_class = str(row[7])
-    retention_days = int(row[8])
-    record_count = int(row[9])
-    content_sha256 = str(row[10])
-    byte_size = int(row[11])
-    file_sha256 = str(row[12])
-    committed_at = str(row[13])
-    if schema_version != SCHEMA_VERSION or frame_version != FRAME_VERSION:
-        raise ValueError("unexpected schema or frame version")
-    if _SHA256_HEX.fullmatch(config_generation) is None:
-        raise ValueError("config_generation is not a sha-256 digest")
-    if scope not in _SCOPES or (scope == "target") != (target_id is not None):
-        raise ValueError("scope/target relation is invalid")
-    if privacy_class not in _ALLOWED_PRIVACY:
-        raise ValueError("privacy class is invalid")
-    if not 1 <= retention_days <= 3650 or record_count < 0 or byte_size <= 0:
-        raise ValueError("retention/count/size out of bounds")
-    if _SHA256_HEX.fullmatch(content_sha256) is None or _SHA256_HEX.fullmatch(file_sha256) is None:
-        raise ValueError("a digest is not a sha-256")
-    if _STAMP.fullmatch(committed_at) is None or committed_at[:_DAY_LENGTH] != day:
-        raise ValueError("committed_at is not a canonical stamp matching the day")
-    return SegmentRecord(
-        batch_id=str(row[0]),
-        day=day,
-        schema_version=schema_version,
-        frame_version=frame_version,
-        config_generation=config_generation,
-        scope=scope,
-        target_id=target_id,
-        privacy_class=privacy_class,
-        retention_days=retention_days,
-        record_count=record_count,
-        content_sha256=content_sha256,
-        byte_size=byte_size,
-        file_sha256=file_sha256,
-        committed_at=committed_at,
-        exporters=exporters,
-    )
-
-
-def _load_exporters(connection: sqlite3.Connection, batch_id: str) -> tuple[ExporterDelivery, ...]:
-    rows = connection.execute(
-        "SELECT exporter_id, delivery_status FROM _segment_exporters WHERE batch_id = ? "
-        "ORDER BY exporter_id",
-        (batch_id,),
-    ).fetchall()
-    exporters: list[ExporterDelivery] = []
-    for exporter_id, delivery_status in rows:
-        identifier = str(exporter_id)
-        status = str(delivery_status)
-        if EXPORTER_ID_PATTERN.fullmatch(identifier) is None:
-            raise ValueError("exporter id is not well formed")
-        if status not in _DELIVERY_STATES:
-            raise ValueError("delivery status is invalid")
-        exporters.append(ExporterDelivery(exporter_id=identifier, delivery_status=status))
-    return tuple(exporters)
-
-
 class DurableSpool:
-    """A durable spool bound to one control database, commit barrier, and spool root."""
+    """A durable spool bound to one control database, barrier, spool root, and installation id."""
 
-    __slots__ = ("_barrier", "_database", "_spool_root")
+    __slots__ = ("_barrier", "_database", "_installation_id", "_last_reconciliation", "_spool_root")
 
     def __init__(
         self,
@@ -302,6 +136,7 @@ class DurableSpool:
         database: ControlDatabase,
         barrier: GlobalCommitBarrier,
         spool_root: str | Path,
+        installation_id: str,
     ) -> None:
         if not isinstance(database, ControlDatabase):
             _fail("MH_SPOOL_STORE", "a control database is required")
@@ -317,9 +152,43 @@ class DurableSpool:
             _fail("MH_SPOOL_STORE", "the barrier must be the control-plane commit lock")
         if resolved_spool != state_root / _SPOOL:
             _fail("MH_SPOOL_STORE", "the spool root must be <state_root>/spool")
+        if (
+            type(installation_id) is not str
+            or INSTALLATION_ID_PATTERN.fullmatch(installation_id) is None
+        ):
+            _fail("MH_SPOOL_IDENTITY", "a well-formed installation id is required")
         self._database = database
         self._barrier = barrier
         self._spool_root = resolved_spool
+        self._installation_id = installation_id
+        # A writer acquisition performs mandatory recovery: reconcile the spool with the ledger
+        # under the exclusive barrier before any commit is possible, so recovery is never opt-in and
+        # this writer cannot proceed while an earlier durable segment is absent from the ledger.
+        # Imported here to keep the reconcile module's dependency on the ledger one-directional.
+        from milhouse.spooling.reconcile import run_reconciliation_scan
+
+        report: ReconciliationReport | None = None
+        barrier_failed = False
+        try:
+            with self._barrier.exclusive():
+                report = run_reconciliation_scan(
+                    database=self._database,
+                    spool_root=self._spool_root,
+                    installation_id=self._installation_id,
+                )
+        except StateError:
+            # The scan itself remaps its own StateErrors; this only catches a barrier-acquisition
+            # failure so the writer API never surfaces a non-MH_SPOOL_* error.
+            barrier_failed = True
+        if barrier_failed or report is None:
+            _fail("MH_SPOOL_BARRIER", "the commit barrier could not be acquired")
+        self._last_reconciliation = report
+
+    @property
+    def last_reconciliation(self) -> ReconciliationReport:
+        """The reconciliation report produced when this writer acquired the store."""
+
+        return self._last_reconciliation
 
     def commit_segment(
         self,
@@ -332,7 +201,7 @@ class DurableSpool:
 
         if not isinstance(header, SegmentHeaderV1):
             _fail("MH_SPOOL_HEADER", "a segment header is required")
-        _authorize(header.privacy_class)
+        authorize_local_persistence(header.privacy_class)
         stamp = _committed_stamp(committed_at)
         day = stamp[:_DAY_LENGTH]
         content = build_segment_bytes(header, frames)
@@ -351,59 +220,42 @@ class DurableSpool:
             byte_size=len(content),
             file_sha256=hashlib.sha256(content).hexdigest(),
             committed_at=stamp,
+            origin=ORIGIN_COMMITTED,
             exporters=tuple(
                 ExporterDelivery(exporter_id=exporter, delivery_status=_DELIVERY_PENDING)
                 for exporter in header.required_exporters
             ),
         )
-        with self._barrier.shared():
-            day_dir = _pending_day_dir(self._spool_root, day)
-            publish_segment_bytes(day_dir / f"{header.batch_id}.jsonl", content)
-            _insert_ledger(self._database, record)
+        barrier_failed = False
+        try:
+            with self._barrier.shared():
+                day_dir = _pending_day_dir(self._spool_root, day)
+                publish_segment_bytes(day_dir / f"{header.batch_id}.jsonl", content)
+                self._commit_ledger(record)
+        except StateError:
+            barrier_failed = True
+        if barrier_failed:
+            _fail("MH_SPOOL_BARRIER", "the commit barrier could not be acquired")
         return record
+
+    def _commit_ledger(self, record: SegmentRecord) -> None:
+        failed = False
+        try:
+            with self._database.transaction() as connection:
+                insert_segment_row(connection, record)
+        except (sqlite3.Error, StateError):
+            # The file is durably published; any ledger or transaction-boundary failure leaves a
+            # registrable orphan and is reported as commit-uncertain, never as success.
+            failed = True
+        if failed:
+            _fail("MH_SPOOL_COMMIT", "the segment ledger could not be committed")
 
     def read_segment(self, batch_id: str) -> SegmentRecord | None:
         """Return the committed segment ledger record for ``batch_id``, or None. Read-only."""
 
-        failed = False
-        result: SegmentRecord | None = None
-        try:
-            connection = self._database.connection
-            row = connection.execute(
-                f"SELECT {', '.join(_SEGMENT_COLUMNS)} FROM _segments WHERE batch_id = ?",
-                (batch_id,),
-            ).fetchone()
-            if row is not None:
-                result = _validated_segment(row, _load_exporters(connection, str(row[0])))
-        except (sqlite3.Error, ValueError, TypeError):
-            failed = True
-        if failed:
-            _fail("MH_SPOOL_LEDGER", "the segment ledger could not be read")
-        return result
+        return read_segment_record(self._database, batch_id)
 
     def list_segments(self, *, delivery_status: str | None = None) -> tuple[SegmentRecord, ...]:
         """Return committed segments, optionally only those with an exporter in the given status."""
 
-        failed = False
-        records: tuple[SegmentRecord, ...] = ()
-        try:
-            connection = self._database.connection
-            if delivery_status is None:
-                rows = connection.execute(
-                    f"SELECT {', '.join(_SEGMENT_COLUMNS)} FROM _segments ORDER BY batch_id"
-                ).fetchall()
-            else:
-                rows = connection.execute(
-                    f"SELECT {', '.join('s.' + c for c in _SEGMENT_COLUMNS)} FROM _segments s "
-                    "WHERE EXISTS (SELECT 1 FROM _segment_exporters e "
-                    "WHERE e.batch_id = s.batch_id AND e.delivery_status = ?) ORDER BY s.batch_id",
-                    (delivery_status,),
-                ).fetchall()
-            records = tuple(
-                _validated_segment(row, _load_exporters(connection, str(row[0]))) for row in rows
-            )
-        except (sqlite3.Error, ValueError, TypeError):
-            failed = True
-        if failed:
-            _fail("MH_SPOOL_LEDGER", "the segment ledger could not be read")
-        return records
+        return list_segment_records(self._database, delivery_status=delivery_status)

--- a/src/milhouse/spooling/ledger.py
+++ b/src/milhouse/spooling/ledger.py
@@ -1,0 +1,287 @@
+"""Shared segment-ledger primitives for the durable spool (W03).
+
+The commit path (:mod:`milhouse.spooling.commit`) and the reconciliation scan
+(:mod:`milhouse.spooling.reconcile`) both read, validate, authorize, and write ``_segments`` /
+``_segment_exporters`` rows. This leaf module owns those shared primitives — the ``SegmentRecord``
+shape, the fixed egress authorization of the local persistence surfaces, the fully semantic row
+validator, and the single-row insert — so both callers enforce exactly the same contract and neither
+imports the other. Every failure is a fixed ``MH_SPOOL_*`` error raised outside any handler, so no
+filesystem, SQLite, or record detail reaches its cause, context, args, or traceback.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, NoReturn
+
+from milhouse.privacy import (
+    EgressDisposition,
+    EgressSurface,
+    PrivacyError,
+    require_egress,
+)
+from milhouse.spooling.errors import SpoolError
+from milhouse.spooling.segment import (
+    BATCH_ID_PATTERN,
+    EXPORTER_ID_PATTERN,
+    FRAME_VERSION,
+    SCHEMA_VERSION,
+)
+from milhouse.state.database import ControlDatabase
+from milhouse.state.errors import StateError
+
+_DAY_LENGTH = 10
+_DELIVERY_PENDING = "pending"
+_SCOPES = ("installation", "target")
+_ALLOWED_PRIVACY = ("public", "internal", "sensitive")
+_DELIVERY_STATES = ("pending", "delivered", "failed")
+ORIGIN_COMMITTED = "committed"
+ORIGIN_RECONCILED = "reconciled"
+_ORIGINS = (ORIGIN_COMMITTED, ORIGIN_RECONCILED)
+_SHA256_HEX = re.compile(r"[0-9a-f]{64}", flags=re.ASCII)
+_STAMP = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z", flags=re.ASCII
+)
+SEGMENT_COLUMNS = (
+    "batch_id",
+    "day",
+    "schema_version",
+    "frame_version",
+    "config_generation",
+    "scope",
+    "target_id",
+    "privacy_class",
+    "retention_days",
+    "record_count",
+    "content_sha256",
+    "byte_size",
+    "file_sha256",
+    "committed_at",
+    "origin",
+)
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise SpoolError(code, message)
+
+
+@dataclass(frozen=True, slots=True)
+class ExporterDelivery:
+    """The delivery state of one required exporter for a committed segment."""
+
+    exporter_id: str
+    delivery_status: str
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentRecord:
+    """A committed segment's immutable ledger row plus its per-exporter delivery rows.
+
+    ``origin`` is ``committed`` for a normal durable commit and ``reconciled`` for an orphan that
+    reconciliation registered from its durable file, whose ``committed_at`` is a reconstructed
+    day-start rather than the exact (lost) commit instant.
+    """
+
+    batch_id: str
+    day: str
+    schema_version: int
+    frame_version: int
+    config_generation: str
+    scope: str
+    target_id: str | None
+    privacy_class: str
+    retention_days: int
+    record_count: int
+    content_sha256: str
+    byte_size: int
+    file_sha256: str
+    committed_at: str
+    origin: str
+    exporters: tuple[ExporterDelivery, ...]
+
+
+def authorize_local_persistence(privacy_class: str) -> None:
+    """Authorize the local_spool and local_sqlite surfaces for a class, or fail ``MH_SPOOL_EGRESS``.
+
+    This is the single fail-closed policy boundary every persistence path — commit and recovery
+    alike — must cross before writing a segment or a ledger row.
+    """
+
+    denied = False
+    dispositions: tuple[EgressDisposition, ...] = ()
+    try:
+        dispositions = tuple(
+            require_egress(surface=surface, privacy_class=privacy_class)  # type: ignore[arg-type]
+            for surface in (EgressSurface.LOCAL_SPOOL, EgressSurface.LOCAL_SQLITE)
+        )
+    except PrivacyError:
+        denied = True
+    if denied or any(d is not EgressDisposition.REDACTED_RECORD for d in dispositions):
+        _fail(
+            "MH_SPOOL_EGRESS", "the local persistence surfaces do not authorize this privacy class"
+        )
+
+
+def validated_segment(row: Any, exporters: tuple[ExporterDelivery, ...]) -> SegmentRecord:
+    """Reconstruct a SegmentRecord from a raw row, raising ValueError on any semantic violation.
+
+    Callers run this inside a fail-closed boundary that maps the ValueError to ``MH_SPOOL_LEDGER``.
+    The row must carry every :data:`SEGMENT_COLUMNS` value in order, including ``origin`` last.
+    """
+
+    batch_id = str(row[0])
+    if BATCH_ID_PATTERN.fullmatch(batch_id) is None:
+        raise ValueError("batch_id is not well formed")
+    day = str(row[1])
+    datetime.strptime(day, "%Y-%m-%d")  # a bare partition date, not an instant
+    schema_version = int(row[2])
+    frame_version = int(row[3])
+    config_generation = str(row[4])
+    scope = str(row[5])
+    target_id = None if row[6] is None else str(row[6])
+    privacy_class = str(row[7])
+    retention_days = int(row[8])
+    record_count = int(row[9])
+    content_sha256 = str(row[10])
+    byte_size = int(row[11])
+    file_sha256 = str(row[12])
+    committed_at = str(row[13])
+    origin = str(row[14])
+    if schema_version != SCHEMA_VERSION or frame_version != FRAME_VERSION:
+        raise ValueError("unexpected schema or frame version")
+    if _SHA256_HEX.fullmatch(config_generation) is None:
+        raise ValueError("config_generation is not a sha-256 digest")
+    if scope not in _SCOPES or (scope == "target") != (target_id is not None):
+        raise ValueError("scope/target relation is invalid")
+    if privacy_class not in _ALLOWED_PRIVACY:
+        raise ValueError("privacy class is invalid")
+    if not 1 <= retention_days <= 3650 or record_count < 0 or byte_size <= 0:
+        raise ValueError("retention/count/size out of bounds")
+    if _SHA256_HEX.fullmatch(content_sha256) is None or _SHA256_HEX.fullmatch(file_sha256) is None:
+        raise ValueError("a digest is not a sha-256")
+    if _STAMP.fullmatch(committed_at) is None or committed_at[:_DAY_LENGTH] != day:
+        raise ValueError("committed_at is not a canonical stamp matching the day")
+    if origin not in _ORIGINS:
+        raise ValueError("origin is invalid")
+    return SegmentRecord(
+        batch_id=str(row[0]),
+        day=day,
+        schema_version=schema_version,
+        frame_version=frame_version,
+        config_generation=config_generation,
+        scope=scope,
+        target_id=target_id,
+        privacy_class=privacy_class,
+        retention_days=retention_days,
+        record_count=record_count,
+        content_sha256=content_sha256,
+        byte_size=byte_size,
+        file_sha256=file_sha256,
+        committed_at=committed_at,
+        origin=origin,
+        exporters=exporters,
+    )
+
+
+def load_exporters(connection: sqlite3.Connection, batch_id: str) -> tuple[ExporterDelivery, ...]:
+    rows = connection.execute(
+        "SELECT exporter_id, delivery_status FROM _segment_exporters WHERE batch_id = ? "
+        "ORDER BY exporter_id",
+        (batch_id,),
+    ).fetchall()
+    exporters: list[ExporterDelivery] = []
+    for exporter_id, delivery_status in rows:
+        identifier = str(exporter_id)
+        status = str(delivery_status)
+        if EXPORTER_ID_PATTERN.fullmatch(identifier) is None:
+            raise ValueError("exporter id is not well formed")
+        if status not in _DELIVERY_STATES:
+            raise ValueError("delivery status is invalid")
+        exporters.append(ExporterDelivery(exporter_id=identifier, delivery_status=status))
+    return tuple(exporters)
+
+
+def insert_segment_row(connection: sqlite3.Connection, record: SegmentRecord) -> None:
+    """Insert one segment ledger row plus its exporter rows on an open transaction connection."""
+
+    values = (
+        record.batch_id,
+        record.day,
+        record.schema_version,
+        record.frame_version,
+        record.config_generation,
+        record.scope,
+        record.target_id,
+        record.privacy_class,
+        record.retention_days,
+        record.record_count,
+        record.content_sha256,
+        record.byte_size,
+        record.file_sha256,
+        record.committed_at,
+        record.origin,
+    )
+    placeholders = ", ".join("?" for _ in SEGMENT_COLUMNS)
+    connection.execute(
+        f"INSERT INTO _segments ({', '.join(SEGMENT_COLUMNS)}) VALUES ({placeholders})",
+        values,
+    )
+    for exporter in record.exporters:
+        connection.execute(
+            "INSERT INTO _segment_exporters (batch_id, exporter_id, delivery_status) "
+            "VALUES (?, ?, ?)",
+            (record.batch_id, exporter.exporter_id, exporter.delivery_status),
+        )
+
+
+def read_segment_record(database: ControlDatabase, batch_id: str) -> SegmentRecord | None:
+    """Return the validated ledger record for ``batch_id``, or None. Fails ``MH_SPOOL_LEDGER``."""
+
+    failed = False
+    result: SegmentRecord | None = None
+    try:
+        connection = database.connection
+        row = connection.execute(
+            f"SELECT {', '.join(SEGMENT_COLUMNS)} FROM _segments WHERE batch_id = ?",
+            (batch_id,),
+        ).fetchone()
+        if row is not None:
+            result = validated_segment(row, load_exporters(connection, str(row[0])))
+    except (sqlite3.Error, StateError, ValueError, TypeError):
+        failed = True
+    if failed:
+        _fail("MH_SPOOL_LEDGER", "the segment ledger could not be read")
+    return result
+
+
+def list_segment_records(
+    database: ControlDatabase, *, delivery_status: str | None = None
+) -> tuple[SegmentRecord, ...]:
+    """Return validated committed segments, optionally filtered by exporter delivery status."""
+
+    failed = False
+    records: tuple[SegmentRecord, ...] = ()
+    try:
+        connection = database.connection
+        if delivery_status is None:
+            rows = connection.execute(
+                f"SELECT {', '.join(SEGMENT_COLUMNS)} FROM _segments ORDER BY batch_id"
+            ).fetchall()
+        else:
+            rows = connection.execute(
+                f"SELECT {', '.join('s.' + c for c in SEGMENT_COLUMNS)} FROM _segments s "
+                "WHERE EXISTS (SELECT 1 FROM _segment_exporters e "
+                "WHERE e.batch_id = s.batch_id AND e.delivery_status = ?) ORDER BY s.batch_id",
+                (delivery_status,),
+            ).fetchall()
+        records = tuple(
+            validated_segment(row, load_exporters(connection, str(row[0]))) for row in rows
+        )
+    except (sqlite3.Error, StateError, ValueError, TypeError):
+        failed = True
+    if failed:
+        _fail("MH_SPOOL_LEDGER", "the segment ledger could not be read")
+    return records

--- a/src/milhouse/spooling/reader.py
+++ b/src/milhouse/spooling/reader.py
@@ -72,7 +72,7 @@ _TRUSTED_FILE_MODE = 0o600
 # The same installation-id shape the domain enforces (identity.py InstallationIdV1), validated at
 # the trusted-reader boundary so a malformed value fails closed as a fixed code rather than leaking
 # out of a downstream pydantic error.
-_INSTALLATION_ID_PATTERN = re.compile(
+INSTALLATION_ID_PATTERN = re.compile(
     r"mh_in1_[0-9a-f]{12}4[0-9a-f]{3}[89ab][0-9a-f]{15}", flags=re.ASCII
 )
 
@@ -297,7 +297,7 @@ def parse_segment_bytes(content: bytes) -> ParsedSegment:
 def _require_installation_id(installation_id: str) -> None:
     if (
         type(installation_id) is not str
-        or _INSTALLATION_ID_PATTERN.fullmatch(installation_id) is None
+        or INSTALLATION_ID_PATTERN.fullmatch(installation_id) is None
     ):
         # Contained here so a malformed caller-supplied id never reaches a downstream pydantic error
         # that would echo the rejected input.

--- a/src/milhouse/spooling/reconcile.py
+++ b/src/milhouse/spooling/reconcile.py
@@ -1,0 +1,481 @@
+"""Spool reconciliation scan: reconcile the pending spool with the SQLite ledger (W03 slice 3c).
+
+Per ADR 0004 and plan sections 3.4/4.3, startup and every writer acquisition reconcile the durable
+spool with the control ledger before proceeding; :class:`milhouse.spooling.commit.DurableSpool` runs
+this scan on acquisition, and :class:`SpoolReconciler` exposes it for an explicit startup pass. A
+durable commit publishes the segment file and then records its ledger row (slice 3a); a crash
+between those steps leaves a durably-published but unrecorded *orphan*. Holding the exclusive commit
+barrier, the scan inventories ``<spool_root>/pending`` with secure, bounded, descriptor-relative
+enumeration and then, comparing against the fully validated ``_segments`` ledger:
+
+* registers each valid, unambiguous orphan (a trusted, provenance- and egress-authorized segment
+  file with no ledger row and no conflicting duplicate) into the ledger, reconstructing only from
+  the durable header, with a reconstructed day-start ``committed_at`` and ``origin = 'reconciled'``;
+* certifies a present committed file healthy only when it agrees with its ledger row on every
+  immutable field, both digests, byte size, and the exact required-exporter identity set;
+* reports every ledger row whose file is missing, every malformed ledger row, every file that
+  disagrees with its row, every batch id that appears at more than one path (registering none of
+  them), and every foreign entry — carrying only fixed reasons and keyed name fingerprints, never a
+  raw path.
+
+The scan never deletes, quarantines, or moves a file; it registers valid orphans and returns a
+:class:`ReconciliationReport`. Every failure is a fixed ``MH_SPOOL_*`` error raised outside any
+handler.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import re
+import sqlite3
+import stat
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import NoReturn
+
+from milhouse.config.filesystem import lexical_absolute_path
+from milhouse.spooling.errors import SpoolError
+from milhouse.spooling.ledger import (
+    ORIGIN_RECONCILED,
+    SEGMENT_COLUMNS,
+    ExporterDelivery,
+    SegmentRecord,
+    authorize_local_persistence,
+    insert_segment_row,
+    load_exporters,
+    validated_segment,
+)
+from milhouse.spooling.reader import (
+    INSTALLATION_ID_PATTERN,
+    ParsedSegment,
+    read_trusted_segment,
+)
+from milhouse.spooling.segment import (
+    BATCH_ID_PATTERN,
+    FRAME_VERSION,
+    SCHEMA_VERSION,
+)
+from milhouse.state.barrier import GlobalCommitBarrier
+from milhouse.state.database import ControlDatabase
+from milhouse.state.errors import StateError
+
+_SPOOL = "spool"
+_PENDING = "pending"
+_BARRIER_NAME = "commit.lock"
+_SEGMENT_SUFFIX = ".jsonl"
+_DIR_MODE = 0o700
+_DELIVERY_PENDING = "pending"
+# Reconciliation runs under the exclusive barrier, so every bound below caps how long a hostile or
+# corrupt spool can hold it. Exceeding one reports a fixed limit anomaly and stops the scan.
+_MAX_DAYS = 100_000
+_MAX_ENTRIES = 1_000_000
+_MAX_TOTAL = 1_000_000
+_MAX_ANOMALIES = 100_000
+# A strict ASCII partition-day shape. `datetime.strptime(day, "%Y-%m-%d")` alone is not enough: its
+# `%d`/`%m` accept space-padded fields (e.g. "2026-07- 5"), which would then produce a committed_at
+# the schema's length-only CHECK admits but the ledger reader's stricter stamp regex rejects — a
+# poison row that fails-closes every later ledger read. The regex closes that gap; strptime still
+# checks the calendar (rejecting, e.g., 2026-13-45).
+_DAY_PATTERN = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}", flags=re.ASCII)
+
+
+@dataclass(frozen=True, slots=True)
+class OrphanRegistration:
+    """A valid orphan segment file that reconciliation registered into the ledger."""
+
+    batch_id: str
+    day: str
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentAnomaly:
+    """A spool/ledger disagreement that reconciliation surfaced but did not resolve.
+
+    ``kind`` is one of ``missing_file`` (a ledger row with no file), ``corrupt_ledger`` (a malformed
+    ledger row), ``corrupt_file`` (a committed file that fails trusted validation or disagrees with
+    its row), ``corrupt_orphan`` (an unrecorded file that fails trusted validation or egress),
+    ``conflict`` (a batch id at more than one path), ``foreign_name`` (an entry whose name is not a
+    well-formed ``<batch-id>.jsonl`` under a valid day), or ``limit`` (a scan bound was exceeded).
+    ``batch_id`` and ``day`` are validated identifiers or fixed ``sha256:`` fingerprints of an
+    untrusted name; ``detail`` is a fixed reason or ``MH_SPOOL_*`` code — never a raw path.
+    """
+
+    batch_id: str
+    day: str
+    kind: str
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReconciliationReport:
+    """The outcome of one reconciliation scan."""
+
+    registered: tuple[OrphanRegistration, ...]
+    anomalies: tuple[SegmentAnomaly, ...]
+    healthy: int
+    scanned: int
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise SpoolError(code, message)
+
+
+def _current_uid() -> int:
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:  # pragma: no cover - Milhouse supports only POSIX hosts
+        _fail("MH_SPOOL_UNSUPPORTED", "the spool requires a POSIX ownership model")
+    return int(geteuid())
+
+
+def _fingerprint(name: str) -> str:
+    """A stable, path-free fingerprint of an untrusted spool entry name for the report."""
+
+    return "sha256:" + hashlib.sha256(name.encode("utf-8", "surrogatepass")).hexdigest()[:16]
+
+
+def _safe_id(batch_id: str) -> str:
+    """Keep a well-formed batch id readable in the report; fingerprint anything else."""
+
+    return batch_id if BATCH_ID_PATTERN.fullmatch(batch_id) is not None else _fingerprint(batch_id)
+
+
+def _is_valid_day(day: str) -> bool:
+    if _DAY_PATTERN.fullmatch(day) is None:
+        return False
+    valid = True
+    try:
+        datetime.strptime(day, "%Y-%m-%d")  # a bare partition date, not an instant
+    except ValueError:
+        valid = False
+    return valid
+
+
+def _secure_dir_names(path: Path) -> tuple[tuple[str, ...] | None, str | None]:
+    """List a directory over an owned 0700 no-follow descriptor, capping entries before collecting.
+
+    Returns ``(names, None)`` on success (``()`` if absent), or ``(None, reason)`` where reason is
+    ``unsafe`` (symlink, non-directory, wrong owner, or mode) or ``unreadable``.
+    """
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_DIRECTORY", 0)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, flags)
+    except FileNotFoundError:
+        return (), None
+    except OSError as exc:
+        return None, "unsafe" if exc.errno in {errno.ELOOP, errno.ENOTDIR} else "unreadable"
+    problem: str | None = None
+    names: tuple[str, ...] | None = None
+    try:
+        info = os.fstat(descriptor)
+        if (
+            not stat.S_ISDIR(info.st_mode)
+            or info.st_uid != _current_uid()
+            or stat.S_IMODE(info.st_mode) != _DIR_MODE
+        ):
+            problem = "unsafe"
+        else:
+            collected: list[str] = []
+            with os.scandir(descriptor) as entries:
+                for entry in entries:
+                    if len(collected) >= _MAX_ENTRIES:
+                        problem = "too_many"
+                        break
+                    collected.append(entry.name)
+            if problem is None:
+                names = tuple(sorted(collected))
+    except OSError:  # pragma: no cover - defensive: fstat/scandir failure after a successful open
+        problem = "unreadable"
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError:  # pragma: no cover - defensive: close failure on a valid descriptor
+            problem = problem or "unreadable"
+    if problem is not None:
+        return None, problem
+    return names, None
+
+
+def run_reconciliation_scan(
+    *, database: ControlDatabase, spool_root: str | Path, installation_id: str
+) -> ReconciliationReport:
+    """Reconcile the pending spool with the ledger. The caller MUST hold the exclusive barrier."""
+
+    return _Scan(database, lexical_absolute_path(spool_root), installation_id).run()
+
+
+class _Scan:
+    __slots__ = (
+        "_anomalies",
+        "_database",
+        "_healthy",
+        "_installation_id",
+        "_registered",
+        "_scanned",
+        "_spool_root",
+        "_stopped",
+    )
+
+    def __init__(self, database: ControlDatabase, spool_root: Path, installation_id: str) -> None:
+        self._database = database
+        self._spool_root = spool_root
+        self._installation_id = installation_id
+        self._registered: list[OrphanRegistration] = []
+        self._anomalies: list[SegmentAnomaly] = []
+        self._healthy = 0
+        self._scanned = 0
+        self._stopped = False
+
+    def run(self) -> ReconciliationReport:
+        ledger, malformed = self._ledger_index()
+        for batch_id in sorted(malformed):
+            # the batch id came from a row that failed validation, so it may not be well formed
+            self._anomaly(_safe_id(batch_id), "", "corrupt_ledger", "unreadable_row")
+
+        candidates = self._inventory()
+        counts = Counter(batch_id for _day, batch_id, _path in candidates)
+        seen: set[str] = set()
+        for day, batch_id, path in candidates:
+            seen.add(batch_id)
+            if counts[batch_id] > 1:
+                self._anomaly(batch_id, day, "conflict", "duplicate_batch_id")
+            elif batch_id in malformed:
+                continue  # the malformed-row anomaly already covers this batch
+            elif batch_id in ledger:
+                self._verify_committed(path, day, batch_id, ledger[batch_id])
+            else:
+                self._reconcile_orphan(path, day, batch_id)
+
+        for batch_id, record in ledger.items():
+            if batch_id not in seen:
+                self._anomaly(batch_id, record.day, "missing_file", "absent")
+
+        return ReconciliationReport(
+            registered=tuple(self._registered),
+            anomalies=tuple(self._anomalies),
+            healthy=self._healthy,
+            scanned=self._scanned,
+        )
+
+    def _anomaly(self, batch_id: str, day: str, kind: str, detail: str) -> None:
+        if len(self._anomalies) < _MAX_ANOMALIES:
+            self._anomalies.append(SegmentAnomaly(batch_id, day, kind, detail))
+        elif not self._stopped:
+            self._stopped = True
+            self._anomalies.append(SegmentAnomaly("", "", "limit", "anomaly_limit"))
+
+    def _ledger_index(self) -> tuple[dict[str, SegmentRecord], set[str]]:
+        ledger: dict[str, SegmentRecord] = {}
+        malformed: set[str] = set()
+        failed = False
+        try:
+            connection = self._database.connection
+            rows = connection.execute(
+                f"SELECT {', '.join(SEGMENT_COLUMNS)} FROM _segments"
+            ).fetchall()
+            for row in rows:
+                batch_id = str(row[0])
+                try:
+                    ledger[batch_id] = validated_segment(row, load_exporters(connection, batch_id))
+                except (ValueError, TypeError):
+                    malformed.add(batch_id)
+        except (sqlite3.Error, StateError):
+            failed = True
+        if failed:
+            _fail("MH_SPOOL_LEDGER", "the segment ledger could not be read")
+        return ledger, malformed
+
+    def _inventory(self) -> list[tuple[str, str, Path]]:
+        pending = self._spool_root / _PENDING
+        day_names, problem = _secure_dir_names(pending)
+        if problem is not None:
+            self._anomaly("", "", "foreign_name", f"pending_{problem}")
+            return []
+        assert day_names is not None
+        if len(day_names) > _MAX_DAYS:
+            self._anomaly("", "", "limit", "day_limit")
+            day_names = day_names[:_MAX_DAYS]
+        candidates: list[tuple[str, str, Path]] = []
+        for day in day_names:
+            if not _is_valid_day(day):
+                self._anomaly("", _fingerprint(day), "foreign_name", "day")
+                continue
+            entries, entry_problem = _secure_dir_names(pending / day)
+            if entry_problem is not None:
+                self._anomaly("", day, "foreign_name", f"day_{entry_problem}")
+                continue
+            assert entries is not None
+            for name in entries:
+                if self._scanned >= _MAX_TOTAL:
+                    self._anomaly("", "", "limit", "scan_limit")
+                    return candidates
+                self._scanned += 1
+                resolved = self._classify_name(pending / day / name, day, name)
+                if resolved is not None:
+                    candidates.append(resolved)
+        return candidates
+
+    def _classify_name(self, path: Path, day: str, name: str) -> tuple[str, str, Path] | None:
+        if not name.endswith(_SEGMENT_SUFFIX):
+            self._anomaly(_fingerprint(name), day, "foreign_name", "suffix")
+            return None
+        batch_id = name[: -len(_SEGMENT_SUFFIX)]
+        if BATCH_ID_PATTERN.fullmatch(batch_id) is None:
+            self._anomaly(_fingerprint(name), day, "foreign_name", "batch_id")
+            return None
+        return day, batch_id, path
+
+    def _verify_committed(self, path: Path, day: str, batch_id: str, record: SegmentRecord) -> None:
+        parsed, code = self._trusted_read(path)
+        if code is not None:
+            self._anomaly(batch_id, day, "corrupt_file", code)
+        elif not _agrees(parsed, day, batch_id, record):
+            self._anomaly(batch_id, day, "corrupt_file", "ledger_mismatch")
+        else:
+            self._healthy += 1
+
+    def _reconcile_orphan(self, path: Path, day: str, batch_id: str) -> None:
+        parsed, code = self._trusted_read(path)
+        if code is not None:
+            self._anomaly(batch_id, day, "corrupt_orphan", code)
+            return
+        assert parsed is not None
+        if parsed.header.batch_id != batch_id:
+            self._anomaly(batch_id, day, "foreign_name", "header_batch_id")
+            return
+        try:
+            authorize_local_persistence(parsed.header.privacy_class)
+        except SpoolError as denied:
+            self._anomaly(batch_id, day, "corrupt_orphan", denied.code)
+            return
+        self._register(parsed, batch_id, day)
+        self._registered.append(OrphanRegistration(batch_id, day))
+
+    def _trusted_read(self, path: Path) -> tuple[ParsedSegment | None, str | None]:
+        parsed: ParsedSegment | None = None
+        code: str | None = None
+        try:
+            parsed = read_trusted_segment(path, installation_id=self._installation_id)
+        except SpoolError as error:
+            code = error.code
+        return parsed, code
+
+    def _register(self, parsed: ParsedSegment, batch_id: str, day: str) -> None:
+        if (
+            _DAY_PATTERN.fullmatch(day) is None
+        ):  # pragma: no cover - inventory filters to valid days
+            _fail("MH_SPOOL_RECONCILE", "a reconciled orphan requires a canonical partition day")
+        header = parsed.header
+        record = SegmentRecord(
+            batch_id=batch_id,
+            day=day,
+            schema_version=SCHEMA_VERSION,
+            frame_version=FRAME_VERSION,
+            config_generation=header.config_generation,
+            scope=header.scope,
+            target_id=header.target_id,
+            privacy_class=header.privacy_class,
+            retention_days=header.retention_days,
+            record_count=header.record_count,
+            content_sha256=header.content_sha256,
+            byte_size=parsed.byte_size,
+            file_sha256=parsed.file_sha256,
+            committed_at=f"{day}T00:00:00.000Z",  # a reconstructed day-start; the instant is lost
+            origin=ORIGIN_RECONCILED,
+            exporters=tuple(
+                ExporterDelivery(exporter_id=exporter, delivery_status=_DELIVERY_PENDING)
+                for exporter in header.required_exporters
+            ),
+        )
+        failed = False
+        try:
+            with self._database.transaction() as connection:
+                insert_segment_row(connection, record)
+        except (sqlite3.Error, StateError):
+            failed = True
+        if failed:
+            _fail("MH_SPOOL_RECONCILE", "a reconciled orphan could not be registered")
+
+
+def _agrees(parsed: ParsedSegment | None, day: str, batch_id: str, record: SegmentRecord) -> bool:
+    # Compare every *file-attestable* immutable field. The exact sub-day commit instant and the
+    # origin marker are not carried by the durable file (only the partition day is, and it is
+    # checked), so they are not compared here; a within-day committed_at or origin edit is a
+    # control-plane (SQLite-write) concern, not a spool/ledger disagreement this scan can attest.
+    if parsed is None:  # pragma: no cover - callers pass a parsed segment
+        return False
+    header = parsed.header
+    return (
+        header.batch_id == batch_id == record.batch_id
+        and day == record.day
+        and record.schema_version == SCHEMA_VERSION
+        and record.frame_version == FRAME_VERSION
+        and header.config_generation == record.config_generation
+        and header.scope == record.scope
+        and header.target_id == record.target_id
+        and header.privacy_class == record.privacy_class
+        and header.retention_days == record.retention_days
+        and header.record_count == record.record_count
+        and header.content_sha256 == record.content_sha256
+        and parsed.byte_size == record.byte_size
+        and parsed.file_sha256 == record.file_sha256
+        and set(header.required_exporters) == {e.exporter_id for e in record.exporters}
+    )
+
+
+class SpoolReconciler:
+    """Reconcile the pending spool with the control ledger under the exclusive commit barrier."""
+
+    __slots__ = ("_barrier", "_database", "_installation_id", "_spool_root")
+
+    def __init__(
+        self,
+        *,
+        database: ControlDatabase,
+        barrier: GlobalCommitBarrier,
+        spool_root: str | Path,
+        installation_id: str,
+    ) -> None:
+        if not isinstance(database, ControlDatabase):
+            _fail("MH_SPOOL_STORE", "a control database is required")
+        if not isinstance(barrier, GlobalCommitBarrier):
+            _fail("MH_SPOOL_STORE", "a commit barrier is required")
+        control_dir = lexical_absolute_path(database.path).parent
+        state_root = control_dir.parent
+        resolved_spool = lexical_absolute_path(spool_root)
+        if lexical_absolute_path(barrier.path) != control_dir / _BARRIER_NAME:
+            _fail("MH_SPOOL_STORE", "the barrier must be the control-plane commit lock")
+        if resolved_spool != state_root / _SPOOL:
+            _fail("MH_SPOOL_STORE", "the spool root must be <state_root>/spool")
+        if (
+            type(installation_id) is not str
+            or INSTALLATION_ID_PATTERN.fullmatch(installation_id) is None
+        ):
+            _fail("MH_SPOOL_IDENTITY", "a well-formed installation id is required")
+        self._database = database
+        self._barrier = barrier
+        self._spool_root = resolved_spool
+        self._installation_id = installation_id
+
+    def reconcile(self) -> ReconciliationReport:
+        """Scan pending against the ledger under the exclusive barrier; register valid orphans."""
+
+        report: ReconciliationReport | None = None
+        barrier_failed = False
+        try:
+            with self._barrier.exclusive():
+                report = run_reconciliation_scan(
+                    database=self._database,
+                    spool_root=self._spool_root,
+                    installation_id=self._installation_id,
+                )
+        except StateError:
+            barrier_failed = True
+        if barrier_failed or report is None:
+            _fail("MH_SPOOL_BARRIER", "the commit barrier could not be acquired")
+        return report

--- a/src/milhouse/spooling/segment.py
+++ b/src/milhouse/spooling/segment.py
@@ -30,7 +30,7 @@ MAX_HEADER_LINE_BYTES = 8_192
 MAX_FRAME_LINE_BYTES = 262_144 + 1_024  # a canonical record plus the small frame envelope
 MAX_RETENTION_DAYS = 3_650  # matches the config `[retention]` ceiling
 
-_BATCH_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", flags=re.ASCII)
+BATCH_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", flags=re.ASCII)
 EXPORTER_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}", flags=re.ASCII)
 _TARGET_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,255}", flags=re.ASCII)
 _SHA256_HEX_PATTERN = re.compile(r"[0-9a-f]{64}", flags=re.ASCII)
@@ -44,7 +44,7 @@ def _fail(code: str, message: str) -> NoReturn:
 
 
 def _validate_batch_id(value: object) -> None:
-    if type(value) is not str or _BATCH_ID_PATTERN.fullmatch(value) is None:
+    if type(value) is not str or BATCH_ID_PATTERN.fullmatch(value) is None:
         _fail("MH_SPOOL_BATCH_ID", "a bounded safe batch id is required")
 
 

--- a/src/milhouse/state/schema.py
+++ b/src/milhouse/state/schema.py
@@ -68,6 +68,18 @@ CONTROL_MIGRATIONS: tuple[Migration, ...] = (
             "CREATE INDEX _segment_exporters_by_status ON _segment_exporters (delivery_status)",
         ),
     ),
+    Migration(
+        3,
+        "add_segment_origin",
+        (
+            # Reconciliation registers a durably-published-but-unrecorded orphan segment whose exact
+            # commit instant is lost, so it records a reconstructed day-start committed_at and marks
+            # the row 'reconciled'. A normal commit omits the column and defaults to 'committed', so
+            # the ledger never asserts a false precise commit time as if it were original.
+            "ALTER TABLE _segments ADD COLUMN origin TEXT NOT NULL DEFAULT 'committed' "
+            "CHECK (origin IN ('committed', 'reconciled'))",
+        ),
+    ),
 )
 
 

--- a/tests/unit/test_spool_commit.py
+++ b/tests/unit/test_spool_commit.py
@@ -30,7 +30,7 @@ from milhouse.spooling import (
     spool_content_sha256,
     spool_frame_line,
 )
-from milhouse.spooling.commit import _authorize, _validated_segment
+from milhouse.spooling.ledger import authorize_local_persistence, validated_segment
 from milhouse.state import (
     GlobalCommitBarrier,
     StateError,
@@ -121,14 +121,16 @@ def _spool(tmp_path: Path):
     spool_root = tmp_path / "spool"
     spool_root.mkdir(mode=0o700)
     os.chmod(spool_root, 0o700)
-    store = DurableSpool(database=database, barrier=barrier, spool_root=spool_root)
+    store = DurableSpool(
+        database=database, barrier=barrier, spool_root=spool_root, installation_id=_INSTALLATION_ID
+    )
     return database, store, spool_root
 
 
 def test_migration_creates_the_segment_and_exporter_ledgers(tmp_path: Path) -> None:
     database, _store, _spool_root = _spool(tmp_path)
     try:
-        assert schema_version(database) == 2
+        assert schema_version(database) == 3
         tables = {
             row[0]
             for row in database.connection.execute(
@@ -294,6 +296,7 @@ _VALID_ROW: tuple[object, ...] = (
     100,
     "d" * 64,
     "2026-07-24T00:00:00.000Z",
+    "committed",
 )
 
 
@@ -304,10 +307,11 @@ def _mutate(index: int, value: object) -> tuple[object, ...]:
 
 
 def test_a_valid_row_reconstructs_a_segment_record() -> None:
-    record = _validated_segment(_VALID_ROW, ())
+    record = validated_segment(_VALID_ROW, ())
     assert record.batch_id == "batch-1"
     assert record.day == _DAY
     assert record.committed_at == "2026-07-24T00:00:00.000Z"
+    assert record.origin == "committed"
 
 
 @pytest.mark.parametrize(
@@ -329,11 +333,12 @@ def test_a_valid_row_reconstructs_a_segment_record() -> None:
         _mutate(12, "z" * 64),  # file digest: not hex
         _mutate(13, "not-a-stamp"),  # committed_at: not a canonical stamp
         _mutate(13, "2025-01-01T00:00:00.000Z"),  # canonical stamp, wrong day
+        _mutate(14, "bogus"),  # origin: not a known origin
     ],
 )
 def test_every_semantically_invalid_column_is_rejected(row: tuple[object, ...]) -> None:
     with pytest.raises(ValueError):
-        _validated_segment(row, ())
+        validated_segment(row, ())
 
 
 def test_a_malformed_exporter_id_fails_closed(tmp_path: Path) -> None:
@@ -375,13 +380,13 @@ def test_check_constraints_reject_an_invalid_write(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("privacy_class", ["public", "internal", "sensitive"])
 def test_authorize_admits_every_local_persistable_class(privacy_class: str) -> None:
-    _authorize(privacy_class)  # returns without raising
+    authorize_local_persistence(privacy_class)  # returns without raising
 
 
 def test_authorize_denies_a_restricted_class() -> None:
     # Defense behind the header check: if a restricted class reached commit, egress would deny it.
     with pytest.raises(SpoolError) as captured:
-        _authorize("restricted")
+        authorize_local_persistence("restricted")
     assert captured.value.code == "MH_SPOOL_EGRESS"
 
 
@@ -390,12 +395,35 @@ def test_the_store_rejects_a_non_control_database_or_barrier(tmp_path: Path) -> 
     barrier = GlobalCommitBarrier(tmp_path / "control" / "commit.lock")
     try:
         with pytest.raises(SpoolError) as database_error:
-            DurableSpool(database=object(), barrier=barrier, spool_root=spool_root)  # type: ignore[arg-type]
+            DurableSpool(
+                database=object(),  # type: ignore[arg-type]
+                barrier=barrier,
+                spool_root=spool_root,
+                installation_id=_INSTALLATION_ID,
+            )
         assert database_error.value.code == "MH_SPOOL_STORE"
         with pytest.raises(SpoolError) as barrier_error:
-            DurableSpool(database=database, barrier=object(), spool_root=spool_root)  # type: ignore[arg-type]
+            DurableSpool(
+                database=database,
+                barrier=object(),  # type: ignore[arg-type]
+                spool_root=spool_root,
+                installation_id=_INSTALLATION_ID,
+            )
         assert barrier_error.value.code == "MH_SPOOL_STORE"
     finally:
+        database.close()
+
+
+def test_commit_reports_a_barrier_acquisition_failure(tmp_path: Path) -> None:
+    database, store, _spool_root = _spool(tmp_path)
+    os.chmod(tmp_path / "control" / "commit.lock", 0o644)  # tamper the lock after acquisition
+    try:
+        frames = _frames()
+        with pytest.raises(SpoolError) as captured:
+            store.commit_segment(_header(frames), frames, committed_at=_NOW)
+        assert captured.value.code == "MH_SPOOL_BARRIER"
+    finally:
+        os.chmod(tmp_path / "control" / "commit.lock", 0o600)
         database.close()
 
 
@@ -428,6 +456,7 @@ def test_the_store_rejects_a_mismatched_barrier_or_spool_root(tmp_path: Path) ->
                 database=database,
                 barrier=GlobalCommitBarrier(foreign / "commit.lock"),
                 spool_root=spool_root,
+                installation_id=_INSTALLATION_ID,
             )
         assert barrier_error.value.code == "MH_SPOOL_STORE"
         with pytest.raises(SpoolError) as spool_error:
@@ -435,6 +464,7 @@ def test_the_store_rejects_a_mismatched_barrier_or_spool_root(tmp_path: Path) ->
                 database=database,
                 barrier=GlobalCommitBarrier(tmp_path / "control" / "commit.lock"),
                 spool_root=foreign,
+                installation_id=_INSTALLATION_ID,
             )
         assert spool_error.value.code == "MH_SPOOL_STORE"
         # A barrier beside the database but on a different lock file shares no flock with
@@ -444,8 +474,17 @@ def test_the_store_rejects_a_mismatched_barrier_or_spool_root(tmp_path: Path) ->
                 database=database,
                 barrier=GlobalCommitBarrier(tmp_path / "control" / "other.lock"),
                 spool_root=spool_root,
+                installation_id=_INSTALLATION_ID,
             )
         assert wrong_lock.value.code == "MH_SPOOL_STORE"
+        with pytest.raises(SpoolError) as id_error:
+            DurableSpool(
+                database=database,
+                barrier=GlobalCommitBarrier(tmp_path / "control" / "commit.lock"),
+                spool_root=spool_root,
+                installation_id="bad",
+            )
+        assert id_error.value.code == "MH_SPOOL_IDENTITY"
     finally:
         database.close()
 

--- a/tests/unit/test_spool_reader.py
+++ b/tests/unit/test_spool_reader.py
@@ -445,7 +445,7 @@ def test_reader_installation_pattern_matches_the_domain(candidate: str) -> None:
 
     from milhouse.domain.identity import InstallationIdV1
 
-    reader_accepts = reader_module._INSTALLATION_ID_PATTERN.fullmatch(candidate) is not None
+    reader_accepts = reader_module.INSTALLATION_ID_PATTERN.fullmatch(candidate) is not None
     try:
         TypeAdapter(InstallationIdV1).validate_python(candidate)
         domain_accepts = True

--- a/tests/unit/test_spool_reconcile.py
+++ b/tests/unit/test_spool_reconcile.py
@@ -1,0 +1,800 @@
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from milhouse.domain.records import (
+    CollectorDescriptorV1,
+    EventDataV1,
+    RecordDraftV1,
+    RecordEnvelopeV1,
+    SourceDescriptorV1,
+    TargetDescriptorV1,
+    finalize_record,
+)
+from milhouse.spooling import (
+    DurableSpool,
+    OrphanRegistration,
+    SegmentAnomaly,
+    SegmentHeaderV1,
+    SpoolError,
+    SpoolFrameV1,
+    SpoolReconciler,
+    build_segment_bytes,
+    publish_segment_bytes,
+    spool_content_sha256,
+    spool_frame_line,
+)
+from milhouse.spooling import reconcile as reconcile_module
+from milhouse.spooling.reconcile import _fingerprint
+from milhouse.state import (
+    GlobalCommitBarrier,
+    initialize_control_state,
+    open_control_database,
+)
+
+_INSTALLATION_ID = "mh_in1_00000000000040008000000000000000"
+_OTHER_INSTALLATION_ID = "mh_in1_00000000000040008000000000000001"
+_NOW = datetime(2026, 7, 24, 12, 0, 0, tzinfo=UTC)
+_DAY = "2026-07-24"
+
+
+def _envelope(source_event_id: str, installation_id: str = _INSTALLATION_ID) -> RecordEnvelopeV1:
+    values: dict[str, object] = {
+        "record_type": "event",
+        "name": "source.event",
+        "occurred_at": _NOW,
+        "observed_at": _NOW + timedelta(seconds=1),
+        "ingested_at": _NOW + timedelta(seconds=2),
+        "expires_at": _NOW + timedelta(days=30),
+        "source_event_id": source_event_id,
+        "operation_id": "operation-1",
+        "collector_run_id": "collector-run-1",
+        "scope": "target",
+        "source": SourceDescriptorV1.model_validate(
+            {
+                "id": "example-source",
+                "type": "source.event",
+                "producer": "collector",
+                "observation_namespace_id": "mh_ns1_00000000000040008000000000000000",
+                "source_generation_digest": "0" * 64,
+                "observation": {"kind": "source.revision", "parts": {"revision": 1}},
+            }
+        ),
+        "collector": CollectorDescriptorV1(
+            id="c", type="site.canary", implementation_version="1.0.0"
+        ),
+        "target": TargetDescriptorV1(
+            id="example-target", name="E", kind="web.service", environment="test"
+        ),
+        "severity": "info",
+        "trust_level": "authenticated",
+        "privacy_class": "internal",
+        "redaction_version": "r1-e1",
+        "data": EventDataV1(category="availability", status="healthy", message="ok"),
+    }
+    return finalize_record(RecordDraftV1.model_validate(values), installation_id=installation_id)
+
+
+def _segment(
+    batch_id: str = "batch-1", *, installation_id: str = _INSTALLATION_ID, exporters=("clickhouse",)
+) -> tuple[SegmentHeaderV1, tuple[SpoolFrameV1, ...]]:
+    frames = tuple(
+        SpoolFrameV1(
+            batch_id=batch_id, sequence=index, record=_envelope(f"event-{index}", installation_id)
+        )
+        for index in range(1, 3)
+    )
+    lines = [spool_frame_line(frame) for frame in frames]
+    header = SegmentHeaderV1(
+        batch_id=batch_id,
+        config_generation="a" * 64,
+        scope="target",
+        target_id="example-target",
+        privacy_class="internal",
+        retention_days=30,
+        required_exporters=exporters,
+        record_count=len(frames),
+        content_sha256=spool_content_sha256(lines),
+    )
+    return header, frames
+
+
+def _control(tmp_path: Path):
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    os.chmod(control, 0o700)
+    database = open_control_database(control / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(control / "commit.lock")
+    initialize_control_state(database, barrier=barrier, applied_at=_NOW)
+    spool_root = tmp_path / "spool"
+    spool_root.mkdir(mode=0o700)
+    os.chmod(spool_root, 0o700)
+    return database, barrier, spool_root
+
+
+def _reconciler(tmp_path: Path, installation_id: str = _INSTALLATION_ID):
+    database, barrier, spool_root = _control(tmp_path)
+    store = DurableSpool(
+        database=database, barrier=barrier, spool_root=spool_root, installation_id=installation_id
+    )
+    reconciler = SpoolReconciler(
+        database=database, barrier=barrier, spool_root=spool_root, installation_id=installation_id
+    )
+    return database, store, spool_root, reconciler
+
+
+def _publish_orphan(spool_root: Path, day: str, name: str, content: bytes) -> Path:
+    pending = spool_root / "pending"
+    if not pending.exists():
+        pending.mkdir(mode=0o700)
+        os.chmod(pending, 0o700)
+    day_dir = pending / day
+    if not day_dir.exists():
+        day_dir.mkdir(mode=0o700)
+        os.chmod(day_dir, 0o700)
+    path = day_dir / name
+    publish_segment_bytes(path, content)
+    return path
+
+
+def _count(database, table: str = "_segments") -> int:
+    return database.connection.execute(f"SELECT count(*) FROM {table}").fetchone()[0]
+
+
+# --- empty and healthy ---------------------------------------------------------------------------
+
+
+def test_reconciling_an_empty_spool_reports_nothing(tmp_path: Path) -> None:
+    database, _store, _spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        report = reconciler.reconcile()
+        assert report == reconcile_module.ReconciliationReport((), (), 0, 0)
+    finally:
+        database.close()
+
+
+def test_a_committed_segment_reconciles_as_healthy(tmp_path: Path) -> None:
+    database, store, _spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment()
+        store.commit_segment(header, frames, committed_at=_NOW)
+        report = reconciler.reconcile()
+        assert report.healthy == 1
+        assert report.scanned == 1
+        assert report.registered == ()
+        assert report.anomalies == ()
+    finally:
+        database.close()
+
+
+# --- mandatory reconciliation on writer acquisition (P1-1) ---------------------------------------
+
+
+def test_acquiring_the_writer_reconciles_orphans_before_any_commit(tmp_path: Path) -> None:
+    # publish an orphan, then acquire a fresh writer via the normal API — no separate reconcile call
+    database, barrier, spool_root = _control(tmp_path)
+    try:
+        header, frames = _segment(batch_id="orphan-1")
+        _publish_orphan(spool_root, _DAY, "orphan-1.jsonl", build_segment_bytes(header, frames))
+        assert _count(database) == 0
+
+        store = DurableSpool(
+            database=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            installation_id=_INSTALLATION_ID,
+        )
+        # the orphan is registered by acquisition alone, before this writer publishes anything
+        assert store.read_segment("orphan-1") is not None
+        assert store.last_reconciliation.registered == (OrphanRegistration("orphan-1", _DAY),)
+
+        later, later_frames = _segment(batch_id="later-2")
+        store.commit_segment(later, later_frames, committed_at=_NOW)
+        assert {r.batch_id for r in store.list_segments()} == {"orphan-1", "later-2"}
+    finally:
+        database.close()
+
+
+def test_acquisition_barrier_failure_surfaces_a_spool_error(tmp_path: Path) -> None:
+    database, barrier, spool_root = _control(tmp_path)
+    os.chmod(tmp_path / "control" / "commit.lock", 0o644)  # a tampered lock fails the secure open
+    try:
+        with pytest.raises(SpoolError) as captured:
+            DurableSpool(
+                database=database,
+                barrier=barrier,
+                spool_root=spool_root,
+                installation_id=_INSTALLATION_ID,
+            )
+        assert captured.value.code == "MH_SPOOL_BARRIER"
+    finally:
+        os.chmod(tmp_path / "control" / "commit.lock", 0o600)
+        database.close()
+
+
+# --- orphan registration -------------------------------------------------------------------------
+
+
+def test_a_valid_orphan_is_registered_from_its_durable_header(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment()
+        _publish_orphan(spool_root, _DAY, "batch-1.jsonl", build_segment_bytes(header, frames))
+
+        report = reconciler.reconcile()
+
+        assert report.registered == (OrphanRegistration("batch-1", _DAY),)
+        assert report.anomalies == ()
+        row = database.connection.execute(
+            "SELECT day, committed_at, origin FROM _segments WHERE batch_id = 'batch-1'"
+        ).fetchone()
+        assert row == (_DAY, f"{_DAY}T00:00:00.000Z", "reconciled")
+        exporters = database.connection.execute(
+            "SELECT exporter_id, delivery_status FROM _segment_exporters WHERE batch_id = 'batch-1'"
+        ).fetchall()
+        assert exporters == [("clickhouse", "pending")]
+    finally:
+        database.close()
+
+
+def test_reconciliation_is_idempotent(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment()
+        _publish_orphan(spool_root, _DAY, "batch-1.jsonl", build_segment_bytes(header, frames))
+        assert len(reconciler.reconcile().registered) == 1
+        second = reconciler.reconcile()
+        assert second.registered == ()
+        assert second.healthy == 1
+        assert second.anomalies == ()
+        assert _count(database) == 1
+    finally:
+        database.close()
+
+
+def test_a_multi_exporter_orphan_registers_every_exporter(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment(exporters=("alpha", "beta"))
+        _publish_orphan(spool_root, _DAY, "batch-1.jsonl", build_segment_bytes(header, frames))
+        reconciler.reconcile()
+        rows = database.connection.execute(
+            "SELECT exporter_id FROM _segment_exporters WHERE batch_id = 'batch-1' "
+            "ORDER BY exporter_id"
+        ).fetchall()
+        assert [r[0] for r in rows] == ["alpha", "beta"]
+    finally:
+        database.close()
+
+
+# --- provenance and egress during reconciliation -------------------------------------------------
+
+
+def test_an_orphan_minted_by_a_foreign_installation_is_not_registered(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment(installation_id=_OTHER_INSTALLATION_ID)
+        _publish_orphan(spool_root, _DAY, "batch-1.jsonl", build_segment_bytes(header, frames))
+        report = reconciler.reconcile()
+        assert report.registered == ()
+        assert report.anomalies == (
+            SegmentAnomaly("batch-1", _DAY, "corrupt_orphan", "MH_SPOOL_RECORD"),
+        )
+        assert _count(database) == 0
+    finally:
+        database.close()
+
+
+def test_an_egress_denied_orphan_is_not_registered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # the matrix admits every valid class today, but a denial must leave both tables unchanged
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+
+    def _deny(_privacy_class: str) -> None:
+        raise SpoolError("MH_SPOOL_EGRESS", "denied")
+
+    monkeypatch.setattr(reconcile_module, "authorize_local_persistence", _deny)
+    try:
+        header, frames = _segment()
+        _publish_orphan(spool_root, _DAY, "batch-1.jsonl", build_segment_bytes(header, frames))
+        report = reconciler.reconcile()
+        assert report.registered == ()
+        assert report.anomalies == (
+            SegmentAnomaly("batch-1", _DAY, "corrupt_orphan", "MH_SPOOL_EGRESS"),
+        )
+        assert _count(database) == 0
+        assert _count(database, "_segment_exporters") == 0
+    finally:
+        database.close()
+
+
+# --- full ledger/file agreement (P1-2) -----------------------------------------------------------
+
+
+def test_a_fully_matching_committed_file_is_healthy(tmp_path: Path) -> None:
+    database, store, _spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment(exporters=("alpha", "beta"))
+        store.commit_segment(header, frames, committed_at=_NOW)
+        report = reconciler.reconcile()
+        assert report.healthy == 1
+        assert report.anomalies == ()
+    finally:
+        database.close()
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        f"UPDATE _segments SET config_generation = '{'b' * 64}' WHERE batch_id = 'batch-1'",
+        "UPDATE _segments SET privacy_class = 'public' WHERE batch_id = 'batch-1'",
+        "UPDATE _segments SET retention_days = 29 WHERE batch_id = 'batch-1'",
+        "UPDATE _segments SET record_count = 1 WHERE batch_id = 'batch-1'",
+        "UPDATE _segments SET content_sha256 = 'c' || substr(content_sha256, 2) "
+        "WHERE batch_id = 'batch-1'",
+        "UPDATE _segments SET byte_size = byte_size + 1 WHERE batch_id = 'batch-1'",
+        "UPDATE _segments SET file_sha256 = 'e' || substr(file_sha256, 2) "
+        "WHERE batch_id = 'batch-1'",
+        "UPDATE _segments SET target_id = 'other-target' WHERE batch_id = 'batch-1'",
+        "UPDATE _segments SET scope = 'installation', target_id = NULL WHERE batch_id = 'batch-1'",
+        "DELETE FROM _segment_exporters WHERE batch_id = 'batch-1'",
+    ],
+)
+def test_a_committed_file_that_disagrees_with_any_ledger_field_is_not_healthy(
+    tmp_path: Path, mutation: str
+) -> None:
+    database, store, _spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment()
+        store.commit_segment(header, frames, committed_at=_NOW)
+        with database.transaction() as connection:
+            connection.execute(mutation)
+        report = reconciler.reconcile()
+        assert report.healthy == 0
+        assert report.anomalies == (
+            SegmentAnomaly("batch-1", _DAY, "corrupt_file", "ledger_mismatch"),
+        )
+    finally:
+        database.close()
+
+
+def test_a_corrupt_committed_file_is_flagged(tmp_path: Path) -> None:
+    database, store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment()
+        store.commit_segment(header, frames, committed_at=_NOW)
+        (spool_root / "pending" / _DAY / "batch-1.jsonl").write_bytes(b"truncated\n")
+        report = reconciler.reconcile()
+        assert report.healthy == 0
+        assert report.anomalies[0].kind == "corrupt_file"
+        assert report.anomalies[0].detail.startswith("MH_SPOOL_")
+    finally:
+        database.close()
+
+
+def test_a_malformed_ledger_row_is_flagged(tmp_path: Path) -> None:
+    database, _store, _spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        # length-10 but not a calendar day: passes the CHECK, fails semantic validation
+        with database.transaction() as connection:
+            connection.execute(
+                "INSERT INTO _segments (batch_id, day, schema_version, frame_version, "
+                "config_generation, scope, target_id, privacy_class, retention_days, record_count, "
+                "content_sha256, byte_size, file_sha256, committed_at, origin) VALUES "
+                "('bad', '2026-13-45', 1, 1, ?, 'target', 't', 'internal', 30, 1, ?, 10, ?, "
+                "'2026-13-45T00:00:00.000Z', 'committed')",
+                ("a" * 64, "c" * 64, "d" * 64),
+            )
+        report = reconciler.reconcile()
+        assert report.anomalies == (SegmentAnomaly("bad", "", "corrupt_ledger", "unreadable_row"),)
+        assert report.healthy == 0
+    finally:
+        database.close()
+
+
+def test_a_missing_segment_file_is_flagged(tmp_path: Path) -> None:
+    database, store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment()
+        store.commit_segment(header, frames, committed_at=_NOW)
+        (spool_root / "pending" / _DAY / "batch-1.jsonl").unlink()
+        report = reconciler.reconcile()
+        assert report.anomalies == (SegmentAnomaly("batch-1", _DAY, "missing_file", "absent"),)
+        assert report.healthy == 0
+    finally:
+        database.close()
+
+
+# --- conflicting duplicates (P1-3) ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("identical", [True, False])
+def test_a_batch_at_two_paths_registers_none(tmp_path: Path, identical: bool) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header_a, frames_a = _segment(batch_id="batch-1")
+        content_a = build_segment_bytes(header_a, frames_a)
+        if identical:
+            content_b = content_a
+        else:
+            header_b, frames_b = _segment(batch_id="batch-1", exporters=("clickhouse", "extra"))
+            content_b = build_segment_bytes(header_b, frames_b)
+        _publish_orphan(spool_root, "2026-07-23", "batch-1.jsonl", content_a)
+        _publish_orphan(spool_root, "2026-07-24", "batch-1.jsonl", content_b)
+
+        report = reconciler.reconcile()
+
+        assert report.registered == ()
+        assert {a.kind for a in report.anomalies} == {"conflict"}
+        assert len(report.anomalies) == 2
+        assert _count(database) == 0
+        assert _count(database, "_segment_exporters") == 0
+        # a re-run stays mutation-free and deterministic
+        assert reconciler.reconcile().registered == ()
+        assert _count(database) == 0
+    finally:
+        database.close()
+
+
+# --- foreign names and bounds, with no raw path in the report (P2-1) -----------------------------
+
+
+def test_an_orphan_whose_name_disagrees_with_its_header_is_flagged(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment(batch_id="batch-1")
+        _publish_orphan(spool_root, _DAY, "impostor.jsonl", build_segment_bytes(header, frames))
+        report = reconciler.reconcile()
+        assert report.registered == ()
+        assert report.anomalies == (
+            SegmentAnomaly("impostor", _DAY, "foreign_name", "header_batch_id"),
+        )
+    finally:
+        database.close()
+
+
+@pytest.mark.parametrize(
+    ("name", "detail"),
+    [("batch-1.txt", "suffix"), ("..sneaky.jsonl", "batch_id")],
+)
+def test_a_foreign_file_name_is_fingerprinted(tmp_path: Path, name: str, detail: str) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        pending = spool_root / "pending"
+        pending.mkdir(mode=0o700)
+        os.chmod(pending, 0o700)
+        day_dir = pending / _DAY
+        day_dir.mkdir(mode=0o700)
+        os.chmod(day_dir, 0o700)
+        (day_dir / name).write_bytes(b"x")
+        os.chmod(day_dir / name, 0o600)
+        report = reconciler.reconcile()
+        assert report.anomalies == (
+            SegmentAnomaly(_fingerprint(name), _DAY, "foreign_name", detail),
+        )
+        assert name not in report.anomalies[0].batch_id
+    finally:
+        database.close()
+
+
+def test_an_invalid_day_name_is_fingerprinted_and_leaks_no_raw_name(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        pending = spool_root / "pending"
+        pending.mkdir(mode=0o700)
+        os.chmod(pending, 0o700)
+        canary = "CANARY_SECRET-not-a-day"
+        (pending / canary).mkdir(mode=0o700)
+        report = reconciler.reconcile()
+        assert report.anomalies == (
+            SegmentAnomaly("", _fingerprint(canary), "foreign_name", "day"),
+        )
+        assert canary not in repr(report.anomalies[0])
+    finally:
+        database.close()
+
+
+@pytest.mark.parametrize("day", ["not-a-date", "2026-13-45", "2026-07- 5", "2026"])
+def test_a_non_canonical_day_directory_is_rejected_without_a_poison_row(
+    tmp_path: Path, day: str
+) -> None:
+    database, store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment()
+        _publish_orphan(spool_root, day, "batch-1.jsonl", build_segment_bytes(header, frames))
+        report = reconciler.reconcile()
+        assert report.registered == ()
+        assert report.anomalies == (SegmentAnomaly("", _fingerprint(day), "foreign_name", "day"),)
+        assert _count(database) == 0
+        assert store.list_segments() == ()  # the ledger stays readable — no poison row
+    finally:
+        database.close()
+
+
+def test_a_symlinked_day_directory_is_reported_unsafe(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        pending = spool_root / "pending"
+        pending.mkdir(mode=0o700)
+        os.chmod(pending, 0o700)
+        (pending / _DAY).symlink_to(tmp_path)
+        report = reconciler.reconcile()
+        assert report.anomalies == (SegmentAnomaly("", _DAY, "foreign_name", "day_unsafe"),)
+    finally:
+        database.close()
+
+
+def test_a_world_writable_day_directory_is_reported_unsafe(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    pending = spool_root / "pending"
+    pending.mkdir(mode=0o700)
+    os.chmod(pending, 0o700)
+    day_dir = pending / _DAY
+    day_dir.mkdir(mode=0o700)
+    os.chmod(day_dir, 0o777)
+    try:
+        report = reconciler.reconcile()
+        assert report.anomalies == (SegmentAnomaly("", _DAY, "foreign_name", "day_unsafe"),)
+    finally:
+        os.chmod(day_dir, 0o700)
+        database.close()
+
+
+def test_a_world_writable_pending_directory_is_reported_unsafe(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    pending = spool_root / "pending"
+    pending.mkdir(mode=0o700)
+    os.chmod(pending, 0o777)
+    try:
+        report = reconciler.reconcile()
+        assert report.anomalies == (SegmentAnomaly("", "", "foreign_name", "pending_unsafe"),)
+    finally:
+        os.chmod(pending, 0o700)
+        database.close()
+
+
+def _two_day_dirs(spool_root: Path) -> Path:
+    pending = spool_root / "pending"
+    pending.mkdir(mode=0o700)
+    os.chmod(pending, 0o700)
+    for day in ("2026-07-24", "2026-07-25"):
+        (pending / day).mkdir(mode=0o700)
+    return pending
+
+
+def test_too_many_day_directories_hits_the_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    monkeypatch.setattr(reconcile_module, "_MAX_DAYS", 1)
+    _two_day_dirs(spool_root)
+    try:
+        assert SegmentAnomaly("", "", "limit", "day_limit") in reconciler.reconcile().anomalies
+    finally:
+        database.close()
+
+
+def test_too_many_entries_in_a_day_hits_the_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    monkeypatch.setattr(reconcile_module, "_MAX_ENTRIES", 1)
+    day_dir = spool_root / "pending" / _DAY
+    day_dir.mkdir(mode=0o700, parents=True)
+    os.chmod(spool_root / "pending", 0o700)
+    os.chmod(day_dir, 0o700)
+    for name in ("a.jsonl", "b.jsonl"):
+        (day_dir / name).write_bytes(b"x")
+    try:
+        assert reconciler.reconcile().anomalies == (
+            SegmentAnomaly("", _DAY, "foreign_name", "day_too_many"),
+        )
+    finally:
+        database.close()
+
+
+def test_too_many_total_files_stops_the_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    monkeypatch.setattr(reconcile_module, "_MAX_TOTAL", 0)
+    day_dir = spool_root / "pending" / _DAY
+    day_dir.mkdir(mode=0o700, parents=True)
+    os.chmod(spool_root / "pending", 0o700)
+    os.chmod(day_dir, 0o700)
+    (day_dir / "batch-1.jsonl").write_bytes(b"x")
+    try:
+        assert SegmentAnomaly("", "", "limit", "scan_limit") in reconciler.reconcile().anomalies
+    finally:
+        database.close()
+
+
+def test_too_many_anomalies_hits_the_bound(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    monkeypatch.setattr(reconcile_module, "_MAX_ANOMALIES", 1)
+    pending = spool_root / "pending"
+    pending.mkdir(mode=0o700)
+    os.chmod(pending, 0o700)
+    for junk in ("not-a-day-1", "not-a-day-2", "not-a-day-3"):
+        (pending / junk).mkdir(mode=0o700)
+    try:
+        report = reconciler.reconcile()
+        # once the cap is hit the limit anomaly is recorded once; further overflow is dropped
+        assert SegmentAnomaly("", "", "limit", "anomaly_limit") in report.anomalies
+        assert len(report.anomalies) == 2
+    finally:
+        database.close()
+
+
+def test_a_file_for_a_malformed_ledger_row_is_not_reread(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        with database.transaction() as connection:
+            connection.execute(
+                "INSERT INTO _segments (batch_id, day, schema_version, frame_version, "
+                "config_generation, scope, target_id, privacy_class, retention_days, record_count, "
+                "content_sha256, byte_size, file_sha256, committed_at, origin) VALUES "
+                "('batch-1', '2026-13-45', 1, 1, ?, 'target', 't', 'internal', 30, 1, ?, 10, ?, "
+                "'2026-13-45T00:00:00.000Z', 'committed')",
+                ("a" * 64, "c" * 64, "d" * 64),
+            )
+        _publish_orphan(spool_root, _DAY, "batch-1.jsonl", b"anything\n")
+        report = reconciler.reconcile()
+        # the malformed row is reported once; its file is skipped, not registered or certified
+        assert report.anomalies == (
+            SegmentAnomaly("batch-1", "", "corrupt_ledger", "unreadable_row"),
+        )
+        assert report.healthy == 0
+        assert report.registered == ()
+    finally:
+        database.close()
+
+
+# --- origin exposure through the ledger API (P2-3) -----------------------------------------------
+
+
+def test_the_ledger_api_surfaces_committed_and_reconciled_origins(tmp_path: Path) -> None:
+    database, store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        committed_header, committed_frames = _segment(batch_id="committed-1")
+        store.commit_segment(committed_header, committed_frames, committed_at=_NOW)
+        orphan_header, orphan_frames = _segment(batch_id="reconciled-1")
+        _publish_orphan(
+            spool_root,
+            _DAY,
+            "reconciled-1.jsonl",
+            build_segment_bytes(orphan_header, orphan_frames),
+        )
+        reconciler.reconcile()
+
+        origins = {record.batch_id: record.origin for record in store.list_segments()}
+        assert origins == {"committed-1": "committed", "reconciled-1": "reconciled"}
+        reconciled = store.read_segment("reconciled-1")
+        assert reconciled is not None
+        assert reconciled.committed_at == f"{_DAY}T00:00:00.000Z"
+    finally:
+        database.close()
+
+
+# --- binding, barrier, and failure boundary ------------------------------------------------------
+
+
+def test_the_reconciler_rejects_a_bad_binding_or_installation(tmp_path: Path) -> None:
+    database, barrier, spool_root = _control(tmp_path)
+    try:
+        for kwargs, code in (
+            ({"database": object()}, "MH_SPOOL_STORE"),
+            ({"barrier": object()}, "MH_SPOOL_STORE"),
+            (
+                {"barrier": GlobalCommitBarrier(tmp_path / "control" / "other.lock")},
+                "MH_SPOOL_STORE",
+            ),
+            ({"spool_root": tmp_path / "elsewhere"}, "MH_SPOOL_STORE"),
+            ({"installation_id": "bad"}, "MH_SPOOL_IDENTITY"),
+        ):
+            base = {
+                "database": database,
+                "barrier": barrier,
+                "spool_root": spool_root,
+                "installation_id": _INSTALLATION_ID,
+            }
+            base.update(kwargs)
+            with pytest.raises(SpoolError) as captured:
+                SpoolReconciler(**base)  # type: ignore[arg-type]
+            assert captured.value.code == code
+    finally:
+        database.close()
+
+
+def test_reconciliation_happens_inside_the_exclusive_barrier(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    header, frames = _segment()
+    _publish_orphan(spool_root, _DAY, "batch-1.jsonl", build_segment_bytes(header, frames))
+    real_barrier = reconciler._barrier  # type: ignore[attr-defined]
+
+    class _AssertingBarrier:
+        @contextlib.contextmanager
+        def exclusive(self, *, blocking: bool = True) -> Iterator[None]:
+            assert _count(database) == 0  # not yet registered when the exclusive lock is taken
+            with real_barrier.exclusive(blocking=blocking):
+                yield
+
+    reconciler._barrier = _AssertingBarrier()  # type: ignore[attr-defined]
+    try:
+        assert len(reconciler.reconcile().registered) == 1
+        assert _count(database) == 1
+    finally:
+        database.close()
+
+
+def test_a_barrier_acquisition_failure_surfaces_a_spool_error(tmp_path: Path) -> None:
+    # a tampered lock makes the secure barrier open fail with a StateError; the writer API must only
+    # ever surface a fixed MH_SPOOL_* error, never a raw state error
+    database, _store, _spool_root, reconciler = _reconciler(tmp_path)
+    os.chmod(tmp_path / "control" / "commit.lock", 0o644)
+    try:
+        with pytest.raises(SpoolError) as captured:
+            reconciler.reconcile()
+        assert captured.value.code == "MH_SPOOL_BARRIER"
+        assert captured.value.__cause__ is None
+        assert captured.value.__context__ is None
+    finally:
+        os.chmod(tmp_path / "control" / "commit.lock", 0o600)
+        database.close()
+
+
+def test_a_malformed_ledger_batch_id_is_fingerprinted_not_echoed(tmp_path: Path) -> None:
+    database, _store, _spool_root, reconciler = _reconciler(tmp_path)
+    injected = "evil\nINJECTED-CANARY"
+    try:
+        with database.transaction() as connection:
+            connection.execute(
+                "INSERT INTO _segments (batch_id, day, schema_version, frame_version, "
+                "config_generation, scope, target_id, privacy_class, retention_days, record_count, "
+                "content_sha256, byte_size, file_sha256, committed_at, origin) VALUES "
+                "(?, '2026-07-24', 1, 1, ?, 'target', 't', 'internal', 30, 1, ?, 10, ?, "
+                "'2026-07-24T00:00:00.000Z', 'committed')",
+                (injected, "a" * 64, "c" * 64, "d" * 64),
+            )
+        report = reconciler.reconcile()
+        assert report.anomalies == (
+            SegmentAnomaly(_fingerprint(injected), "", "corrupt_ledger", "unreadable_row"),
+        )
+        assert "INJECTED-CANARY" not in repr(report.anomalies[0])
+    finally:
+        database.close()
+
+
+def test_an_unreadable_ledger_fails_closed(tmp_path: Path) -> None:
+    database, _store, _spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        with database.transaction() as connection:
+            connection.execute("DROP TABLE _segments")
+        with pytest.raises(SpoolError) as captured:
+            reconciler.reconcile()
+        assert captured.value.code == "MH_SPOOL_LEDGER"
+    finally:
+        database.close()
+
+
+def test_a_registration_failure_is_reported_as_reconcile_uncertain(tmp_path: Path) -> None:
+    database, _store, spool_root, reconciler = _reconciler(tmp_path)
+    try:
+        header, frames = _segment()
+        _publish_orphan(spool_root, _DAY, "batch-1.jsonl", build_segment_bytes(header, frames))
+        with database.transaction() as connection:
+            connection.execute("DROP TABLE _segment_exporters")
+        with pytest.raises(SpoolError) as captured:
+            reconciler.reconcile()
+        assert captured.value.code == "MH_SPOOL_RECONCILE"
+        assert captured.value.__cause__ is None
+        assert captured.value.__context__ is None
+    finally:
+        database.close()


### PR DESCRIPTION
## W03 slice 3c — spool reconciliation scan

Closes the commit-uncertain gap from slice 3a. Startup and every writer acquisition must reconcile the durable spool with the SQLite ledger (ADR 0004, plan §4.3): a commit publishes the segment file and *then* records its ledger row, so a crash between those steps leaves a durably-published but unrecorded **orphan**.

### What it does
`SpoolReconciler.reconcile()` holds the **exclusive** commit barrier and scans `<spool_root>/pending` against `_segments`:
- **registers each valid orphan** (a trusted, provenance-verified file with no ledger row) — reconstructed **only from the durable header**, never from newer config, with a reconstructed day-start `committed_at` and `origin='reconciled'` so the ledger never records a false precise commit time;
- **reports** every ledger row whose file is missing, every present file that fails trusted validation or disagrees with its row, and every foreign file name;
- returns a `ReconciliationReport(registered, anomalies, healthy, scanned)`. It never deletes, quarantines, or moves a file.

Orphans are registered **only** through `read_trusted_segment` (slice 3b), so a canonical-but-forged or foreign-installation record is never registered as durable state (regression test included).

Migration 3 adds an append-only `origin` column (`DEFAULT 'committed'`); a normal commit omits it, so `commit.py` is unchanged.

### Trust & safety
- All mutation is inside `barrier.exclusive()`; the ledger snapshot and every INSERT share that scope, and committers take the shared side, so no committer can slip a row in between.
- Every failure is a fixed `MH_SPOOL_*` raised outside any handler: registration failure → `MH_SPOOL_RECONCILE`, ledger-read failure → `MH_SPOOL_LEDGER` (both catch `sqlite3.Error` **and** `StateError`).

### Pre-push adversarial review
Confirmed provenance, config-independence, exclusive-barrier mutation, and the fixed-error boundary. It caught a **P1**, now fixed:

> `datetime.strptime('%Y-%m-%d')` accepts a **space-padded** day (`"2026-07- 5"`). Registering it would write a `committed_at` the schema's length-only CHECK admits but the ledger reader's stricter `_STAMP` regex rejects — a **poison row** that fail-closes every later `list_segments`/`read_segment`.

Fix: strict ASCII day regex + a defensive register-time guard; regression proves the ledger stays fully readable. Two P3 notes also addressed (bounded the untrusted day echoed into a report; documented the convergent mid-scan-abort behavior).

### Gate
23 reconciler tests; `reconcile.py` **100% branch**. `make quality`, `test-coverage`, `package` pass — **3284 tests**; line 97.92%, branch 96.75%. DCO-clean single commit.

### Next
Quarantine (move corrupt/foreign files to `quarantine/`), stale-`tmp/` recovery, anomaly persistence, then torn-frame recovery and `spool verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
