### PR TITLE
fix(core,state): remediate the five post-merge D04 findings (structured-log surface)

### DIFF
--- a/src/milhouse/core/log_store.py
+++ b/src/milhouse/core/log_store.py
@@ -140,13 +140,18 @@ def _resolve_logs_dir(logs_dir: str | Path) -> Path:
     return resolved
 
 
-def _open_logs_dir(logs_dir: Path) -> int:
-    """Open the logs directory as an owned, exact-0700, ACL-free no-follow descriptor."""
+def _close_fd(descriptor: int) -> None:
+    try:
+        os.close(descriptor)
+    except OSError:  # pragma: no cover - defensive close failure
+        pass
+
+
+def _require_logs_envelope(descriptor: int) -> None:
+    """Require an opened logs directory to be an owned, exact-0700, ACL-free directory."""
 
     unsafe = False
-    descriptor: int | None = None
     try:
-        descriptor = os.open(logs_dir, os.O_RDONLY | _NOFOLLOW | _DIRECTORY | _CLOEXEC)
         info = os.fstat(descriptor)
         if (
             not stat.S_ISDIR(info.st_mode)
@@ -159,41 +164,85 @@ def _open_logs_dir(logs_dir: Path) -> int:
     except Exception:
         unsafe = True
     if unsafe:
-        if descriptor is not None:
-            try:
-                os.close(descriptor)
-            except OSError:  # pragma: no cover - defensive close failure
-                pass
         _fail("MH_LOG_DIR", "the logs directory must be an owned, ACL-free 0o700 directory")
+
+
+def _open_dir_component(parent_fd: int | None, name: str | Path) -> int:
+    """Open one path component as an owned no-follow directory descriptor.
+
+    ``parent_fd`` is None only for the trusted state-root anchor (opened by absolute path, so its
+    own ancestors are the authenticated runtime home); every component beneath it is opened
+    descriptor-relative, so a symlinked ancestor at any depth below the state root fails closed.
+    """
+
+    unsafe = False
+    descriptor: int | None = None
+    flags = os.O_RDONLY | _NOFOLLOW | _DIRECTORY | _CLOEXEC
+    try:
+        descriptor = (
+            os.open(name, flags) if parent_fd is None else os.open(name, flags, dir_fd=parent_fd)
+        )
+        info = os.fstat(descriptor)
+        if not stat.S_ISDIR(info.st_mode) or info.st_uid != _current_uid():
+            unsafe = True
+    except Exception:
+        unsafe = True
+    if unsafe:
+        if descriptor is not None:
+            _close_fd(descriptor)
+        _fail("MH_LOG_DIR", "the logs path must be an owned symlink-free directory chain")
     assert descriptor is not None
     return descriptor
 
 
-def _require_live_directory(directory_fd: int, logs_dir: Path, code: str) -> None:
-    """Require the configured logs path to still name the held directory descriptor.
+def _open_logs_dir(state_root: Path, logs_dir: Path) -> int:
+    """Open the logs directory by walking the state-root-to-logs chain no-follow per component.
 
-    A directory swap after open would otherwise silently redirect every descriptor-relative
-    write outside ``[paths].logs`` while the API reports success — the held descriptor follows
-    the renamed directory. Every mutation and maintenance operation re-proves the live binding
-    under the log lock before touching anything (POSIX offers no bind-and-operate, so the
-    one-syscall residual window is closed to cooperating processes by that lock).
+    The state root's own path is trusted (the A06 authenticated runtime home); every component
+    from the state root down to the logs directory is opened ``O_NOFOLLOW``, so a symlinked
+    ancestor at any depth beneath the state root fails closed and never redirects creation or
+    descriptor-relative writes outside ``[paths].logs``. The logs directory must additionally be an
+    owned, ACL-free ``0o700`` directory and must lie within the state root.
+    """
+
+    root = lexical_absolute_path(state_root)
+    logs = lexical_absolute_path(logs_dir)
+    if logs != root and not logs.is_relative_to(root):
+        _fail("MH_LOG_DIR", "the logs directory must lie within the state root")
+    directory_fd = _open_dir_component(None, root)
+    try:
+        for component in logs.relative_to(root).parts:
+            child_fd = _open_dir_component(directory_fd, component)
+            _close_fd(directory_fd)
+            directory_fd = child_fd
+        _require_logs_envelope(directory_fd)
+    except BaseException:
+        _close_fd(directory_fd)
+        raise
+    return directory_fd
+
+
+def _require_live_directory(directory_fd: int, state_root: Path, logs_dir: Path, code: str) -> None:
+    """Require the configured state-root-to-logs chain to still name the held descriptor.
+
+    A directory swap, or a symlink newly interposed on the chain after open, would otherwise
+    silently redirect every descriptor-relative write outside ``[paths].logs``. Every mutation and
+    maintenance operation re-walks the chain no-follow under the log lock and proves the live logs
+    inode still equals the held descriptor before touching anything.
     """
 
     bound = False
     probe: int | None = None
     try:
-        probe = os.open(logs_dir, os.O_RDONLY | _NOFOLLOW | _DIRECTORY | _CLOEXEC)
+        probe = _open_logs_dir(state_root, logs_dir)
         held = os.fstat(directory_fd)
         live = os.fstat(probe)
         bound = (held.st_dev, held.st_ino) == (live.st_dev, live.st_ino)
-    except OSError:
+    except (LoggingError, OSError):
         bound = False
     finally:
         if probe is not None:
-            try:
-                os.close(probe)
-            except OSError:  # pragma: no cover - defensive close failure
-                bound = False
+            _close_fd(probe)
     if not bound:
         _fail(code, "the configured logs directory no longer names the held descriptor")
 
@@ -575,19 +624,29 @@ def _list_rotated(directory_fd: int) -> dict[int, str]:
     return rotated
 
 
-def _require_logs_barrier(barrier: GlobalCommitBarrier, logs_dir: Path) -> None:
-    """Require the state root's own commit barrier before maintenance takes its exclusive side.
+def _require_logs_barrier(barrier: GlobalCommitBarrier, logs_dir: Path) -> Path:
+    """Require the passed barrier's own state root and that the logs directory lies within it.
 
-    The logs directory is a runtime child of the state root, whose control-plane commit lock is
-    ``<state_root>/control/commit.lock``. Maintenance authority is the genuine exclusive ``flock``
-    of THAT barrier — acquired by the caller of ``barrier.exclusive()`` below, never a mintable
-    token — so a barrier bound to any other lock path, or any non-barrier object, is not authority
-    here and fails closed before a descriptor is opened.
+    The barrier is the maintenance authority; its lock is ``<state_root>/control/commit.lock``, so
+    the state root is derived from the barrier itself rather than assumed to be the logs directory's
+    parent — the latter is wrong for a plan-valid nested ``[paths].logs``. A non-barrier, a barrier
+    whose lock is not a control commit lock, a self-inconsistent (tampered) barrier, or a logs
+    directory outside that state root fails closed before a descriptor is opened. Returns the state
+    root so the caller can open the logs chain no-follow within it.
     """
 
-    expected = lexical_absolute_path(logs_dir).parent / _CONTROL_DIR / _BARRIER_NAME
-    if not _is_bound_barrier(barrier, expected):
-        _fail("MH_LOG_AUTHORITY", "maintenance requires a live exclusive hold of this state root")
+    if type(barrier) is not GlobalCommitBarrier:
+        _fail("MH_LOG_AUTHORITY", "maintenance requires this state root's commit barrier")
+    lock_path = lexical_absolute_path(barrier.path)
+    if lock_path.name != _BARRIER_NAME or lock_path.parent.name != _CONTROL_DIR:
+        _fail("MH_LOG_AUTHORITY", "maintenance requires this state root's commit barrier")
+    if not _is_bound_barrier(barrier, lock_path):
+        _fail("MH_LOG_AUTHORITY", "maintenance requires this state root's commit barrier")
+    state_root = lock_path.parent.parent
+    logs = lexical_absolute_path(logs_dir)
+    if logs != state_root and not logs.is_relative_to(state_root):
+        _fail("MH_LOG_AUTHORITY", "the logs directory is not within the barrier's state root")
+    return state_root
 
 
 class StructuredLogStore:
@@ -616,6 +675,7 @@ class StructuredLogStore:
         "_logs_dir",
         "_retention_days",
         "_size",
+        "_state_root",
     )
 
     def __init__(
@@ -625,15 +685,21 @@ class StructuredLogStore:
         retention_days: int,
         monotonic: Callable[[], float],
         opened_at: datetime,
+        state_root: str | Path | None = None,
         sleeper: Callable[[float], None] = time.sleep,
     ) -> None:
         _require_platform()
         if type(retention_days) is not int or not 1 <= retention_days <= 3_650:
             _fail("MH_LOG_RETENTION", "a bounded positive retention is required")
         self._logs_dir = _resolve_logs_dir(logs_dir)
+        # the trusted anchor the logs chain is opened no-follow within; defaults to the logs
+        # parent, but a caller with a nested [paths].logs passes the true state root
+        self._state_root = (
+            _resolve_logs_dir(state_root) if state_root is not None else self._logs_dir.parent
+        )
         self._retention_days = retention_days
         self._closed = False
-        self._directory_fd = _open_logs_dir(self._logs_dir)
+        self._directory_fd = _open_logs_dir(self._state_root, self._logs_dir)
         self._lock = _LogLock(self._directory_fd, monotonic, sleeper)
         lock_fd = self._lock.acquire()
         try:
@@ -774,7 +840,9 @@ class StructuredLogStore:
         never corrupted.
         """
 
-        _require_live_directory(self._directory_fd, self._logs_dir, "MH_LOG_CONFLICT")
+        _require_live_directory(
+            self._directory_fd, self._state_root, self._logs_dir, "MH_LOG_CONFLICT"
+        )
         conflicted = False
         try:
             cached = os.fstat(self._descriptor)
@@ -981,13 +1049,13 @@ def recover_structured_logs(
 
     _require_platform()
     resolved = _resolve_logs_dir(logs_dir)
-    _require_logs_barrier(barrier, resolved)
+    state_root = _require_logs_barrier(barrier, resolved)
     with barrier.exclusive():
-        directory_fd = _open_logs_dir(resolved)
+        directory_fd = _open_logs_dir(state_root, resolved)
         lock = _LogLock(directory_fd, monotonic, sleeper)
         lock_fd = lock.acquire()
         try:
-            _require_live_directory(directory_fd, resolved, "MH_LOG_DIR")
+            _require_live_directory(directory_fd, state_root, resolved, "MH_LOG_DIR")
             truncated, completed = _repair_active(directory_fd)
             removed = _remove_staging(directory_fd)
             return LogRecoveryReport(
@@ -1147,20 +1215,109 @@ def _complete_rotation(directory_fd: int, sequence: int, info: os.stat_result) -
         _fail("MH_LOG_RECOVER", "the interrupted rotation could not be completed")
 
 
-def _remove_staging(directory_fd: int) -> bool:
-    try:
-        os.stat(_STAGING_NAME, dir_fd=directory_fd, follow_symlinks=False)
-    except FileNotFoundError:
+_HEADER_PREFIX = b'{"line":"header"'
+
+
+def _classify_staging(content: bytes, directory_fd: int) -> bool:
+    """Return whether staging bytes are a legitimate ``_publish_fresh_current`` crash artifact.
+
+    A crash can leave the staging file empty (created, unwritten), a single torn partial header
+    line consistent with a canonical header prefix, or exactly one complete header line at a
+    successor sequence above every surviving rotation. Multiple lines, a non-header line, content
+    past a header, an inconsistent partial, or a reused sequence is foreign or ambiguous, never a
+    crash artifact.
+    """
+
+    if not content.endswith(_LF):
+        # empty or one torn partial line only, and consistent with a canonical header prefix
+        return _LF not in content and (
+            content.startswith(_HEADER_PREFIX) or _HEADER_PREFIX.startswith(content)
+        )
+    lines = content.split(_LF)[:-1]
+    if len(lines) != 1:
         return False
+    header: StructuredLogHeaderV1 | None = None
+    try:
+        header = _parse_header_line(lines[0] + _LF)
+    except LoggingError:
+        header = None
+    if header is None:
+        return False
+    return header.sequence > max(_list_rotated(directory_fd), default=0)
+
+
+def _remove_staging(directory_fd: int) -> bool:
+    """Remove ONLY a classified log-protocol staging crash artifact; refuse foreign occupants.
+
+    The staging name is opened no-follow and non-blocking (so a planted FIFO cannot hang),
+    required to be an owned, single-link, ACL-free ``0o600`` regular file, read under the header
+    bound, and classified as a legitimate crash artifact before an identity-bound unlink. A
+    symlink, hard link, directory, FIFO, wrong mode/owner, over-long or malformed content, a
+    reused sequence, or an occupant swapped in after classification fails closed with a fixed code
+    and is left exactly in place — recovery never destroys an object it has not proven belongs to
+    the log protocol.
+    """
+
+    descriptor: int | None = None
+    absent = False
+    try:
+        descriptor = _open_regular_at(
+            directory_fd, _STAGING_NAME, flags=os.O_RDONLY | os.O_NONBLOCK
+        )
+    except FileNotFoundError:
+        absent = True
     except OSError:
-        _fail("MH_LOG_RECOVER", "the staging name could not be examined")
+        _fail("MH_LOG_RECOVER", "the staging occupant could not be securely opened")
+    if absent:
+        return False
+    assert descriptor is not None
     failed = False
+    refused = False
+    content = b""
+    identity: tuple[int, int] | None = None
+    try:
+        _require_private_file(descriptor)
+        info = os.fstat(descriptor)
+        identity = (info.st_dev, info.st_ino)
+        content = _read_bounded(descriptor, MAX_HEADER_LINE_BYTES, "MH_LOG_RECOVER")
+    except LoggingError:
+        refused = True
+    except OSError:
+        failed = True
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError:  # pragma: no cover - defensive close failure
+            failed = True
+    if failed:
+        _fail("MH_LOG_RECOVER", "the staging occupant could not be read")
+    if refused or identity is None or not _classify_staging(content, directory_fd):
+        _fail("MH_LOG_RECOVER", "the staging occupant is not a log-protocol crash artifact")
+    # identity-bound unlink: the name must still resolve to the exact classified inode
+    verified = False
+    probe: int | None = None
+    try:
+        probe = _open_regular_at(directory_fd, _STAGING_NAME, flags=os.O_RDONLY | os.O_NONBLOCK)
+        live = os.fstat(probe)
+        verified = (live.st_dev, live.st_ino) == identity
+    except OSError:
+        verified = False
+    finally:
+        if probe is not None:
+            try:
+                os.close(probe)
+            except OSError:  # pragma: no cover - defensive close failure
+                verified = False
+    if not verified:
+        _fail("MH_LOG_RECOVER", "the staging occupant changed before removal")
+    removed = False
     try:
         os.unlink(_STAGING_NAME, dir_fd=directory_fd)
         os.fsync(directory_fd)
+        removed = True
     except OSError:
-        failed = True
-    if failed:
+        removed = False
+    if not removed:
         _fail("MH_LOG_RECOVER", "the crashed staging file could not be removed")
     return True
 
@@ -1413,13 +1570,13 @@ def retention_preview(
 
     _require_platform()
     resolved = _resolve_logs_dir(logs_dir)
-    _require_logs_barrier(barrier, resolved)
+    state_root = _require_logs_barrier(barrier, resolved)
     with barrier.exclusive():
-        directory_fd = _open_logs_dir(resolved)
+        directory_fd = _open_logs_dir(state_root, resolved)
         lock = _LogLock(directory_fd, monotonic, sleeper)
         lock_fd = lock.acquire()
         try:
-            _require_live_directory(directory_fd, resolved, "MH_LOG_DIR")
+            _require_live_directory(directory_fd, state_root, resolved, "MH_LOG_DIR")
             active, _state = _active_status(directory_fd, retention_days, now)
             report, _validated = _preview_locked(directory_fd, retention_days, now)
             return RetentionReport(segments=report.segments, refused=report.refused, active=active)
@@ -1570,6 +1727,67 @@ def _parse_trailer_line(
     return trailer
 
 
+def _prune_expired_closed(
+    directory_fd: int,
+    retention_days: int,
+    now: datetime,
+    removed: list[RetainedSegment],
+    refused: list[RefusedSegment],
+) -> None:
+    """Delete every expired, identity-verified closed rotation; append outcomes to the lists."""
+
+    preview, validated = _preview_locked(directory_fd, retention_days, now)
+    refused.extend(preview.refused)
+    for segment in preview.segments:
+        if not segment.expired:
+            continue
+        if _unlink_verified(
+            directory_fd, _rotated_name(segment.sequence), validated[segment.sequence]
+        ):
+            removed.append(segment)
+        else:
+            # the name no longer resolves to the exact object whose expiry was proven: the
+            # replacement is left byte-for-byte intact and the sequence is NOT claimed removed
+            refused.append(RefusedSegment(sequence=segment.sequence, code="MH_LOG_RETENTION"))
+
+
+def _prune_specific_rotation(
+    directory_fd: int,
+    sequence: int,
+    retention_days: int,
+    now: datetime,
+    removed: list[RetainedSegment],
+    refused: list[RefusedSegment],
+) -> None:
+    """Delete one just-closed rotation when it is expired; defer to the next pass on any drift."""
+
+    code: str | None = None
+    header: StructuredLogHeaderV1 | None = None
+    trailer: StructuredLogTrailerV1 | None = None
+    identity: tuple[int, int, int, int, int] | None = None
+    try:
+        header, trailer, identity = _read_closed_segment(
+            directory_fd, _rotated_name(sequence), sequence
+        )
+    except LoggingError as error:
+        code = error.code  # a fixed MH_LOG_* code, value-safe by construction
+    if code is not None or header is None or trailer is None or identity is None:
+        refused.append(RefusedSegment(sequence=sequence, code=code or "MH_LOG_RETENTION"))
+        return
+    effective = min(trailer.expires_at, header.opened_at + timedelta(days=retention_days))
+    if effective <= now and _unlink_verified(directory_fd, _rotated_name(sequence), identity):
+        removed.append(
+            RetainedSegment(
+                sequence=sequence,
+                expires_at=trailer.expires_at,
+                effective_expires_at=effective,
+                expired=True,
+            )
+        )
+    else:
+        refused.append(RefusedSegment(sequence=sequence, code="MH_LOG_RETENTION"))
+
+
 def retention_apply(
     *,
     logs_dir: str | Path,
@@ -1579,61 +1797,61 @@ def retention_apply(
     now: datetime,
     sleeper: Callable[[float], None] = time.sleep,
 ) -> RetentionReport:
-    """Rotate a due active segment, then delete expired validated closed rotations.
+    """Reclaim expired closed rotations, then retire a due active segment or report it blocked.
 
-    The active segment is authenticated first under the exclusive barrier and log lock: if its
-    effective deadline has passed it is closed with an authenticated trailer and rotated in the
-    fixed crash order, a fresh empty successor is published, and the newly closed segment then
-    flows through the same closed-segment path below — so no acknowledged event outlives the
-    log-class privacy ceiling just because appends stopped. Then only validated closed segments
-    whose effective deadline has passed are deleted, with a descriptor-bound unlink and a parent
-    fsync. A rotation that fails validation is reported in ``refused`` and left exactly in place.
-    An active segment that cannot be cleanly authenticated is left for recovery and reported in
-    ``active`` with a fixed code; closed-segment pruning still proceeds.
+    Expired validated closed rotations are pruned FIRST (descriptor-bound unlink and parent fsync)
+    so a due active segment can rotate even near ``MAX_ROTATIONS``. The active segment is
+    authenticated under the exclusive barrier and log lock; if its effective deadline has passed it
+    is closed with an authenticated trailer, rotated in the fixed crash order, given a fresh empty
+    successor, and the newly closed segment is pruned in the same pass — so no acknowledged event
+    outlives the log-class privacy ceiling once appends stop. If the rotation bound is still pinned
+    after reclamation (for example by refused corrupt rotations), the due active is left in place
+    and reported ``rotated=False`` with a fixed ``MH_LOG_RETENTION_BOUND`` code rather than a silent
+    successful apply. An active segment that cannot be cleanly authenticated is left for recovery
+    with a fixed code; a closed rotation that fails validation is reported ``refused``.
     """
 
     _require_platform()
     resolved = _resolve_logs_dir(logs_dir)
-    _require_logs_barrier(barrier, resolved)
+    state_root = _require_logs_barrier(barrier, resolved)
     with barrier.exclusive():
-        directory_fd = _open_logs_dir(resolved)
+        directory_fd = _open_logs_dir(state_root, resolved)
         lock = _LogLock(directory_fd, monotonic, sleeper)
         lock_fd = lock.acquire()
         try:
-            _require_live_directory(directory_fd, resolved, "MH_LOG_DIR")
+            _require_live_directory(directory_fd, state_root, resolved, "MH_LOG_DIR")
             active, state = _active_status(directory_fd, retention_days, now)
-            if (
-                active is not None
-                and active.expired
-                and state is not None
-                and len(_list_rotated(directory_fd)) < MAX_ROTATIONS
-            ):
-                # close the due active segment into a rotation; the loop below then prunes it
-                _close_and_rotate_active(directory_fd, state, now)
-                _publish_fresh_current(directory_fd, state.header.sequence + 1, now, retention_days)
-                active = ActiveSegmentStatus(
-                    sequence=active.sequence,
-                    effective_expires_at=active.effective_expires_at,
-                    expired=True,
-                    rotated=True,
-                    code=None,
-                )
-            preview, validated = _preview_locked(directory_fd, retention_days, now)
             removed: list[RetainedSegment] = []
-            refused = list(preview.refused)
-            for segment in preview.segments:
-                if not segment.expired:
-                    continue
-                if _unlink_verified(
-                    directory_fd, _rotated_name(segment.sequence), validated[segment.sequence]
-                ):
-                    removed.append(segment)
+            refused: list[RefusedSegment] = []
+            # reclaim eligible closed rotations FIRST so a due active can rotate near the bound
+            _prune_expired_closed(directory_fd, retention_days, now, removed, refused)
+            if active is not None and active.expired and state is not None:
+                if len(_list_rotated(directory_fd)) < MAX_ROTATIONS:
+                    _close_and_rotate_active(directory_fd, state, now)
+                    _publish_fresh_current(
+                        directory_fd, state.header.sequence + 1, now, retention_days
+                    )
+                    active = ActiveSegmentStatus(
+                        sequence=active.sequence,
+                        effective_expires_at=active.effective_expires_at,
+                        expired=True,
+                        rotated=True,
+                        code=None,
+                    )
+                    # prune the just-closed rotation this pass; deferred to the next pass on drift
+                    _prune_specific_rotation(
+                        directory_fd, state.header.sequence, retention_days, now, removed, refused
+                    )
                 else:
-                    # the name no longer resolves to the exact object whose expiry was proven: the
-                    # replacement is left byte-for-byte intact and the sequence is NOT claimed
-                    # removed — reported refused instead
-                    refused.append(
-                        RefusedSegment(sequence=segment.sequence, code="MH_LOG_RETENTION")
+                    # the bound is still pinned after reclamation (e.g. by refused rotations): the
+                    # expired active cannot be retired now, so report it blocked — never a silent
+                    # successful apply that leaves expired bytes past the ceiling
+                    active = ActiveSegmentStatus(
+                        sequence=active.sequence,
+                        effective_expires_at=active.effective_expires_at,
+                        expired=True,
+                        rotated=False,
+                        code="MH_LOG_RETENTION_BOUND",
                     )
             return RetentionReport(segments=tuple(removed), refused=tuple(refused), active=active)
         finally:

--- a/src/milhouse/core/log_store.py
+++ b/src/milhouse/core/log_store.py
@@ -1215,24 +1215,25 @@ def _complete_rotation(directory_fd: int, sequence: int, info: os.stat_result) -
         _fail("MH_LOG_RECOVER", "the interrupted rotation could not be completed")
 
 
-_HEADER_PREFIX = b'{"line":"header"'
+# The invariant leading bytes of every canonical header line (sorted keys ``line``, ``opened_at``,
+# … with no spaces), up to where the first variable value begins. A torn header write can only be
+# a prefix of these bytes; arbitrary trailing content after ``{"line":"header"`` is not.
+_HEADER_PREAMBLE = b'{"line":"header","opened_at":"'
 
 
 def _classify_staging(content: bytes, directory_fd: int) -> bool:
     """Return whether staging bytes are a legitimate ``_publish_fresh_current`` crash artifact.
 
-    A crash can leave the staging file empty (created, unwritten), a single torn partial header
-    line consistent with a canonical header prefix, or exactly one complete header line at a
-    successor sequence above every surviving rotation. Multiple lines, a non-header line, content
-    past a header, an inconsistent partial, or a reused sequence is foreign or ambiguous, never a
-    crash artifact.
+    A crash can leave the staging file empty (created, unwritten), a single torn partial line that
+    is a genuine byte-prefix of the canonical header preamble, or exactly one complete header line
+    at a successor sequence above every surviving rotation. Multiple lines, a non-header line,
+    content past a header, a partial that diverges from the canonical header bytes, or a reused
+    sequence is foreign or ambiguous, never a crash artifact.
     """
 
     if not content.endswith(_LF):
-        # empty or one torn partial line only, and consistent with a canonical header prefix
-        return _LF not in content and (
-            content.startswith(_HEADER_PREFIX) or _HEADER_PREFIX.startswith(content)
-        )
+        # empty or one torn partial line that is a real prefix of the canonical header preamble
+        return _LF not in content and _HEADER_PREAMBLE.startswith(content)
     lines = content.split(_LF)[:-1]
     if len(lines) != 1:
         return False

--- a/src/milhouse/state/barrier.py
+++ b/src/milhouse/state/barrier.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import fcntl
 import os
 import stat
+import threading
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -154,16 +155,30 @@ def _is_bound_barrier(barrier: object, lock_path: Path) -> bool:
     )
 
 
+# In-process record of which barrier instance, in which thread, currently holds each exclusive lock
+# path: ``{lock_path: (barrier, thread_id)}``. Exclusive acquisition is exact-instance reentrant: a
+# nested ``exclusive()`` on the SAME instance in the acquiring thread reuses the held flock, so
+# composed maintenance that receives one already-held barrier never deadlocks. A DIFFERENT instance
+# for the same path IN THE SAME THREAD would deadlock re-acquiring that flock, so it fails closed; a
+# different THREAD (or process) is genuine contention and blocks on the flock as before. A main/gate
+# path mutated during a held hold also fails closed, so one state root's authority never stands in
+# for another.
+_EXCLUSIVE_OWNERS: dict[Path, tuple[GlobalCommitBarrier, int]] = {}
+
+
 class GlobalCommitBarrier:
     """A cross-process, writer-preferring readers-writer commit barrier over one lock file pair."""
 
-    __slots__ = ("_gate_path", "_path")
+    __slots__ = ("_exclusive_depth", "_exclusive_key", "_exclusive_thread", "_gate_path", "_path")
 
     def __init__(self, lock_path: str | Path) -> None:
         if _NOFOLLOW == 0:  # pragma: no cover - Milhouse supports only no-follow POSIX hosts
             _fail("MH_STATE_UNSUPPORTED", "the commit barrier requires no-follow file support")
         self._path = lexical_absolute_path(lock_path)
         self._gate_path = self._path.with_name(self._path.name + _GATE_SUFFIX)
+        self._exclusive_depth = 0
+        self._exclusive_key: tuple[Path, Path] | None = None
+        self._exclusive_thread: int | None = None
 
     @property
     def path(self) -> Path:
@@ -197,20 +212,56 @@ class GlobalCommitBarrier:
 
     @contextmanager
     def exclusive(self, *, blocking: bool = True) -> Iterator[None]:
-        """Hold the exclusive side; block new shared entrants and drain existing ones."""
+        """Hold the exclusive side; block new shared entrants and drain existing ones.
 
+        Acquisition is exact-instance reentrant: a nested ``exclusive()`` on the SAME instance
+        reuses the flock already held (so composed maintenance that receives one already-held
+        barrier never deadlocks), while a different in-process instance for the same lock path, or
+        a main/gate path mutated during a held hold, fails closed rather than deadlocking or letting
+        one state root's authority stand in for another. Cross-process exclusion is unchanged.
+        """
+
+        key = (lexical_absolute_path(self._path), lexical_absolute_path(self._gate_path))
+        me = threading.get_ident()
+        if self._exclusive_depth > 0 and self._exclusive_thread == me:
+            if self._exclusive_key != key:
+                _fail("MH_STATE_BARRIER", "the barrier lock path changed during a held hold")
+            self._exclusive_depth += 1
+            try:
+                yield
+            finally:
+                self._exclusive_depth -= 1
+            return
+        owner = _EXCLUSIVE_OWNERS.get(key[0])
+        if owner is not None and owner[1] == me and owner[0] is not self:
+            # a different instance in THIS thread already holds the flock: re-acquiring it would
+            # deadlock, so fail closed instead of blocking forever
+            _fail("MH_STATE_BARRIER", "another barrier instance already holds this exclusive lock")
         main_fd = _secure_lock_descriptor(self._path)
         gate_fd: int | None = None
         gate_held = False
         main_held = False
+        registered = False
         try:
             gate_fd = _secure_lock_descriptor(self._gate_path)
             _acquire(gate_fd, fcntl.LOCK_EX, blocking=blocking)
             gate_held = True
             _acquire(main_fd, fcntl.LOCK_EX, blocking=blocking)
             main_held = True
+            self._exclusive_key = key
+            self._exclusive_thread = me
+            self._exclusive_depth = 1
+            _EXCLUSIVE_OWNERS[key[0]] = (self, me)
+            registered = True
             yield
         finally:
+            if registered:
+                self._exclusive_depth = 0
+                self._exclusive_key = None
+                self._exclusive_thread = None
+                existing = _EXCLUSIVE_OWNERS.get(key[0])
+                if existing is not None and existing[0] is self:
+                    del _EXCLUSIVE_OWNERS[key[0]]
             if main_held:
                 _release(main_fd)
             if gate_held and gate_fd is not None:

--- a/tests/unit/test_log_d04.py
+++ b/tests/unit/test_log_d04.py
@@ -215,6 +215,13 @@ def _plant_shaped_but_invalid(staging: Path, tmp_path: Path) -> None:
     os.chmod(staging, 0o600)
 
 
+def _plant_prefix_garbage(staging: Path, tmp_path: Path) -> None:
+    # a header prefix followed by arbitrary bytes with no line feed: not a canonical torn header,
+    # so it must not be classified as a crash artifact merely because it starts like a header
+    staging.write_bytes(b'{"line":"header"' + b"x" * 200)
+    os.chmod(staging, 0o600)
+
+
 _FOREIGN = [
     ("regular", _plant_foreign_regular),
     ("symlink", _plant_symlink),
@@ -222,6 +229,7 @@ _FOREIGN = [
     ("directory", _plant_directory),
     ("fifo", _plant_fifo),
     ("shaped-invalid", _plant_shaped_but_invalid),
+    ("prefix-garbage", _plant_prefix_garbage),
 ]
 
 

--- a/tests/unit/test_log_d04.py
+++ b/tests/unit/test_log_d04.py
@@ -1,0 +1,423 @@
+"""D04 remediation: regression evidence for the five post-merge exact-head review P1s.
+
+Each test pins a defect the merge-race review reproduced on the PR #45 tree, so a regression
+re-opens a failing test rather than silently re-crossing the durability, privacy, authority, or
+filesystem-containment contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from milhouse.core import FixedClock
+from milhouse.core import log_store as log_store_module
+from milhouse.core.log_store import (
+    StructuredLogStore,
+    recover_structured_logs,
+    retention_apply,
+    retention_preview,
+)
+from milhouse.core.log_wire import StructuredLogHeaderV1, structured_log_header_line
+from milhouse.core.logging import (
+    LogEventSpec,
+    LoggingError,
+    LogLevel,
+    LogMetric,
+    LogMetricKind,
+    LogMetricSpec,
+    StructuredLogEventV1,
+    StructuredLogger,
+)
+from milhouse.privacy import Pseudonymizer
+from milhouse.state import GlobalCommitBarrier, initialize_control_state, open_control_database
+from milhouse.state.errors import StateError
+
+_NOW = datetime(2026, 7, 26, 12, 0, 0, tzinfo=UTC)
+_RECORDS = LogMetricSpec("records", LogMetricKind.COUNT)
+_SPEC = LogEventSpec("collector.completed", LogLevel.INFO, metrics=(_RECORDS,))
+
+
+def _monotonic() -> float:
+    return 0.0
+
+
+class _Sink:
+    def write(self, event: StructuredLogEventV1) -> None:  # pragma: no cover - unused capture
+        pass
+
+
+def _event(timestamp: datetime = _NOW) -> StructuredLogEventV1:
+    logger = StructuredLogger(
+        catalog=(_SPEC,),
+        clock=FixedClock(timestamp),
+        sink=_Sink(),
+        minimum_level=LogLevel.DEBUG,
+        pseudonymizer=Pseudonymizer(b"f" * 32),
+    )
+    event = logger.emit(_SPEC, metrics=(LogMetric(_RECORDS, 1),))
+    assert event is not None
+    return event
+
+
+def _state_root(tmp_path: Path) -> Path:
+    logs = tmp_path / "logs"
+    logs.mkdir(mode=0o700)
+    os.chmod(logs, 0o700)
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    os.chmod(control, 0o700)
+    return logs
+
+
+def _barrier(tmp_path: Path) -> GlobalCommitBarrier:
+    control = tmp_path / "control"
+    database = open_control_database(control / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(control / "commit.lock")
+    initialize_control_state(database, barrier=barrier, applied_at=_NOW)
+    database.close()
+    return barrier
+
+
+def _store(logs: Path) -> StructuredLogStore:
+    return StructuredLogStore(
+        logs_dir=logs, retention_days=14, monotonic=_monotonic, opened_at=_NOW
+    )
+
+
+def _events_on_disk(logs: Path) -> int:
+    total = 0
+    for path in logs.glob("structured-log.*.jsonl"):
+        for line in path.read_bytes().split(b"\n"):
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except ValueError:
+                continue  # a corrupt/tampered line is not a valid event
+            if obj.get("line") == "event":
+                total += 1
+    return total
+
+
+def _corrupt(path: Path) -> None:
+    path.write_bytes(path.read_bytes()[:-10] + b"tampered!\n")  # break only the trailer
+
+
+# --- D04-3: the rotation bound can no longer permanently retain an expired active segment ---------
+
+
+def test_retention_retires_the_expired_active_after_reclaiming_room(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    logs = _state_root(tmp_path)
+    monkeypatch.setattr(log_store_module, "MAX_ROTATIONS", 2)
+    store = _store(logs)
+    store.append(_event())
+    store.rotate(closed_at=_NOW + timedelta(minutes=1))  # rotation 1: valid, will expire
+    store.append(_event(_NOW + timedelta(minutes=2)))
+    store.rotate(closed_at=_NOW + timedelta(minutes=3))  # rotation 2: will be corrupted/refused
+    store.append(_event(_NOW + timedelta(minutes=4)))  # active sequence 3 holds an event
+    store.close()
+    _corrupt(logs / f"structured-log.{2:020d}.jsonl")
+    barrier = _barrier(tmp_path)
+    report = retention_apply(
+        logs_dir=logs,
+        barrier=barrier,
+        monotonic=_monotonic,
+        retention_days=14,
+        now=_NOW + timedelta(days=365),
+    )
+    # reclaiming rotation 1 frees room, so the due active (3) is still retired despite corrupt 2
+    assert report.active is not None and report.active.rotated is True
+    assert sorted(segment.sequence for segment in report.segments) == [1, 3]
+    assert [refused.sequence for refused in report.refused] == [2]
+    assert _events_on_disk(logs) == 1  # only the refused corrupt rotation's evidence bytes remain
+
+
+def test_retention_reports_blocked_when_the_bound_is_pinned_by_a_refused_rotation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    logs = _state_root(tmp_path)
+    monkeypatch.setattr(log_store_module, "MAX_ROTATIONS", 1)
+    store = _store(logs)
+    store.append(_event())
+    store.rotate(closed_at=_NOW + timedelta(minutes=1))  # the only rotation; will be corrupted
+    store.append(_event(_NOW + timedelta(minutes=2)))  # active sequence 2 holds an event
+    store.close()
+    _corrupt(logs / f"structured-log.{1:020d}.jsonl")
+    barrier = _barrier(tmp_path)
+    first = retention_apply(
+        logs_dir=logs,
+        barrier=barrier,
+        monotonic=_monotonic,
+        retention_days=14,
+        now=_NOW + timedelta(days=365),
+    )
+    # the corrupt rotation pins the bound and cannot be pruned, so the expired active is reported
+    # blocked rather than silently retained behind a "successful" apply
+    assert first.active is not None
+    assert first.active.expired is True and first.active.rotated is False
+    assert first.active.code == "MH_LOG_RETENTION_BOUND"
+    assert first.segments == ()
+    assert [refused.sequence for refused in first.refused] == [1]
+    # retry convergence: a later apply is idempotent — same blocked result, no sequence reuse
+    second = retention_apply(
+        logs_dir=logs,
+        barrier=barrier,
+        monotonic=_monotonic,
+        retention_days=14,
+        now=_NOW + timedelta(days=366),
+    )
+    assert second.active is not None and second.active.code == "MH_LOG_RETENTION_BOUND"
+    reopened = _store(logs)
+    try:
+        assert reopened.sequence == 2  # the active is still sequence 2 — no sequence reuse
+    finally:
+        reopened.close()
+
+
+# --- D04-5: recovery removes only a classified staging crash artifact, never a foreign occupant ---
+
+_STAGING = ".structured-log.next.tmp"
+
+
+def _plant_foreign_regular(staging: Path, tmp_path: Path) -> None:
+    staging.write_bytes(b"not a header line at all\n")  # complete line, not a header
+    os.chmod(staging, 0o600)
+
+
+def _plant_symlink(staging: Path, tmp_path: Path) -> None:
+    os.symlink(tmp_path / "outside", staging)
+
+
+def _plant_hard_link(staging: Path, tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.write_bytes(b"x")
+    os.chmod(target, 0o600)
+    os.link(target, staging)  # nlink == 2
+
+
+def _plant_directory(staging: Path, tmp_path: Path) -> None:
+    staging.mkdir(mode=0o700)
+
+
+def _plant_fifo(staging: Path, tmp_path: Path) -> None:
+    os.mkfifo(staging, 0o600)  # a no-follow non-blocking open must not hang
+
+
+def _plant_shaped_but_invalid(staging: Path, tmp_path: Path) -> None:
+    staging.write_bytes(b'{"line":"header"}\n')  # header-shaped but missing required fields
+    os.chmod(staging, 0o600)
+
+
+_FOREIGN = [
+    ("regular", _plant_foreign_regular),
+    ("symlink", _plant_symlink),
+    ("hard-link", _plant_hard_link),
+    ("directory", _plant_directory),
+    ("fifo", _plant_fifo),
+    ("shaped-invalid", _plant_shaped_but_invalid),
+]
+
+
+@pytest.mark.parametrize("plant", [p for _, p in _FOREIGN], ids=[n for n, _ in _FOREIGN])
+def test_recovery_refuses_and_preserves_a_foreign_staging_occupant(
+    tmp_path: Path,
+    plant,  # type: ignore[no-untyped-def]
+) -> None:
+    logs = _state_root(tmp_path)
+    _store(logs).close()
+    staging = logs / _STAGING
+    plant(staging, tmp_path)
+    barrier = _barrier(tmp_path)
+    with pytest.raises(LoggingError) as refused:
+        recover_structured_logs(logs_dir=logs, barrier=barrier, monotonic=_monotonic)
+    assert refused.value.code == "MH_LOG_RECOVER"
+    assert os.path.lexists(staging)  # the occupant is left exactly in place, never followed
+
+
+def test_recovery_refuses_a_staging_header_at_a_reused_sequence(tmp_path: Path) -> None:
+    logs = _state_root(tmp_path)
+    store = _store(logs)
+    store.rotate(closed_at=_NOW)  # rotation 1 survives; a staging header must exceed it
+    store.close()
+    staging = logs / _STAGING
+    staging.write_bytes(
+        structured_log_header_line(
+            StructuredLogHeaderV1(sequence=1, opened_at=_NOW, retention_days=14)
+        )
+    )
+    os.chmod(staging, 0o600)
+    barrier = _barrier(tmp_path)
+    with pytest.raises(LoggingError) as refused:
+        recover_structured_logs(logs_dir=logs, barrier=barrier, monotonic=_monotonic)
+    assert refused.value.code == "MH_LOG_RECOVER"
+    assert staging.exists()  # a reused sequence is not a crash artifact; left in place
+
+
+def test_recovery_removes_a_complete_successor_staging_header(tmp_path: Path) -> None:
+    logs = _state_root(tmp_path)
+    _store(logs).close()  # fresh store: current is sequence 1, no rotations
+    staging = logs / _STAGING
+    staging.write_bytes(
+        structured_log_header_line(
+            StructuredLogHeaderV1(sequence=2, opened_at=_NOW, retention_days=14)
+        )
+    )
+    os.chmod(staging, 0o600)
+    barrier = _barrier(tmp_path)
+    report = recover_structured_logs(logs_dir=logs, barrier=barrier, monotonic=_monotonic)
+    assert report.removed_staging is True
+    assert not staging.exists()
+
+
+# --- D04-1: maintenance no longer deadlocks re-acquiring an already-held exclusive barrier ---
+
+
+def test_maintenance_runs_under_an_already_held_exclusive_barrier(tmp_path: Path) -> None:
+    import threading
+
+    logs = _state_root(tmp_path)
+    _store(logs).close()
+    barrier = _barrier(tmp_path)
+    done = threading.Event()
+    result: dict[str, object] = {}
+
+    def _run() -> None:
+        # a genuine OUTER exclusive hold; each maintenance call must re-enter the same instance,
+        # not re-acquire a second flock (which would deadlock)
+        with barrier.exclusive():
+            recover_structured_logs(logs_dir=logs, barrier=barrier, monotonic=_monotonic)
+            result["preview"] = retention_preview(
+                logs_dir=logs, barrier=barrier, monotonic=_monotonic, retention_days=14, now=_NOW
+            )
+            result["apply"] = retention_apply(
+                logs_dir=logs, barrier=barrier, monotonic=_monotonic, retention_days=14, now=_NOW
+            )
+        done.set()
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    assert done.wait(timeout=5), "nested maintenance deadlocked while re-acquiring the barrier"
+    assert result["preview"].segments == ()  # type: ignore[union-attr]
+    assert result["apply"].segments == ()  # type: ignore[union-attr]
+
+
+def test_a_foreign_same_thread_instance_is_rejected_not_deadlocked(tmp_path: Path) -> None:
+    logs = _state_root(tmp_path)
+    _store(logs).close()
+    held = _barrier(tmp_path)
+    foreign = GlobalCommitBarrier(tmp_path / "control" / "commit.lock")  # same lock, other instance
+    with held.exclusive():
+        # a different instance for the same lock, in THIS thread, must fail closed (would deadlock),
+        # never silently reuse the held authority
+        with pytest.raises(StateError) as rejected:
+            retention_apply(
+                logs_dir=logs,
+                barrier=foreign,
+                monotonic=_monotonic,
+                retention_days=14,
+                now=_NOW,
+            )
+        assert rejected.value.code == "MH_STATE_BARRIER"
+
+
+def test_a_barrier_path_mutated_during_a_hold_cannot_reuse_its_authority(tmp_path: Path) -> None:
+    _state_root(tmp_path)
+    held = _barrier(tmp_path)
+    other = tmp_path / "other" / "control"
+    other.mkdir(parents=True, mode=0o700)
+    with held.exclusive():
+        # tamper root A's held barrier to name root B, then re-enter: it must not let root A's held
+        # flock stand in as root B authority
+        held._path = (other / "commit.lock").resolve()
+        with pytest.raises(StateError) as rejected:
+            with held.exclusive():
+                pass  # pragma: no cover - the re-entry fails closed before the body
+        assert rejected.value.code == "MH_STATE_BARRIER"
+
+
+# --- D04-2 + D04-4: state-root anchoring and full-chain no-follow ---
+
+
+def _nested_root(tmp_path: Path) -> tuple[Path, Path, GlobalCommitBarrier]:
+    root = tmp_path
+    control = root / "control"
+    control.mkdir(mode=0o700)
+    os.chmod(control, 0o700)
+    data = root / "data"
+    data.mkdir(mode=0o700)
+    os.chmod(data, 0o700)
+    logs = data / "logs"  # [paths].logs nested below the state root
+    logs.mkdir(mode=0o700)
+    os.chmod(logs, 0o700)
+    database = open_control_database(control / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(control / "commit.lock")
+    initialize_control_state(database, barrier=barrier, applied_at=_NOW)
+    database.close()
+    return root, logs, barrier
+
+
+def test_maintenance_accepts_a_plan_valid_nested_logs_directory(tmp_path: Path) -> None:
+    root, logs, barrier = _nested_root(tmp_path)
+    store = StructuredLogStore(
+        logs_dir=logs,
+        retention_days=14,
+        monotonic=_monotonic,
+        opened_at=_NOW,
+        state_root=root,
+    )
+    store.append(_event())
+    store.close()
+    # the state root is derived from the barrier, so the nested logs is authenticated, not the
+    # MH_LOG_AUTHORITY the old logs.parent assumption produced
+    preview = retention_preview(
+        logs_dir=logs, barrier=barrier, monotonic=_monotonic, retention_days=14, now=_NOW
+    )
+    assert preview.active is not None and preview.active.code is None
+    recovered = recover_structured_logs(logs_dir=logs, barrier=barrier, monotonic=_monotonic)
+    assert recovered.truncated_bytes == 0  # authenticated and recoverable
+
+
+def test_a_symlinked_ancestor_is_rejected_for_the_store_and_maintenance(tmp_path: Path) -> None:
+    root = tmp_path
+    control = root / "control"
+    control.mkdir(mode=0o700)
+    os.chmod(control, 0o700)
+    real = root / "real"
+    real.mkdir(mode=0o700)
+    os.chmod(real, 0o700)
+    (real / "logs").mkdir(mode=0o700)
+    os.chmod(real / "logs", 0o700)
+    os.symlink(real, root / "alias")  # a directory-symlink ancestor between root and logs
+    through_symlink = root / "alias" / "logs"
+
+    with pytest.raises(LoggingError) as construct:
+        StructuredLogStore(
+            logs_dir=through_symlink,
+            retention_days=14,
+            monotonic=_monotonic,
+            opened_at=_NOW,
+            state_root=root,
+        )
+    assert construct.value.code == "MH_LOG_DIR"  # never published through the symlink
+
+    database = open_control_database(control / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(control / "commit.lock")
+    initialize_control_state(database, barrier=barrier, applied_at=_NOW)
+    database.close()
+    with pytest.raises(LoggingError) as maintained:
+        retention_preview(
+            logs_dir=through_symlink,
+            barrier=barrier,
+            monotonic=_monotonic,
+            retention_days=14,
+            now=_NOW,
+        )
+    assert maintained.value.code == "MH_LOG_DIR"
+    assert (root / "alias").is_symlink()  # the symlink is never followed or removed

--- a/tests/unit/test_log_store.py
+++ b/tests/unit/test_log_store.py
@@ -275,7 +275,12 @@ def test_a_leftover_staging_file_requires_recovery_and_is_removed(tmp_path: Path
     store = _store(logs)
     store.close()
     staging = logs / ".structured-log.next.tmp"
-    staging.write_bytes(b"crashed header")
+    # a torn partial successor-header write — the exact crash artifact _publish_fresh_current
+    # leaves behind — which recovery classifies as a log-protocol crash state and removes
+    header = structured_log_header_line(
+        StructuredLogHeaderV1(sequence=2, opened_at=_NOW, retention_days=14)
+    )
+    staging.write_bytes(header[:24])
     os.chmod(staging, 0o600)
     with pytest.raises(LoggingError) as refused:
         _store(logs)
@@ -955,22 +960,16 @@ def test_a_failed_truncation_fails_closed(tmp_path: Path, monkeypatch: pytest.Mo
     assert captured.value.code == "MH_LOG_RECOVER"
 
 
-def test_an_unexaminable_staging_name_fails_recovery_closed(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_an_unexaminable_staging_name_fails_recovery_closed(tmp_path: Path) -> None:
     logs, _control = _state_root(tmp_path)
     barrier = _hold_for(tmp_path)
-    real_stat = os.stat
-
-    def _blocked_stat(target, *args, **kwargs):  # type: ignore[no-untyped-def]
-        if target == ".structured-log.next.tmp" and kwargs.get("dir_fd") is not None:
-            raise PermissionError(13, "planted stat failure")
-        return real_stat(target, *args, **kwargs)
-
-    monkeypatch.setattr(os, "stat", _blocked_stat)
+    # a symlink at the staging name is not a crash artifact: the no-follow open fails recovery
+    # closed, and the symlink is never followed or removed
+    os.symlink(tmp_path / "outside", logs / ".structured-log.next.tmp")
     with pytest.raises(LoggingError) as captured:
         recover_structured_logs(logs_dir=logs, barrier=barrier, monotonic=_monotonic)
     assert captured.value.code == "MH_LOG_RECOVER"
+    assert (logs / ".structured-log.next.tmp").is_symlink()  # never followed or deleted
 
 
 def test_a_failed_staging_removal_fails_closed(
@@ -1749,11 +1748,15 @@ def test_the_live_store_refuses_to_rotate_past_the_rotation_bound(
         retention_days=14,
         now=_NOW + timedelta(days=365),
     )
-    assert [segment.sequence for segment in removed.segments] == [1, 2]  # the API escape works
+    # reclaiming the closed rotations frees room, so the expired active (3) is retired this pass too
+    assert [segment.sequence for segment in removed.segments] == [1, 2, 3]
+    assert removed.active is not None and removed.active.rotated is True
     resumed = _store(logs)
     try:
-        resumed.rotate(closed_at=_NOW + timedelta(minutes=3))  # rotation resumes post-prune
-        assert resumed.sequence == 4
+        resumed.rotate(
+            closed_at=_NOW + timedelta(days=365, minutes=1)
+        )  # rotation resumes post-prune
+        assert resumed.sequence == 5
     finally:
         resumed.close()
 


### PR DESCRIPTION
Remediates the five P1 defects the post-merge exact-head review found on PR #45's merged tree (defect **D04**); G03 is blocked until these are corrected and independently re-reviewed.

**Fixes (each with adversarial regression evidence in `tests/unit/test_log_d04.py`):**
- **D04-1** — `GlobalCommitBarrier.exclusive()` is now exact-instance/exact-thread reentrant via a thread-aware registry: composed maintenance receiving an already-held barrier reuses the flock instead of deadlocking; a different thread/process still contends on the flock; a same-thread foreign instance and a path mutated mid-hold fail closed.
- **D04-2** — maintenance derives the state root from the barrier's own lock path (not `logs.parent`), so a plan-valid nested `[paths].logs` is authenticated, not rejected.
- **D04-3** — retention reclaims expired closed rotations before rotating a due active segment, then prunes it; if the bound stays pinned it returns an explicit `MH_LOG_RETENTION_BOUND` blocked result — never a silent apply that keeps expired bytes past the ceiling.
- **D04-4** — the state-root→logs chain is opened descriptor-relative with `O_NOFOLLOW` per component, rejecting a symlinked ancestor at any depth for construction, append, rotation, recovery, preview, and apply.
- **D04-5** — recovery opens the staging occupant no-follow/non-blocking, requires the private-file envelope, classifies only a genuine crash artifact (empty / canonical-header-preamble prefix / complete successor header at an unused sequence) before an identity-bound unlink, and refuses foreign or ambiguous occupants without mutation.

An independent exact-head review returned **PASS** (no P0/P1); its one P2 (an over-permissive torn-header prefix) is fixed in the second commit. Local gates green: `test-coverage` (branch 96.81%, all 49 critical files ≥95%), `quality`, `mypy`, `docs-check`, `skill-check`, `secret-scan` (tree + history). Commits are DCO signed-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)