### PR TITLE
feat(w03): slice 5a — read-only spool verify audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ test-coverage:
 		--critical 'src/milhouse/spooling/reconcile.py' \
 		--critical 'src/milhouse/spooling/replay.py' \
 		--critical 'src/milhouse/spooling/segment.py' \
+		--critical 'src/milhouse/spooling/verify.py' \
 		--critical 'src/milhouse/spooling/writer.py' \
 		--critical 'scripts/check_artifacts.py' \
 		--critical 'scripts/check_coverage.py' \

--- a/src/milhouse/spooling/__init__.py
+++ b/src/milhouse/spooling/__init__.py
@@ -27,6 +27,7 @@ from milhouse.spooling.segment import (
     spool_frame_line,
     spool_segment_header_line,
 )
+from milhouse.spooling.verify import SegmentVerification, VerifyReport, verify_spool
 from milhouse.spooling.writer import (
     build_segment_bytes,
     publish_segment_bytes,
@@ -46,9 +47,11 @@ __all__ = [
     "SegmentAnomaly",
     "SegmentHeaderV1",
     "SegmentRecord",
+    "SegmentVerification",
     "SpoolError",
     "SpoolFrameV1",
     "SpoolReconciler",
+    "VerifyReport",
     "build_segment_bytes",
     "deliver_segment",
     "parse_segment_bytes",
@@ -59,5 +62,6 @@ __all__ = [
     "spool_content_sha256",
     "spool_frame_line",
     "spool_segment_header_line",
+    "verify_spool",
     "write_spool_segment",
 ]

--- a/src/milhouse/spooling/verify.py
+++ b/src/milhouse/spooling/verify.py
@@ -1,0 +1,146 @@
+"""Read-only spool audit — ``spool verify`` (W03 slice 5a, plan sections 4.4/4.9).
+
+``spool verify`` re-validates every committed segment against its ledger row WITHOUT mutating
+anything, so an operator or the health surface can confirm the durable spool is intact and see its
+delivery watermark. It is the read-only counterpart to reconciliation (which registers file→ledger
+orphans) and replay (which reprocesses trusted state): verify walks ledger→file and reports the
+integrity of each committed segment.
+
+Crucially, verify differs from replay in its failure posture. Replay fails closed on the first bad
+segment because it is about to reprocess trusted state; verify instead EXAMINES EVERY segment and
+RECORDS which are unhealthy, so one corrupt or missing file never hides the state of the rest. For
+each committed segment it opens the durable file through :func:`read_trusted_segment` (no-follow,
+owner-only, canonical, record-authentic) and cross-checks it against the ledger's recorded digests
+(``file_sha256``, ``byte_size``, ``content_sha256``, ``record_count``); any failure is captured as
+that segment's fixed ``MH_SPOOL_*`` code rather than raised. It also reports the destination
+delivery watermark — whether every required exporter is delivered. Backup watermarks are a W16
+concern and are out of scope here.
+
+Verify never writes and never holds the barrier across the pass (that would block maintenance while
+auditing every segment); the trusted reader's own mutation detection classifies a file that changes
+mid-read. Only an argument-validation fault raises a fixed ``MH_SPOOL_*`` error outside the handler.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+from milhouse.spooling.errors import SpoolError
+from milhouse.spooling.ledger import SegmentRecord, list_segment_records
+from milhouse.spooling.reader import INSTALLATION_ID_PATTERN, ParsedSegment, read_trusted_segment
+from milhouse.state.database import ControlDatabase
+
+_PENDING = "pending"
+_DELIVERED = "delivered"
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise SpoolError(code, message)
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentVerification:
+    """The audit result for one committed segment.
+
+    ``intact`` is the integrity verdict (durable file present, canonical, record-authentic, and in
+    exact agreement with the ledger row); ``code`` is the fixed classification when it is not
+    intact, and ``None`` when it is. ``delivered`` is a separate delivery-watermark dimension — an
+    intact segment that has not finished delivery is still healthy, just not yet exported.
+    """
+
+    batch_id: str
+    intact: bool
+    code: str | None
+    delivered: bool
+
+
+@dataclass(frozen=True, slots=True)
+class VerifyReport:
+    """The result of one read-only verification pass over the committed segments."""
+
+    segments: tuple[SegmentVerification, ...]
+
+    @property
+    def intact(self) -> bool:
+        """True iff every audited segment agrees with its ledger row."""
+
+        return all(segment.intact for segment in self.segments)
+
+    @property
+    def fully_delivered(self) -> bool:
+        """True iff every audited segment has delivered to all its required exporters."""
+
+        return all(segment.delivered for segment in self.segments)
+
+    @property
+    def compromised(self) -> tuple[SegmentVerification, ...]:
+        """The segments that failed the integrity check, in audit order."""
+
+        return tuple(segment for segment in self.segments if not segment.intact)
+
+
+def _matches_ledger(parsed: ParsedSegment, record: SegmentRecord) -> bool:
+    # The exact ledger-agreement check: identical bytes, both digests, and count. Kept in step with
+    # replay's equivalent cross-check — a durable file that drifted from its committing row is not a
+    # verified segment even though the trusted reader accepted it as canonical and authentic.
+    return (
+        parsed.file_sha256 == record.file_sha256
+        and parsed.byte_size == record.byte_size
+        and parsed.header.content_sha256 == record.content_sha256
+        and len(parsed.frames) == record.record_count
+    )
+
+
+def _verify_segment(record: SegmentRecord, spool_root: Path, installation_id: str) -> str | None:
+    """Return ``None`` if the segment is intact, else the fixed ``MH_SPOOL_*`` classification."""
+
+    path = spool_root / _PENDING / record.day / f"{record.batch_id}.jsonl"
+    try:
+        parsed = read_trusted_segment(path, installation_id=installation_id)
+    except SpoolError as error:
+        # The reader classifies every corruption/absence/provenance failure into a fixed code;
+        # record it as this segment's status and keep auditing the rest.
+        return error.code
+    if not _matches_ledger(parsed, record):
+        return "MH_SPOOL_VERIFY"
+    return None
+
+
+def verify_spool(
+    database: ControlDatabase,
+    *,
+    spool_root: str | Path,
+    installation_id: str,
+) -> VerifyReport:
+    """Audit every committed segment against its ledger row without mutating anything.
+
+    Each segment is examined independently and its integrity verdict plus delivery watermark are
+    recorded; a corrupt or missing file is reported, never raised, so the report always reflects the
+    whole spool. The pass holds no barrier, so it never blocks a concurrent commit or maintenance.
+    """
+
+    if type(database) is not ControlDatabase:
+        _fail("MH_SPOOL_VERIFY", "a control database is required")
+    if (
+        type(installation_id) is not str
+        or INSTALLATION_ID_PATTERN.fullmatch(installation_id) is None
+    ):
+        _fail("MH_SPOOL_IDENTITY", "a well-formed installation id is required")
+    root = Path(spool_root)
+
+    records = list_segment_records(database)
+    verifications: list[SegmentVerification] = []
+    for record in records:
+        code = _verify_segment(record, root, installation_id)
+        delivered = all(exporter.delivery_status == _DELIVERED for exporter in record.exporters)
+        verifications.append(
+            SegmentVerification(
+                batch_id=record.batch_id,
+                intact=code is None,
+                code=code,
+                delivered=delivered,
+            )
+        )
+    return VerifyReport(segments=tuple(verifications))

--- a/src/milhouse/spooling/verify.py
+++ b/src/milhouse/spooling/verify.py
@@ -10,11 +10,18 @@ Crucially, verify differs from replay in its failure posture. Replay fails close
 segment because it is about to reprocess trusted state; verify instead EXAMINES EVERY segment and
 RECORDS which are unhealthy, so one corrupt or missing file never hides the state of the rest. For
 each committed segment it opens the durable file through :func:`read_trusted_segment` (no-follow,
-owner-only, canonical, record-authentic) and cross-checks it against the ledger's recorded digests
-(``file_sha256``, ``byte_size``, ``content_sha256``, ``record_count``); any failure is captured as
-that segment's fixed ``MH_SPOOL_*`` code rather than raised. It also reports the destination
-delivery watermark — whether every required exporter is delivered. Backup watermarks are a W16
-concern and are out of scope here.
+owner-only, canonical, record-authentic) and cross-checks it against the ledger row using
+reconciliation's canonical agreement predicate — every file-attestable immutable field (batch id,
+day, config generation, scope/target, privacy/retention class, required exporters, count) plus both
+digests and byte size — so a post-commit ledger edit of a policy field with intact bytes is caught,
+not just digest drift. Any failure is captured as that segment's fixed ``MH_SPOOL_*`` code rather
+than raised. It also reports the destination delivery watermark — whether every required exporter is
+delivered. Backup watermarks are a W16 concern and are out of scope here.
+
+The report-don't-raise resilience is scoped to the durable *files*: a malformed ledger *row* (one
+that fails ledger-row validation) surfaces as a single fixed ``MH_SPOOL_LEDGER`` from the ledger
+read and stops the pass, exactly as it does for replay — a corrupt control row is a harder fault
+than a bad file and is not something an audit silently rides over.
 
 Verify never writes and never holds the barrier across the pass (that would block maintenance while
 auditing every segment); the trusted reader's own mutation detection classifies a file that changes
@@ -23,13 +30,15 @@ mid-read. Only an argument-validation fault raises a fixed ``MH_SPOOL_*`` error 
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NoReturn
 
 from milhouse.spooling.errors import SpoolError
 from milhouse.spooling.ledger import SegmentRecord, list_segment_records
-from milhouse.spooling.reader import INSTALLATION_ID_PATTERN, ParsedSegment, read_trusted_segment
+from milhouse.spooling.reader import INSTALLATION_ID_PATTERN, read_trusted_segment
+from milhouse.spooling.reconcile import _agrees
 from milhouse.state.database import ControlDatabase
 
 _PENDING = "pending"
@@ -81,18 +90,6 @@ class VerifyReport:
         return tuple(segment for segment in self.segments if not segment.intact)
 
 
-def _matches_ledger(parsed: ParsedSegment, record: SegmentRecord) -> bool:
-    # The exact ledger-agreement check: identical bytes, both digests, and count. Kept in step with
-    # replay's equivalent cross-check — a durable file that drifted from its committing row is not a
-    # verified segment even though the trusted reader accepted it as canonical and authentic.
-    return (
-        parsed.file_sha256 == record.file_sha256
-        and parsed.byte_size == record.byte_size
-        and parsed.header.content_sha256 == record.content_sha256
-        and len(parsed.frames) == record.record_count
-    )
-
-
 def _verify_segment(record: SegmentRecord, spool_root: Path, installation_id: str) -> str | None:
     """Return ``None`` if the segment is intact, else the fixed ``MH_SPOOL_*`` classification."""
 
@@ -103,7 +100,13 @@ def _verify_segment(record: SegmentRecord, spool_root: Path, installation_id: st
         # The reader classifies every corruption/absence/provenance failure into a fixed code;
         # record it as this segment's status and keep auditing the rest.
         return error.code
-    if not _matches_ledger(parsed, record):
+    # Reuse reconciliation's canonical ledger-agreement predicate — the single source of truth for
+    # "does this durable file match its committing row" — so verify checks every file-attestable
+    # immutable field (batch id, day, config generation, scope/target, privacy/retention class,
+    # required exporters, count, and both digests), not just the digests. A post-commit ledger edit
+    # of a policy field with intact bytes is therefore caught, and verify can never diverge from
+    # what reconciliation would accept.
+    if not _agrees(parsed, record.day, record.batch_id, record):
         return "MH_SPOOL_VERIFY"
     return None
 
@@ -123,6 +126,10 @@ def verify_spool(
 
     if type(database) is not ControlDatabase:
         _fail("MH_SPOOL_VERIFY", "a control database is required")
+    if not isinstance(spool_root, (str, os.PathLike)):
+        # Validate symmetrically with the other guards so a non-path argument fails closed with a
+        # fixed code rather than escaping as a bare TypeError from Path().
+        _fail("MH_SPOOL_VERIFY", "a spool root path is required")
     if (
         type(installation_id) is not str
         or INSTALLATION_ID_PATTERN.fullmatch(installation_id) is None

--- a/tests/security/test_makefile_safety.py
+++ b/tests/security/test_makefile_safety.py
@@ -46,6 +46,7 @@ CRITICAL_COVERAGE_FILES = {
     "src/milhouse/spooling/reconcile.py",
     "src/milhouse/spooling/replay.py",
     "src/milhouse/spooling/segment.py",
+    "src/milhouse/spooling/verify.py",
     "src/milhouse/spooling/writer.py",
     "scripts/check_artifacts.py",
     "scripts/check_coverage.py",

--- a/tests/unit/test_spool_reconcile.py
+++ b/tests/unit/test_spool_reconcile.py
@@ -643,6 +643,9 @@ def test_the_package_export_surface_cannot_bypass_mandatory_reconciliation() -> 
     # and only under the shared barrier over segments already committed (hence already reconciled).
     # It therefore cannot bypass mandatory reconciliation. Exporter/ExporterAttempt/ReplayReport are
     # inert protocol/value types.
+    # The slice-5a audit surface (verify_spool) is strictly READ-ONLY: it opens durable files and
+    # reads ledger rows to report integrity, mutating nothing and holding no barrier.
+    # SegmentVerification/VerifyReport are inert value types.
     assert set(spooling.__all__) == {
         "DurableSpool",
         "Exporter",
@@ -656,9 +659,11 @@ def test_the_package_export_surface_cannot_bypass_mandatory_reconciliation() -> 
         "SegmentAnomaly",
         "SegmentHeaderV1",
         "SegmentRecord",
+        "SegmentVerification",
         "SpoolError",
         "SpoolFrameV1",
         "SpoolReconciler",
+        "VerifyReport",
         "build_segment_bytes",
         "deliver_segment",
         "parse_segment_bytes",
@@ -669,6 +674,7 @@ def test_the_package_export_surface_cannot_bypass_mandatory_reconciliation() -> 
         "spool_content_sha256",
         "spool_frame_line",
         "spool_segment_header_line",
+        "verify_spool",
         "write_spool_segment",
     }
     assert "insert_segment_row" not in spooling.__all__

--- a/tests/unit/test_spool_verify.py
+++ b/tests/unit/test_spool_verify.py
@@ -1,0 +1,261 @@
+"""Behavioural guarantees for the read-only spool audit (W03 slice 5a, ``spool verify``).
+
+Verify walks ledger→file and reports each segment's integrity and delivery watermark WITHOUT
+mutating anything. Its defining property (vs replay) is that it EXAMINES EVERY segment and RECORDS
+failures rather than raising on the first bad one, so one corrupt or missing file never hides the
+state of the rest.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from milhouse.domain.records import (
+    CollectorDescriptorV1,
+    EventDataV1,
+    RecordDraftV1,
+    RecordEnvelopeV1,
+    SourceDescriptorV1,
+    TargetDescriptorV1,
+    finalize_record,
+)
+from milhouse.spooling import (
+    DurableSpool,
+    SegmentHeaderV1,
+    SpoolFrameV1,
+    deliver_segment,
+    spool_content_sha256,
+    spool_frame_line,
+    verify_spool,
+)
+from milhouse.spooling.errors import SpoolError
+from milhouse.state import (
+    GlobalCommitBarrier,
+    initialize_control_state,
+    open_control_database,
+)
+
+_INSTALLATION_ID = "mh_in1_00000000000040008000000000000000"
+_NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=UTC)
+_DAY = "2026-07-28"
+_GENERATION = "a" * 64
+
+
+class _FakeExporter:
+    def __init__(self, exporter_id: str) -> None:
+        self._exporter_id = exporter_id
+
+    @property
+    def exporter_id(self) -> str:
+        return self._exporter_id
+
+    def deliver(self, record, frames) -> None:  # a confirming exporter
+        return None
+
+
+def _envelope(source_event_id: str) -> RecordEnvelopeV1:
+    values: dict[str, object] = {
+        "record_type": "event",
+        "name": "source.event",
+        "occurred_at": _NOW,
+        "observed_at": _NOW + timedelta(seconds=1),
+        "ingested_at": _NOW + timedelta(seconds=2),
+        "expires_at": _NOW + timedelta(days=30),
+        "source_event_id": source_event_id,
+        "operation_id": "operation-1",
+        "collector_run_id": "collector-run-1",
+        "scope": "target",
+        "source": SourceDescriptorV1.model_validate(
+            {
+                "id": "example-source",
+                "type": "source.event",
+                "producer": "collector",
+                "observation_namespace_id": "mh_ns1_00000000000040008000000000000000",
+                "source_generation_digest": "0" * 64,
+                "observation": {"kind": "source.revision", "parts": {"revision": 1}},
+            }
+        ),
+        "collector": CollectorDescriptorV1(
+            id="c", type="site.canary", implementation_version="1.0.0"
+        ),
+        "target": TargetDescriptorV1(
+            id="example-target", name="E", kind="web.service", environment="test"
+        ),
+        "severity": "info",
+        "trust_level": "authenticated",
+        "privacy_class": "internal",
+        "redaction_version": "r1-e1",
+        "data": EventDataV1(category="availability", status="healthy", message="ok"),
+    }
+    return finalize_record(RecordDraftV1.model_validate(values), installation_id=_INSTALLATION_ID)
+
+
+def _frames(batch_id: str, event_ids: tuple[str, ...]) -> list[SpoolFrameV1]:
+    return [
+        SpoolFrameV1(batch_id=batch_id, sequence=index, record=_envelope(event_id))
+        for index, event_id in enumerate(event_ids, start=1)
+    ]
+
+
+def _header(batch_id: str, frames: list[SpoolFrameV1]) -> SegmentHeaderV1:
+    lines = [spool_frame_line(frame) for frame in frames]
+    return SegmentHeaderV1(
+        batch_id=batch_id,
+        config_generation=_GENERATION,
+        scope="target",
+        target_id="example-target",
+        privacy_class="internal",
+        retention_days=30,
+        required_exporters=("clickhouse",),
+        record_count=len(frames),
+        content_sha256=spool_content_sha256(lines),
+    )
+
+
+def _spool(tmp_path: Path):
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    os.chmod(control, 0o700)
+    database = open_control_database(control / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(control / "commit.lock")
+    initialize_control_state(database, barrier=barrier, applied_at=_NOW)
+    spool_root = tmp_path / "spool"
+    spool_root.mkdir(mode=0o700)
+    os.chmod(spool_root, 0o700)
+    store = DurableSpool(
+        database=database, barrier=barrier, spool_root=spool_root, installation_id=_INSTALLATION_ID
+    )
+    return database, barrier, spool_root, store
+
+
+def _commit(store, batch_id: str, event_ids: tuple[str, ...]):
+    frames = _frames(batch_id, event_ids)
+    return store.commit_segment(_header(batch_id, frames), frames, committed_at=_NOW), frames
+
+
+def _segment_file(spool_root: Path, batch_id: str) -> Path:
+    return spool_root / "pending" / _DAY / f"{batch_id}.jsonl"
+
+
+def test_a_healthy_undelivered_spool_verifies_intact(tmp_path: Path) -> None:
+    database, _barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", ("a-1", "a-2"))
+        _commit(store, "batch-b", ("b-1",))
+        report = verify_spool(database, spool_root=spool_root, installation_id=_INSTALLATION_ID)
+        assert [s.batch_id for s in report.segments] == ["batch-a", "batch-b"]
+        assert all(s.intact and s.code is None for s in report.segments)
+        assert report.intact is True
+        assert report.compromised == ()
+        # Exporters are still pending, so the delivery watermark is not yet satisfied.
+        assert all(s.delivered is False for s in report.segments)
+        assert report.fully_delivered is False
+    finally:
+        database.close()
+
+
+def test_the_delivery_watermark_reflects_completed_delivery(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        record, frames = _commit(store, "batch-a", ("a-1",))
+        deliver_segment(
+            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}
+        )
+        report = verify_spool(database, spool_root=spool_root, installation_id=_INSTALLATION_ID)
+        assert report.intact is True
+        assert report.fully_delivered is True
+        assert report.segments[0].delivered is True
+    finally:
+        database.close()
+
+
+def test_a_missing_file_is_reported_without_hiding_the_rest(tmp_path: Path) -> None:
+    database, _barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", ("a-1",))
+        _commit(store, "batch-b", ("b-1",))
+        _segment_file(spool_root, "batch-a").unlink()
+        report = verify_spool(database, spool_root=spool_root, installation_id=_INSTALLATION_ID)
+        by_id = {s.batch_id: s for s in report.segments}
+        assert by_id["batch-a"].intact is False
+        assert by_id["batch-a"].code == "MH_SPOOL_NOT_FOUND"
+        # The audit did NOT abort: the healthy sibling is still reported.
+        assert by_id["batch-b"].intact is True
+        assert report.intact is False
+        assert [s.batch_id for s in report.compromised] == ["batch-a"]
+    finally:
+        database.close()
+
+
+def test_a_ledger_digest_drift_is_classified_as_a_verify_mismatch(tmp_path: Path) -> None:
+    database, _barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", ("a-1",))
+        # The durable file is still valid and authentic; only the ledger's recorded digest is wrong,
+        # so the trusted reader passes but the ledger-agreement cross-check fails.
+        with database.transaction() as connection:
+            connection.execute(
+                "UPDATE _segments SET file_sha256 = ? WHERE batch_id = 'batch-a'", ("d" * 64,)
+            )
+        report = verify_spool(database, spool_root=spool_root, installation_id=_INSTALLATION_ID)
+        assert report.segments[0].intact is False
+        assert report.segments[0].code == "MH_SPOOL_VERIFY"
+    finally:
+        database.close()
+
+
+def test_a_corrupt_file_is_classified_not_raised(tmp_path: Path) -> None:
+    database, _barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", ("a-1",))
+        # Rewrite the segment body in place with non-canonical bytes; the trusted reader must reject
+        # it, and verify must record the classification rather than raise.
+        _segment_file(spool_root, "batch-a").write_bytes(b'{"not":"a header"}\n')
+        report = verify_spool(database, spool_root=spool_root, installation_id=_INSTALLATION_ID)
+        assert report.segments[0].intact is False
+        assert report.segments[0].code is not None
+        assert report.segments[0].code.startswith("MH_SPOOL_")
+    finally:
+        database.close()
+
+
+def test_verify_over_an_empty_ledger_is_empty_and_vacuously_healthy(tmp_path: Path) -> None:
+    database, _barrier, spool_root, _store = _spool(tmp_path)
+    try:
+        report = verify_spool(database, spool_root=spool_root, installation_id=_INSTALLATION_ID)
+        assert report.segments == ()
+        assert report.intact is True
+        assert report.fully_delivered is True
+        assert report.compromised == ()
+    finally:
+        database.close()
+
+
+def test_verify_holds_no_barrier_so_it_runs_under_an_exclusive_hold(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", ("a-1",))
+        # Verify acquires no barrier; it must complete even while exclusive maintenance authority is
+        # held, or it would deadlock/block maintenance while auditing.
+        with barrier.exclusive():
+            report = verify_spool(database, spool_root=spool_root, installation_id=_INSTALLATION_ID)
+        assert report.intact is True
+    finally:
+        database.close()
+
+
+def test_verify_rejects_invalid_arguments(tmp_path: Path) -> None:
+    database, _barrier, spool_root, _store = _spool(tmp_path)
+    try:
+        with pytest.raises(SpoolError) as bad_db:
+            verify_spool(object(), spool_root=spool_root, installation_id=_INSTALLATION_ID)  # type: ignore[arg-type]
+        assert bad_db.value.code == "MH_SPOOL_VERIFY"
+        with pytest.raises(SpoolError) as bad_id:
+            verify_spool(database, spool_root=spool_root, installation_id="not-an-installation")
+        assert bad_id.value.code == "MH_SPOOL_IDENTITY"
+    finally:
+        database.close()

--- a/tests/unit/test_spool_verify.py
+++ b/tests/unit/test_spool_verify.py
@@ -191,15 +191,30 @@ def test_a_missing_file_is_reported_without_hiding_the_rest(tmp_path: Path) -> N
         database.close()
 
 
-def test_a_ledger_digest_drift_is_classified_as_a_verify_mismatch(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [
+        ("file_sha256", "'" + "d" * 64 + "'"),  # whole-file digest drift
+        ("content_sha256", "'" + "e" * 64 + "'"),  # frame-bytes digest drift
+        ("byte_size", "999999"),  # size drift
+        ("record_count", "99"),  # count drift
+        ("privacy_class", "'public'"),  # policy-field drift with intact bytes
+        ("retention_days", "3650"),  # policy-field drift with intact bytes
+        ("config_generation", "'" + "b" * 64 + "'"),  # policy-field drift with intact bytes
+    ],
+)
+def test_any_ledger_field_drift_is_classified_as_a_verify_mismatch(
+    tmp_path: Path, column: str, value: str
+) -> None:
     database, _barrier, spool_root, store = _spool(tmp_path)
     try:
         _commit(store, "batch-a", ("a-1",))
-        # The durable file is still valid and authentic; only the ledger's recorded digest is wrong,
-        # so the trusted reader passes but the ledger-agreement cross-check fails.
+        # The durable file stays valid and authentic; only one ledger column is edited. verify uses
+        # reconciliation's full agreement predicate, so a policy-field edit with intact bytes is
+        # caught, not merely a digest change.
         with database.transaction() as connection:
             connection.execute(
-                "UPDATE _segments SET file_sha256 = ? WHERE batch_id = 'batch-a'", ("d" * 64,)
+                f"UPDATE _segments SET {column} = {value} WHERE batch_id = 'batch-a'"
             )
         report = verify_spool(database, spool_root=spool_root, installation_id=_INSTALLATION_ID)
         assert report.segments[0].intact is False
@@ -254,6 +269,9 @@ def test_verify_rejects_invalid_arguments(tmp_path: Path) -> None:
         with pytest.raises(SpoolError) as bad_db:
             verify_spool(object(), spool_root=spool_root, installation_id=_INSTALLATION_ID)  # type: ignore[arg-type]
         assert bad_db.value.code == "MH_SPOOL_VERIFY"
+        with pytest.raises(SpoolError) as bad_root:
+            verify_spool(database, spool_root=None, installation_id=_INSTALLATION_ID)  # type: ignore[arg-type]
+        assert bad_root.value.code == "MH_SPOOL_VERIFY"
         with pytest.raises(SpoolError) as bad_id:
             verify_spool(database, spool_root=spool_root, installation_id="not-an-installation")
         assert bad_id.value.code == "MH_SPOOL_IDENTITY"


### PR DESCRIPTION
## W03 slice 5a — `spool verify` (read-only audit)

First slice of W03 slice 5 (retention + audit + compaction), split for reviewability:
- **5a (this PR): `spool verify`** — read-only integrity audit.
- 5b: retention preview + apply (wholesale-expired pruning + audit event).
- 5c: audited compaction (mixed-expiry rewrite protocol).

### What landed
`verify_spool(database, *, spool_root, installation_id) -> VerifyReport` re-validates every committed segment against its ledger row **without mutating anything** — the read-only counterpart to reconciliation (file→ledger orphans) and replay (reprocessing), walking ledger→file (plan §4.4/§4.9).

- **Report, don't raise.** Unlike replay, verify examines *every* segment and records which are unhealthy, so one corrupt or missing file never hides the rest. Each is opened via `read_trusted_segment` (no-follow, owner-only, canonical, record-authentic); any failure is captured as that segment's fixed `MH_SPOOL_*` code.
- **Full ledger agreement.** Reuses reconciliation's canonical `_agrees` predicate, so verify checks every file-attestable immutable field (batch id, day, config generation, scope/target, privacy/retention class, required exporters, count) plus both digests and byte size — a policy-field edit with intact bytes is caught, and verify can never diverge from reconciliation. A ledger-agreement mismatch is `MH_SPOOL_VERIFY`.
- **Delivery watermark** reported per segment (every required exporter delivered); backup watermarks are a W16 concern.
- **Holds no barrier** across the pass, so it never blocks a concurrent commit or maintenance.

### Discipline
- `verify_spool`/`VerifyReport`/`SegmentVerification` are read-only additions (export-surface guard updated with that rationale); `verify.py` is a critical-coverage file at **100% branch**.
- Independent **pre-merge exact-head review**: no P1/P2; confirmed read-only, report-don't-raise, classification, path safety, and arg validation. Its P3s addressed — full ledger agreement, `spool_root` guard, per-dimension tests, and a doc note on ledger-row faults.
- Full suite green; `test-coverage`, `quality` (incl. mypy) all pass; DCO signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)