### PR TITLE
feat(w03): slice 5b part 1 — audit trail + read-only retention preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ test-coverage:
 		--critical 'src/milhouse/privacy/redact.py' \
 		--critical 'src/milhouse/privacy/render.py' \
 		--critical 'src/milhouse/privacy/sanitize.py' \
+		--critical 'src/milhouse/state/audit.py' \
 		--critical 'src/milhouse/state/barrier.py' \
 		--critical 'src/milhouse/state/cursors.py' \
 		--critical 'src/milhouse/state/database.py' \

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ test-coverage:
 		--critical 'src/milhouse/spooling/reader.py' \
 		--critical 'src/milhouse/spooling/reconcile.py' \
 		--critical 'src/milhouse/spooling/replay.py' \
+		--critical 'src/milhouse/spooling/retention.py' \
 		--critical 'src/milhouse/spooling/segment.py' \
 		--critical 'src/milhouse/spooling/verify.py' \
 		--critical 'src/milhouse/spooling/writer.py' \

--- a/src/milhouse/spooling/__init__.py
+++ b/src/milhouse/spooling/__init__.py
@@ -20,6 +20,11 @@ from milhouse.spooling.reconcile import (
     SpoolReconciler,
 )
 from milhouse.spooling.replay import ReplayReport, replay_segments
+from milhouse.spooling.retention import (
+    RetentionPreview,
+    SegmentRetention,
+    retention_preview,
+)
 from milhouse.spooling.segment import (
     SegmentHeaderV1,
     SpoolFrameV1,
@@ -44,9 +49,11 @@ __all__ = [
     "QuarantinedFile",
     "ReconciliationReport",
     "ReplayReport",
+    "RetentionPreview",
     "SegmentAnomaly",
     "SegmentHeaderV1",
     "SegmentRecord",
+    "SegmentRetention",
     "SegmentVerification",
     "SpoolError",
     "SpoolFrameV1",
@@ -59,6 +66,7 @@ __all__ = [
     "read_trusted_segment",
     "read_untrusted_segment",
     "replay_segments",
+    "retention_preview",
     "spool_content_sha256",
     "spool_frame_line",
     "spool_segment_header_line",

--- a/src/milhouse/spooling/retention.py
+++ b/src/milhouse/spooling/retention.py
@@ -1,0 +1,187 @@
+"""Spool retention: preview and apply over committed segments (W03 slice 5b, plan section 4.8/4.9).
+
+Retention is driven by each record's own ``expires_at``, not the segment's commit time: a committed
+segment can be pruned wholesale only when EVERY record it contains has expired. A segment with some
+expired and some live records is a *mixed-expiry* segment that must be rewritten by audited
+compaction (slice 5c), never deleted here, so no unexpired record is ever lost. Record-class privacy
+expiry is a hard upper bound — an expired segment is removed even if it was never delivered — so an
+expired-yet-undelivered segment is flagged for a critical audit/health event before removal.
+
+This module classifies each segment by reading its durable frames back through the trusted reader
+and taking the min/max record ``expires_at``:
+
+* ``fully_expired`` — max expiry has passed; prunable wholesale.
+* ``mixed`` — some records expired, some live; a compaction candidate (5c), never pruned here.
+* ``live`` — nothing expired yet.
+* ``unreadable`` — the durable file could not be read as trusted state; reported, never silently
+  dropped, and never treated as prunable.
+
+:func:`retention_preview` is read-only and reports exact reclaimable counts and bytes without
+mutating. The mutating :func:`retention_apply` is added in the same slice. Every failure normalizes
+to a fixed ``MH_SPOOL_*`` error raised outside the handler.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import NoReturn
+
+from milhouse.core.clock import TimeError, format_timestamp
+from milhouse.spooling.errors import SpoolError
+from milhouse.spooling.ledger import SegmentRecord, list_segment_records
+from milhouse.spooling.reader import INSTALLATION_ID_PATTERN, read_trusted_segment
+from milhouse.state.database import ControlDatabase
+
+_PENDING = "pending"
+_DELIVERED = "delivered"
+
+STATUS_FULLY_EXPIRED = "fully_expired"
+STATUS_MIXED = "mixed"
+STATUS_LIVE = "live"
+STATUS_UNREADABLE = "unreadable"
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise SpoolError(code, message)
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentRetention:
+    """One committed segment's retention classification.
+
+    ``byte_size``/``record_count`` come from the ledger row (what pruning would reclaim). ``code``
+    is the fixed ``MH_SPOOL_*`` classification when the durable file is ``unreadable``, else
+    ``None``. ``delivered`` is whether every required exporter has delivered — a ``fully_expired``
+    segment that is not delivered means data reached its privacy deadline before it was exported.
+    """
+
+    batch_id: str
+    status: str
+    record_count: int
+    byte_size: int
+    delivered: bool
+    code: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionPreview:
+    """A read-only view of what retention would reclaim and what needs compaction."""
+
+    segments: tuple[SegmentRetention, ...]
+
+    @property
+    def fully_expired(self) -> tuple[SegmentRetention, ...]:
+        """Segments whose every record has expired — prunable wholesale."""
+
+        return tuple(s for s in self.segments if s.status == STATUS_FULLY_EXPIRED)
+
+    @property
+    def compaction_candidates(self) -> tuple[SegmentRetention, ...]:
+        """Mixed-expiry segments that slice-5c compaction must rewrite rather than delete."""
+
+        return tuple(s for s in self.segments if s.status == STATUS_MIXED)
+
+    @property
+    def unreadable(self) -> tuple[SegmentRetention, ...]:
+        """Segments whose durable file could not be read as trusted state."""
+
+        return tuple(s for s in self.segments if s.status == STATUS_UNREADABLE)
+
+    @property
+    def undelivered_expired(self) -> tuple[SegmentRetention, ...]:
+        """Fully-expired segments that were never delivered — a critical event on removal."""
+
+        return tuple(s for s in self.fully_expired if not s.delivered)
+
+    @property
+    def reclaimable_records(self) -> int:
+        return sum(s.record_count for s in self.fully_expired)
+
+    @property
+    def reclaimable_bytes(self) -> int:
+        return sum(s.byte_size for s in self.fully_expired)
+
+
+def _require_now(now: datetime) -> None:
+    invalid = False
+    try:
+        format_timestamp(now)  # rejects a naive or out-of-range instant the same way commit does
+    except (OverflowError, TimeError, AttributeError, TypeError):
+        invalid = True
+    if invalid:
+        _fail("MH_SPOOL_RETENTION", "the retention instant must be an aware in-range UTC instant")
+
+
+def _classify(
+    record: SegmentRecord, spool_root: Path, installation_id: str, now: datetime
+) -> SegmentRetention:
+    delivered = all(exporter.delivery_status == _DELIVERED for exporter in record.exporters)
+    path = spool_root / _PENDING / record.day / f"{record.batch_id}.jsonl"
+    status = STATUS_LIVE
+    code: str | None = None
+    try:
+        parsed = read_trusted_segment(path, installation_id=installation_id)
+    except SpoolError as error:
+        return SegmentRetention(
+            batch_id=record.batch_id,
+            status=STATUS_UNREADABLE,
+            record_count=record.record_count,
+            byte_size=record.byte_size,
+            delivered=delivered,
+            code=error.code,
+        )
+    expiries = [frame.record.expires_at for frame in parsed.frames]
+    if not expiries:
+        # A segment with a header but no record frames carries no record-class expiry to reason
+        # about; leave it live rather than ever auto-pruning an ambiguous segment.
+        status = STATUS_LIVE
+    elif max(expiries) <= now:
+        status = STATUS_FULLY_EXPIRED
+    elif min(expiries) <= now:
+        status = STATUS_MIXED
+    return SegmentRetention(
+        batch_id=record.batch_id,
+        status=status,
+        record_count=record.record_count,
+        byte_size=record.byte_size,
+        delivered=delivered,
+        code=code,
+    )
+
+
+def _validate_common(database: object, spool_root: object, installation_id: object) -> None:
+    if type(database) is not ControlDatabase:
+        _fail("MH_SPOOL_RETENTION", "a control database is required")
+    if not isinstance(spool_root, (str, os.PathLike)):
+        _fail("MH_SPOOL_RETENTION", "a spool root path is required")
+    if (
+        type(installation_id) is not str
+        or INSTALLATION_ID_PATTERN.fullmatch(installation_id) is None
+    ):
+        _fail("MH_SPOOL_IDENTITY", "a well-formed installation id is required")
+
+
+def retention_preview(
+    database: ControlDatabase,
+    *,
+    spool_root: str | Path,
+    installation_id: str,
+    now: datetime,
+) -> RetentionPreview:
+    """Classify every committed segment by record-class expiry without mutating anything.
+
+    Reports the fully-expired segments (with exact reclaimable counts and bytes), the mixed-expiry
+    compaction candidates, and any unreadable segments, plus which fully-expired segments were never
+    delivered. Holds no barrier; a file that changes mid-read is reported unreadable by the trusted
+    reader rather than raising.
+    """
+
+    _validate_common(database, spool_root, installation_id)
+    _require_now(now)
+    root = Path(spool_root)
+    records = list_segment_records(database)
+    segments = tuple(_classify(record, root, installation_id, now) for record in records)
+    return RetentionPreview(segments=segments)

--- a/src/milhouse/state/__init__.py
+++ b/src/milhouse/state/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from milhouse.state.audit import AuditRecord, list_audit, record_audit
 from milhouse.state.barrier import GlobalCommitBarrier
 from milhouse.state.cursors import SourceCursor, advance_cursor, read_cursor
 from milhouse.state.database import ControlDatabase, open_control_database
@@ -23,6 +24,7 @@ from milhouse.state.schema import CONTROL_MIGRATIONS, initialize_control_state
 
 __all__ = [
     "CONTROL_MIGRATIONS",
+    "AuditRecord",
     "ControlDatabase",
     "DerivationCheckpoint",
     "GlobalCommitBarrier",
@@ -34,10 +36,12 @@ __all__ = [
     "advance_checkpoint",
     "advance_cursor",
     "initialize_control_state",
+    "list_audit",
     "migrate",
     "open_control_database",
     "read_checkpoint",
     "read_cursor",
+    "record_audit",
     "release_lease",
     "renew_lease",
     "require_current_lease",

--- a/src/milhouse/state/audit.py
+++ b/src/milhouse/state/audit.py
@@ -27,6 +27,7 @@ from milhouse.state.errors import StateError
 
 _AUDIT_TABLE = "_audit"
 _MAX_TEXT = 1024
+_MAX_COUNT = 2**63 - 1  # the largest value SQLite's signed 64-bit INTEGER can store
 _DEFAULT_LIMIT = 1000
 _MAX_LIMIT = 100_000
 
@@ -67,9 +68,11 @@ def _validate_optional_text(value: object, subject: str) -> str | None:
 def _validate_optional_count(value: object, subject: str) -> int | None:
     if value is None:
         return None
-    # ``bool`` is an ``int`` subtype; reject it so a stray flag cannot pose as a count.
-    if type(value) is not int or value < 0:
-        _fail("MH_STATE_AUDIT", f"an audit {subject} must be a whole number >= 0 or absent")
+    # ``bool`` is an ``int`` subtype; reject it so a stray flag cannot pose as a count. The upper
+    # bound keeps a too-large count from overflowing the signed-64 INTEGER binding at INSERT and
+    # escaping as a raw OverflowError instead of the fixed code.
+    if type(value) is not int or not 0 <= value <= _MAX_COUNT:
+        _fail("MH_STATE_AUDIT", f"an audit {subject} must be a whole number in 0..2^63-1 or absent")
     return value
 
 
@@ -107,12 +110,20 @@ def record_audit(
         invalid_time = True
     if invalid_time:
         _fail("MH_STATE_AUDIT", "an audit timestamp must be an aware in-range UTC instant")
-    connection.execute(
-        f"INSERT INTO {_AUDIT_TABLE} "
-        "(recorded_at, action, actor, outcome, resource, reason, record_count, byte_size) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        (recorded_at, action, actor, outcome, resource, reason, record_count, byte_size),
-    )
+    failed = False
+    try:
+        connection.execute(
+            f"INSERT INTO {_AUDIT_TABLE} "
+            "(recorded_at, action, actor, outcome, resource, reason, record_count, byte_size) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (recorded_at, action, actor, outcome, resource, reason, record_count, byte_size),
+        )
+    except (sqlite3.Error, OverflowError):
+        # Normalize any residual backend fault to the fixed code raised outside the handler, so no
+        # SQLite/binding detail escapes; the caller's transaction still rolls back.
+        failed = True
+    if failed:
+        _fail("MH_STATE_AUDIT", "the audit row could not be recorded")
 
 
 def _row_to_audit(row: Sequence[Any]) -> AuditRecord:

--- a/src/milhouse/state/audit.py
+++ b/src/milhouse/state/audit.py
@@ -1,0 +1,158 @@
+"""Append-only maintenance audit trail (W03 slice 5b, plan sections 4.4/4.6/4.9).
+
+Every deliberate maintenance mutation — retention pruning, compaction, purge, restore — records one
+append-only row in ``_audit`` describing what happened in privacy-safe terms: the action, the actor
+class, an optional opaque resource id, an outcome, a safe coded reason, and safe counts. An audit
+row never carries the acted-on raw payload (plan section 4.6 ``audit``).
+
+:func:`record_audit` is transaction-scoped: the caller records the audit row on the SAME open
+connection, inside the SAME transaction, as the mutation it attests (e.g. the ledger prune), so the
+trail and the state it describes commit or roll back together and can never diverge. Inputs are
+fully validated before the insert so a malformed entry fails closed with a fixed ``MH_STATE_AUDIT``
+code rather than tripping a database CHECK; the CHECK constraints remain as defense in depth. The
+read side normalizes any SQLite fault to the same fixed code raised outside the handler.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, NoReturn
+
+from milhouse.core.clock import TimeError, format_timestamp
+from milhouse.state.database import ControlDatabase
+from milhouse.state.errors import StateError
+
+_AUDIT_TABLE = "_audit"
+_MAX_TEXT = 1024
+_DEFAULT_LIMIT = 1000
+_MAX_LIMIT = 100_000
+
+
+def _fail(code: str, message: str) -> NoReturn:
+    raise StateError(code, message)
+
+
+@dataclass(frozen=True, slots=True)
+class AuditRecord:
+    """One append-only maintenance audit entry as recorded in the control database."""
+
+    id: int
+    recorded_at: str
+    action: str
+    actor: str
+    outcome: str
+    resource: str | None
+    reason: str | None
+    record_count: int | None
+    byte_size: int | None
+
+
+def _validate_required_text(value: object, subject: str) -> str:
+    if type(value) is not str or not 0 < len(value) <= _MAX_TEXT:
+        _fail("MH_STATE_AUDIT", f"an audit {subject} must be bounded non-empty text")
+    return value
+
+
+def _validate_optional_text(value: object, subject: str) -> str | None:
+    if value is None:
+        return None
+    if type(value) is not str or not 0 < len(value) <= _MAX_TEXT:
+        _fail("MH_STATE_AUDIT", f"an audit {subject} must be bounded non-empty text or absent")
+    return value
+
+
+def _validate_optional_count(value: object, subject: str) -> int | None:
+    if value is None:
+        return None
+    # ``bool`` is an ``int`` subtype; reject it so a stray flag cannot pose as a count.
+    if type(value) is not int or value < 0:
+        _fail("MH_STATE_AUDIT", f"an audit {subject} must be a whole number >= 0 or absent")
+    return value
+
+
+def record_audit(
+    connection: sqlite3.Connection,
+    *,
+    now: datetime,
+    action: str,
+    actor: str,
+    outcome: str,
+    resource: str | None = None,
+    reason: str | None = None,
+    record_count: int | None = None,
+    byte_size: int | None = None,
+) -> None:
+    """Append one audit row on the caller's open transaction connection.
+
+    Call this inside the same transaction as the mutation it describes so the trail and the state
+    commit or roll back atomically together. Every field is validated first; a malformed entry fails
+    closed with ``MH_STATE_AUDIT`` before any write.
+    """
+
+    _validate_required_text(action, "action")
+    _validate_required_text(actor, "actor")
+    _validate_required_text(outcome, "outcome")
+    _validate_optional_text(resource, "resource")
+    _validate_optional_text(reason, "reason")
+    _validate_optional_count(record_count, "record count")
+    _validate_optional_count(byte_size, "byte size")
+    invalid_time = False
+    recorded_at = ""
+    try:
+        recorded_at = format_timestamp(now)
+    except (OverflowError, TimeError):
+        invalid_time = True
+    if invalid_time:
+        _fail("MH_STATE_AUDIT", "an audit timestamp must be an aware in-range UTC instant")
+    connection.execute(
+        f"INSERT INTO {_AUDIT_TABLE} "
+        "(recorded_at, action, actor, outcome, resource, reason, record_count, byte_size) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (recorded_at, action, actor, outcome, resource, reason, record_count, byte_size),
+    )
+
+
+def _row_to_audit(row: Sequence[Any]) -> AuditRecord:
+    return AuditRecord(
+        id=int(row[0]),
+        recorded_at=str(row[1]),
+        action=str(row[2]),
+        actor=str(row[3]),
+        outcome=str(row[4]),
+        resource=None if row[5] is None else str(row[5]),
+        reason=None if row[6] is None else str(row[6]),
+        record_count=None if row[7] is None else int(row[7]),
+        byte_size=None if row[8] is None else int(row[8]),
+    )
+
+
+def list_audit(
+    database: ControlDatabase, *, action: str | None = None, limit: int = _DEFAULT_LIMIT
+) -> tuple[AuditRecord, ...]:
+    """Return audit rows in append order (oldest first), optionally filtered to one ``action``."""
+
+    if type(limit) is not int or not 0 < limit <= _MAX_LIMIT:
+        _fail("MH_STATE_AUDIT", "an audit read limit must be a whole number in 1..100000")
+    if action is not None:
+        _validate_required_text(action, "action")
+    rows: list[tuple[Any, ...]] = []
+    failed = False
+    columns = "id, recorded_at, action, actor, outcome, resource, reason, record_count, byte_size"
+    try:
+        if action is None:
+            rows = database.connection.execute(
+                f"SELECT {columns} FROM {_AUDIT_TABLE} ORDER BY id LIMIT ?", (limit,)
+            ).fetchall()
+        else:
+            rows = database.connection.execute(
+                f"SELECT {columns} FROM {_AUDIT_TABLE} WHERE action = ? ORDER BY id LIMIT ?",
+                (action, limit),
+            ).fetchall()
+    except sqlite3.Error:
+        failed = True
+    if failed:
+        _fail("MH_STATE_AUDIT", "the audit trail could not be read")
+    return tuple(_row_to_audit(row) for row in rows)

--- a/src/milhouse/state/schema.py
+++ b/src/milhouse/state/schema.py
@@ -120,6 +120,33 @@ CONTROL_MIGRATIONS: tuple[Migration, ...] = (
             "CHECK (revision >= 1))",
         ),
     ),
+    Migration(
+        6,
+        "create_audit",
+        (
+            # Append-only audit trail for maintenance actions (plan sections 4.4/4.9). An audit row
+            # records only the action, the actor class, an optional opaque resource id, an outcome,
+            # a safe coded reason, and safe counts — never the acted-on raw payload (plan section
+            # 4.6 'audit'). ``INTEGER PRIMARY KEY AUTOINCREMENT`` gives a monotonic, never-reused
+            # sequence so the trail cannot silently lose or reorder an entry. Retention (slice 5b)
+            # is the first writer; compaction (5c), purge, and backup reuse this table.
+            "CREATE TABLE _audit ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "recorded_at TEXT NOT NULL, "
+            "action TEXT NOT NULL, "
+            "actor TEXT NOT NULL, "
+            "outcome TEXT NOT NULL, "
+            "resource TEXT, "
+            "reason TEXT, "
+            "record_count INTEGER, "
+            "byte_size INTEGER, "
+            "CHECK (length(action) > 0), "
+            "CHECK (length(actor) > 0), "
+            "CHECK (length(outcome) > 0), "
+            "CHECK (record_count IS NULL OR record_count >= 0), "
+            "CHECK (byte_size IS NULL OR byte_size >= 0))",
+        ),
+    ),
 )
 
 

--- a/tests/security/test_makefile_safety.py
+++ b/tests/security/test_makefile_safety.py
@@ -30,6 +30,7 @@ CRITICAL_COVERAGE_FILES = {
     "src/milhouse/privacy/redact.py",
     "src/milhouse/privacy/render.py",
     "src/milhouse/privacy/sanitize.py",
+    "src/milhouse/state/audit.py",
     "src/milhouse/state/barrier.py",
     "src/milhouse/state/cursors.py",
     "src/milhouse/state/database.py",

--- a/tests/security/test_makefile_safety.py
+++ b/tests/security/test_makefile_safety.py
@@ -46,6 +46,7 @@ CRITICAL_COVERAGE_FILES = {
     "src/milhouse/spooling/reader.py",
     "src/milhouse/spooling/reconcile.py",
     "src/milhouse/spooling/replay.py",
+    "src/milhouse/spooling/retention.py",
     "src/milhouse/spooling/segment.py",
     "src/milhouse/spooling/verify.py",
     "src/milhouse/spooling/writer.py",

--- a/tests/unit/test_spool_commit.py
+++ b/tests/unit/test_spool_commit.py
@@ -135,7 +135,7 @@ def _spool(tmp_path: Path):
 def test_migration_creates_the_segment_and_exporter_ledgers(tmp_path: Path) -> None:
     database, _store, _spool_root = _spool(tmp_path)
     try:
-        assert schema_version(database) == 5
+        assert schema_version(database) == 6
         tables = {
             row[0]
             for row in database.connection.execute(
@@ -147,6 +147,7 @@ def test_migration_creates_the_segment_and_exporter_ledgers(tmp_path: Path) -> N
             "_segment_exporters",
             "_cursors",
             "_derivation_checkpoints",
+            "_audit",
         } <= tables
     finally:
         database.close()

--- a/tests/unit/test_spool_reconcile.py
+++ b/tests/unit/test_spool_reconcile.py
@@ -646,6 +646,11 @@ def test_the_package_export_surface_cannot_bypass_mandatory_reconciliation() -> 
     # The slice-5a audit surface (verify_spool) is strictly READ-ONLY: it opens durable files and
     # reads ledger rows to report integrity, mutating nothing and holding no barrier.
     # SegmentVerification/VerifyReport are inert value types.
+    # The slice-5b retention_preview is likewise strictly READ-ONLY: it reads each committed
+    # segment's frames and ledger row to classify record-class expiry and report reclaimable
+    # counts/bytes, mutating nothing and holding no barrier. The mutating retention_apply is NOT
+    # part of this surface yet (it is a follow-up that takes exclusive maintenance authority + a
+    # confirm token). RetentionPreview/SegmentRetention are inert value types.
     assert set(spooling.__all__) == {
         "DurableSpool",
         "Exporter",
@@ -656,9 +661,11 @@ def test_the_package_export_surface_cannot_bypass_mandatory_reconciliation() -> 
         "QuarantinedFile",
         "ReconciliationReport",
         "ReplayReport",
+        "RetentionPreview",
         "SegmentAnomaly",
         "SegmentHeaderV1",
         "SegmentRecord",
+        "SegmentRetention",
         "SegmentVerification",
         "SpoolError",
         "SpoolFrameV1",
@@ -671,6 +678,7 @@ def test_the_package_export_surface_cannot_bypass_mandatory_reconciliation() -> 
         "read_trusted_segment",
         "read_untrusted_segment",
         "replay_segments",
+        "retention_preview",
         "spool_content_sha256",
         "spool_frame_line",
         "spool_segment_header_line",

--- a/tests/unit/test_spool_retention_preview.py
+++ b/tests/unit/test_spool_retention_preview.py
@@ -1,0 +1,288 @@
+"""Behavioural guarantees for read-only retention preview (W03 slice 5b, plan section 4.8).
+
+Retention is per-record-expiry driven: a segment is fully expired only when its every record's
+``expires_at`` has passed, mixed when some have, and live when none have. Preview classifies each
+segment by reading its durable frames and reports exact reclaimable counts/bytes without mutating.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from milhouse.domain.records import (
+    CollectorDescriptorV1,
+    EventDataV1,
+    RecordDraftV1,
+    RecordEnvelopeV1,
+    SourceDescriptorV1,
+    TargetDescriptorV1,
+    finalize_record,
+)
+from milhouse.spooling import (
+    DurableSpool,
+    SegmentHeaderV1,
+    SpoolFrameV1,
+    deliver_segment,
+    spool_content_sha256,
+    spool_frame_line,
+)
+from milhouse.spooling.errors import SpoolError
+from milhouse.spooling.retention import (
+    STATUS_FULLY_EXPIRED,
+    STATUS_LIVE,
+    STATUS_MIXED,
+    STATUS_UNREADABLE,
+    retention_preview,
+)
+from milhouse.state import (
+    GlobalCommitBarrier,
+    initialize_control_state,
+    open_control_database,
+)
+
+_INSTALLATION_ID = "mh_in1_00000000000040008000000000000000"
+_NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=UTC)
+_DAY = "2026-07-28"
+_GENERATION = "a" * 64
+_EXPIRED_AT = _NOW + timedelta(hours=1)  # already past by preview time
+_LIVE_AT = _NOW + timedelta(days=30)  # still in the future by preview time
+_PREVIEW_NOW = _NOW + timedelta(days=1)
+
+
+class _FakeExporter:
+    def __init__(self, exporter_id: str) -> None:
+        self._exporter_id = exporter_id
+
+    @property
+    def exporter_id(self) -> str:
+        return self._exporter_id
+
+    def deliver(self, record, frames) -> None:
+        return None
+
+
+def _envelope(source_event_id: str, expires_at: datetime) -> RecordEnvelopeV1:
+    values: dict[str, object] = {
+        "record_type": "event",
+        "name": "source.event",
+        "occurred_at": _NOW,
+        "observed_at": _NOW + timedelta(seconds=1),
+        "ingested_at": _NOW + timedelta(seconds=2),
+        "expires_at": expires_at,
+        "source_event_id": source_event_id,
+        "operation_id": "operation-1",
+        "collector_run_id": "collector-run-1",
+        "scope": "target",
+        "source": SourceDescriptorV1.model_validate(
+            {
+                "id": "example-source",
+                "type": "source.event",
+                "producer": "collector",
+                "observation_namespace_id": "mh_ns1_00000000000040008000000000000000",
+                "source_generation_digest": "0" * 64,
+                "observation": {"kind": "source.revision", "parts": {"revision": 1}},
+            }
+        ),
+        "collector": CollectorDescriptorV1(
+            id="c", type="site.canary", implementation_version="1.0.0"
+        ),
+        "target": TargetDescriptorV1(
+            id="example-target", name="E", kind="web.service", environment="test"
+        ),
+        "severity": "info",
+        "trust_level": "authenticated",
+        "privacy_class": "internal",
+        "redaction_version": "r1-e1",
+        "data": EventDataV1(category="availability", status="healthy", message="ok"),
+    }
+    return finalize_record(RecordDraftV1.model_validate(values), installation_id=_INSTALLATION_ID)
+
+
+def _frames(batch_id: str, specs: list[tuple[str, datetime]]) -> list[SpoolFrameV1]:
+    return [
+        SpoolFrameV1(batch_id=batch_id, sequence=index, record=_envelope(event_id, expires_at))
+        for index, (event_id, expires_at) in enumerate(specs, start=1)
+    ]
+
+
+def _header(batch_id: str, frames: list[SpoolFrameV1]) -> SegmentHeaderV1:
+    lines = [spool_frame_line(frame) for frame in frames]
+    return SegmentHeaderV1(
+        batch_id=batch_id,
+        config_generation=_GENERATION,
+        scope="target",
+        target_id="example-target",
+        privacy_class="internal",
+        retention_days=30,
+        required_exporters=("clickhouse",),
+        record_count=len(frames),
+        content_sha256=spool_content_sha256(lines),
+    )
+
+
+def _spool(tmp_path: Path):
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    os.chmod(control, 0o700)
+    database = open_control_database(control / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(control / "commit.lock")
+    initialize_control_state(database, barrier=barrier, applied_at=_NOW)
+    spool_root = tmp_path / "spool"
+    spool_root.mkdir(mode=0o700)
+    os.chmod(spool_root, 0o700)
+    store = DurableSpool(
+        database=database, barrier=barrier, spool_root=spool_root, installation_id=_INSTALLATION_ID
+    )
+    return database, barrier, spool_root, store
+
+
+def _commit(store, batch_id: str, specs: list[tuple[str, datetime]]):
+    frames = _frames(batch_id, specs)
+    return store.commit_segment(_header(batch_id, frames), frames, committed_at=_NOW), frames
+
+
+def _segment_file(spool_root: Path, batch_id: str) -> Path:
+    return spool_root / "pending" / _DAY / f"{batch_id}.jsonl"
+
+
+def test_preview_classifies_fully_expired_mixed_and_live(tmp_path: Path) -> None:
+    database, _barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-expired", [("e1", _EXPIRED_AT), ("e2", _EXPIRED_AT)])
+        _commit(store, "batch-mixed", [("m1", _EXPIRED_AT), ("m2", _LIVE_AT)])
+        _commit(store, "batch-live", [("l1", _LIVE_AT)])
+        preview = retention_preview(
+            database, spool_root=spool_root, installation_id=_INSTALLATION_ID, now=_PREVIEW_NOW
+        )
+        by_id = {s.batch_id: s.status for s in preview.segments}
+        assert by_id == {
+            "batch-expired": STATUS_FULLY_EXPIRED,
+            "batch-mixed": STATUS_MIXED,
+            "batch-live": STATUS_LIVE,
+        }
+        assert [s.batch_id for s in preview.fully_expired] == ["batch-expired"]
+        assert [s.batch_id for s in preview.compaction_candidates] == ["batch-mixed"]
+    finally:
+        database.close()
+
+
+def test_reclaimable_counts_and_bytes_sum_only_fully_expired(tmp_path: Path) -> None:
+    database, _barrier, spool_root, store = _spool(tmp_path)
+    try:
+        expired_record, _ = _commit(
+            store, "batch-expired", [("e1", _EXPIRED_AT), ("e2", _EXPIRED_AT)]
+        )
+        _commit(store, "batch-live", [("l1", _LIVE_AT)])
+        preview = retention_preview(
+            database, spool_root=spool_root, installation_id=_INSTALLATION_ID, now=_PREVIEW_NOW
+        )
+        assert preview.reclaimable_records == 2  # only the expired segment's two records
+        assert preview.reclaimable_bytes == expired_record.byte_size
+    finally:
+        database.close()
+
+
+def test_an_expired_but_undelivered_segment_is_flagged(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        delivered_record, delivered_frames = _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
+        deliver_segment(
+            database,
+            barrier,
+            delivered_record,
+            delivered_frames,
+            {"clickhouse": _FakeExporter("clickhouse")},
+        )
+        _commit(store, "batch-b", [("b1", _EXPIRED_AT)])  # left undelivered
+        preview = retention_preview(
+            database, spool_root=spool_root, installation_id=_INSTALLATION_ID, now=_PREVIEW_NOW
+        )
+        # Both are fully expired, but only the undelivered one is a critical-on-removal case.
+        assert {s.batch_id for s in preview.fully_expired} == {"batch-a", "batch-b"}
+        assert [s.batch_id for s in preview.undelivered_expired] == ["batch-b"]
+    finally:
+        database.close()
+
+
+def test_an_empty_segment_is_left_live(tmp_path: Path) -> None:
+    database, _barrier, spool_root, store = _spool(tmp_path)
+    try:
+        frames: list[SpoolFrameV1] = []
+        store.commit_segment(_header("batch-empty", frames), frames, committed_at=_NOW)
+        preview = retention_preview(
+            database, spool_root=spool_root, installation_id=_INSTALLATION_ID, now=_PREVIEW_NOW
+        )
+        assert preview.segments[0].status == STATUS_LIVE  # no record-class expiry to reason about
+        assert preview.fully_expired == ()
+    finally:
+        database.close()
+
+
+def test_an_unreadable_segment_is_reported_not_prunable(tmp_path: Path) -> None:
+    database, _barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
+        _segment_file(spool_root, "batch-a").unlink()
+        preview = retention_preview(
+            database, spool_root=spool_root, installation_id=_INSTALLATION_ID, now=_PREVIEW_NOW
+        )
+        segment = preview.segments[0]
+        assert segment.status == STATUS_UNREADABLE
+        assert segment.code == "MH_SPOOL_NOT_FOUND"
+        assert preview.fully_expired == ()  # never treated as reclaimable
+        assert [s.batch_id for s in preview.unreadable] == ["batch-a"]
+    finally:
+        database.close()
+
+
+def test_preview_over_an_empty_ledger_is_empty(tmp_path: Path) -> None:
+    database, _barrier, spool_root, _store = _spool(tmp_path)
+    try:
+        preview = retention_preview(
+            database, spool_root=spool_root, installation_id=_INSTALLATION_ID, now=_PREVIEW_NOW
+        )
+        assert preview.segments == ()
+        assert preview.reclaimable_records == 0
+        assert preview.reclaimable_bytes == 0
+    finally:
+        database.close()
+
+
+def test_preview_rejects_invalid_arguments(tmp_path: Path) -> None:
+    database, _barrier, spool_root, _store = _spool(tmp_path)
+    try:
+        with pytest.raises(SpoolError) as bad_db:
+            retention_preview(
+                object(),
+                spool_root=spool_root,
+                installation_id=_INSTALLATION_ID,
+                now=_PREVIEW_NOW,  # type: ignore[arg-type]
+            )
+        assert bad_db.value.code == "MH_SPOOL_RETENTION"
+        with pytest.raises(SpoolError) as bad_root:
+            retention_preview(
+                database,
+                spool_root=None,
+                installation_id=_INSTALLATION_ID,
+                now=_PREVIEW_NOW,  # type: ignore[arg-type]
+            )
+        assert bad_root.value.code == "MH_SPOOL_RETENTION"
+        with pytest.raises(SpoolError) as bad_id:
+            retention_preview(
+                database, spool_root=spool_root, installation_id="nope", now=_PREVIEW_NOW
+            )
+        assert bad_id.value.code == "MH_SPOOL_IDENTITY"
+        with pytest.raises(SpoolError) as bad_now:
+            retention_preview(
+                database,
+                spool_root=spool_root,
+                installation_id=_INSTALLATION_ID,
+                now=datetime(2026, 7, 28, 12),  # naive
+            )
+        assert bad_now.value.code == "MH_SPOOL_RETENTION"
+    finally:
+        database.close()

--- a/tests/unit/test_state_audit.py
+++ b/tests/unit/test_state_audit.py
@@ -1,0 +1,234 @@
+"""Behavioural guarantees for the append-only maintenance audit trail (W03 slice 5b).
+
+An audit row records a maintenance action in privacy-safe terms and is written on the caller's
+transaction, so it commits or rolls back atomically with the state it attests. Malformed entries
+fail closed with a fixed ``MH_STATE_AUDIT`` code before any write.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from milhouse.state import (
+    AuditRecord,
+    GlobalCommitBarrier,
+    StateError,
+    initialize_control_state,
+    list_audit,
+    open_control_database,
+    record_audit,
+    schema_version,
+)
+
+_NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=UTC)
+_STAMP = "2026-07-28T12:00:00.000Z"
+
+
+def _database(tmp_path: Path):
+    directory = tmp_path / "control"
+    directory.mkdir(mode=0o700)
+    os.chmod(directory, 0o700)
+    database = open_control_database(directory / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(directory / "commit.lock")
+    initialize_control_state(database, barrier=barrier, applied_at=_NOW)
+    return database
+
+
+def _record(database, **kwargs) -> None:
+    with database.transaction() as connection:
+        record_audit(connection, **kwargs)
+
+
+def test_migration_6_creates_the_audit_table(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        assert schema_version(database) == 6
+        tables = {
+            row[0]
+            for row in database.connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "_audit" in tables
+    finally:
+        database.close()
+
+
+def test_a_full_audit_row_round_trips(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        _record(
+            database,
+            now=_NOW,
+            action="retention_prune",
+            actor="maintenance",
+            outcome="pruned",
+            resource="batch-1",
+            reason="expired",
+            record_count=3,
+            byte_size=128,
+        )
+        rows = list_audit(database)
+        assert rows == (
+            AuditRecord(
+                id=1,
+                recorded_at=_STAMP,
+                action="retention_prune",
+                actor="maintenance",
+                outcome="pruned",
+                resource="batch-1",
+                reason="expired",
+                record_count=3,
+                byte_size=128,
+            ),
+        )
+    finally:
+        database.close()
+
+
+def test_optional_fields_default_to_none(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        _record(database, now=_NOW, action="retention_apply", actor="maintenance", outcome="ok")
+        row = list_audit(database)[0]
+        assert (row.resource, row.reason, row.record_count, row.byte_size) == (
+            None,
+            None,
+            None,
+            None,
+        )
+    finally:
+        database.close()
+
+
+def test_ids_are_monotonic_and_append_ordered(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        for index in range(1, 4):
+            _record(
+                database,
+                now=_NOW,
+                action="a",
+                actor="maintenance",
+                outcome="ok",
+                resource=str(index),
+            )
+        rows = list_audit(database)
+        assert [r.id for r in rows] == [1, 2, 3]
+        assert [r.resource for r in rows] == ["1", "2", "3"]
+    finally:
+        database.close()
+
+
+def test_list_filters_by_action_and_respects_the_limit(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        _record(database, now=_NOW, action="prune", actor="m", outcome="ok")
+        _record(database, now=_NOW, action="compact", actor="m", outcome="ok")
+        _record(database, now=_NOW, action="prune", actor="m", outcome="ok")
+        assert [r.action for r in list_audit(database, action="prune")] == ["prune", "prune"]
+        assert len(list_audit(database, limit=2)) == 2
+    finally:
+        database.close()
+
+
+def test_an_audit_row_rolls_back_with_a_failed_caller_transaction(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            with database.transaction() as connection:
+                record_audit(connection, now=_NOW, action="prune", actor="m", outcome="ok")
+                raise RuntimeError("boom")
+        # The audit row is transaction-scoped, so it did not survive the caller's rollback.
+        assert list_audit(database) == ()
+    finally:
+        database.close()
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("action", ""),
+        ("action", 5),
+        ("actor", ""),
+        ("outcome", ""),
+        ("resource", ""),
+        ("resource", 5),
+        ("reason", ""),
+        ("record_count", -1),
+        ("record_count", True),
+        ("byte_size", -1),
+        ("action", "x" * 1025),
+    ],
+)
+def test_malformed_fields_are_rejected(tmp_path: Path, field: str, value: object) -> None:
+    database = _database(tmp_path)
+    try:
+        kwargs: dict[str, object] = {
+            "now": _NOW,
+            "action": "prune",
+            "actor": "maintenance",
+            "outcome": "ok",
+        }
+        kwargs[field] = value
+        with pytest.raises(StateError) as captured:
+            record_audit(database.connection, **kwargs)  # type: ignore[arg-type]
+        assert captured.value.code == "MH_STATE_AUDIT"
+        assert list_audit(database) == ()  # nothing written
+    finally:
+        database.close()
+
+
+def test_record_rejects_a_naive_timestamp(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        with pytest.raises(StateError) as captured:
+            record_audit(
+                database.connection,
+                now=datetime(2026, 7, 28, 12),  # naive, no tzinfo
+                action="prune",
+                actor="m",
+                outcome="ok",
+            )
+        assert captured.value.code == "MH_STATE_AUDIT"
+    finally:
+        database.close()
+
+
+@pytest.mark.parametrize("limit", [0, -1, 100_001])
+def test_list_rejects_a_bad_limit(tmp_path: Path, limit: int) -> None:
+    database = _database(tmp_path)
+    try:
+        with pytest.raises(StateError) as captured:
+            list_audit(database, limit=limit)
+        assert captured.value.code == "MH_STATE_AUDIT"
+    finally:
+        database.close()
+
+
+def test_list_rejects_a_malformed_action_filter(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        with pytest.raises(StateError) as captured:
+            list_audit(database, action="")
+        assert captured.value.code == "MH_STATE_AUDIT"
+    finally:
+        database.close()
+
+
+def test_a_read_against_a_broken_store_normalizes_to_a_stable_code(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        with database.transaction() as connection:
+            connection.execute("DROP TABLE _audit")
+        with pytest.raises(StateError) as captured:
+            list_audit(database)
+        assert captured.value.code == "MH_STATE_AUDIT"
+        assert captured.value.__cause__ is None
+        assert captured.value.__context__ is None
+    finally:
+        database.close()

--- a/tests/unit/test_state_audit.py
+++ b/tests/unit/test_state_audit.py
@@ -161,7 +161,9 @@ def test_an_audit_row_rolls_back_with_a_failed_caller_transaction(tmp_path: Path
         ("reason", ""),
         ("record_count", -1),
         ("record_count", True),
+        ("record_count", 2**63),  # would overflow the signed-64 INTEGER binding at INSERT
         ("byte_size", -1),
+        ("byte_size", 2**63),
         ("action", "x" * 1025),
     ],
 )
@@ -227,6 +229,22 @@ def test_a_read_against_a_broken_store_normalizes_to_a_stable_code(tmp_path: Pat
             connection.execute("DROP TABLE _audit")
         with pytest.raises(StateError) as captured:
             list_audit(database)
+        assert captured.value.code == "MH_STATE_AUDIT"
+        assert captured.value.__cause__ is None
+        assert captured.value.__context__ is None
+    finally:
+        database.close()
+
+
+def test_a_write_against_a_broken_store_normalizes_to_a_stable_code(tmp_path: Path) -> None:
+    database = _database(tmp_path)
+    try:
+        with database.transaction() as connection:
+            connection.execute("DROP TABLE _audit")
+        with pytest.raises(StateError) as captured:
+            with database.transaction() as connection:
+                record_audit(connection, now=_NOW, action="prune", actor="m", outcome="ok")
+        # A backend fault on the insert normalizes to the fixed code with no leaked detail.
         assert captured.value.code == "MH_STATE_AUDIT"
         assert captured.value.__cause__ is None
         assert captured.value.__context__ is None

--- a/tests/unit/test_state_slice4_schema.py
+++ b/tests/unit/test_state_slice4_schema.py
@@ -51,7 +51,9 @@ def _insert_committed_segment(database, batch_id: str = "batch-1") -> str:
 def test_slice4_migrations_create_the_cursor_and_checkpoint_tables(tmp_path: Path) -> None:
     database = _initialized(tmp_path)
     try:
-        assert schema_version(database) >= 5  # slice-4 migrations applied (later slices append more)
+        assert (
+            schema_version(database) >= 5
+        )  # slice-4 migrations applied (later slices append more)
         tables = {
             row[0]
             for row in database.connection.execute(

--- a/tests/unit/test_state_slice4_schema.py
+++ b/tests/unit/test_state_slice4_schema.py
@@ -51,7 +51,7 @@ def _insert_committed_segment(database, batch_id: str = "batch-1") -> str:
 def test_slice4_migrations_create_the_cursor_and_checkpoint_tables(tmp_path: Path) -> None:
     database = _initialized(tmp_path)
     try:
-        assert schema_version(database) == 5
+        assert schema_version(database) >= 5  # slice-4 migrations applied (later slices append more)
         tables = {
             row[0]
             for row in database.connection.execute(


### PR DESCRIPTION
## W03 slice 5b (part 1) — maintenance audit trail + read-only retention preview

Slice 5b (retention) split into a read-only foundation (this PR) and the destructive `retention_apply` (follow-up), keeping the data-deleting code on its own reviewable PR.

### What landed
- **`_audit` control table (migration 6) + API** (`state/audit.py`). Every deliberate maintenance mutation records one append-only, privacy-safe row: action, actor class, optional opaque resource id, outcome, safe coded reason, and safe counts — never the acted-on raw payload (plan §4.6). `id INTEGER PRIMARY KEY AUTOINCREMENT` gives a monotonic, never-reused sequence. `record_audit` is **transaction-scoped** — the caller writes it on its own connection in the same transaction as the mutation it attests, so trail and state commit or roll back together. Retention apply (follow-up) is the first writer; compaction/purge/backup reuse it.
- **Read-only `retention_preview`** (`spooling/retention.py`). Retention is per-record-expiry driven: a segment is prunable wholesale only when **every** record's `expires_at` has passed. Preview reads each committed segment's frames and classifies it `fully_expired` / `mixed` (a 5c compaction candidate, never pruned here) / `live` / `unreadable`, reporting exact reclaimable records/bytes and flagging fully-expired-but-undelivered segments (data that reached its privacy deadline before export). Holds no barrier; mutates nothing.

### Discipline
- Read-only additions to the spooling surface; export-surface guard records that `retention_apply` is deliberately **not** on this surface yet (it takes exclusive authority + a confirm token). `audit.py` and `retention.py` are critical-coverage files at **100% branch**.
- Independent **pre-merge exact-head review**: no P1; confirmed read-only/no-barrier, expiry classification (mixed can never be fully_expired), transaction-scoped atomic audit, privacy, migration correctness, and unreadable-not-reclaimable. Its one **P2** — an unbounded audit count could overflow the INTEGER binding and escape as a raw `OverflowError` — is fixed (counts bounded to 0..2⁶³-1; the insert now normalizes any write fault to `MH_STATE_AUDIT`).
- Full suite green; `test-coverage`, `quality` (incl. mypy) pass; DCO signed.

### Follow-up (5b part 2)
`retention_apply`: prune fully-expired segments under the exclusive barrier with a confirm token, row-first ordering (so a crash leaves a re-registerable orphan, not a row-without-file), a new secure descriptor-relative unlink primitive, undelivered-expired critical audit events, and failure-injection tests. Then 5c (audited compaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)