### PR TITLE
feat(w03): slice 5b part 2 — destructive retention_apply + secure unlink

### DIFF
--- a/src/milhouse/config/filesystem.py
+++ b/src/milhouse/config/filesystem.py
@@ -795,6 +795,79 @@ def inspect_regular_file_no_follow(
     return opened.selection
 
 
+def remove_regular_file_no_follow(
+    path: str | Path,
+    *,
+    expected_identity: FileIdentity | None = None,
+) -> None:
+    """Securely unlink one regular file relative to its no-follow-opened private parent, then fsync.
+
+    The parent directory chain is opened no-follow, so no symlinked ancestor can redirect it, and
+    the parent is required to be an owned, ACL-free ``0700`` directory. The leaf is ``lstat``-ed
+    relative to the parent descriptor (a final symlink is never followed) and must be an owner-only,
+    single-link regular file; when ``expected_identity`` is supplied it must also match that exact
+    ``(device, inode)``, so a file swapped in since the caller selected it is refused rather than
+    unlinked. The name is then unlinked relative to the parent descriptor and the parent directory
+    is fsynced so the removal is durable across a crash.
+
+    POSIX cannot atomically bind the identity check to the subsequent unlink-by-name; that
+    one-syscall residual window is excluded for cooperating writers by the exclusive maintenance
+    barrier and, for a hostile same-account process, by the installation-account trust boundary
+    (ADR 0008 / amendment A06). Every failure raises a fixed :class:`SecureFileError` carrying no
+    path or OS detail.
+    """
+
+    normalized = lexical_absolute_path(path)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if nofollow == 0:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+    effective_user_id = getattr(os, "geteuid", None)
+    if effective_user_id is None:
+        raise SecureFileError(SecureFileErrorKind.SECURITY_UNSUPPORTED)
+
+    parent_descriptor: int | None = None
+    failure: SecureFileError | None = None
+    try:
+        parent_descriptor, leaf = _open_directory_chain(normalized, nofollow=nofollow)
+        _require_private_parent(parent_descriptor, os.fstat(parent_descriptor))
+        metadata = os.stat(leaf, dir_fd=parent_descriptor, follow_symlinks=False)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != effective_user_id()
+            or metadata.st_nlink != 1
+        ):
+            raise SecureFileError(SecureFileErrorKind.NOT_REGULAR)
+        if expected_identity is not None and FileIdentity.from_stat(metadata) != expected_identity:
+            raise SecureFileError(SecureFileErrorKind.CHANGED)
+        os.unlink(leaf, dir_fd=parent_descriptor)
+        os.fsync(parent_descriptor)
+    except FileNotFoundError:
+        failure = SecureFileError(SecureFileErrorKind.NOT_FOUND)
+    except SecureFileError as error:
+        failure = error
+    except ValueError:
+        failure = SecureFileError(SecureFileErrorKind.INVALID)
+    except OSError as exc:
+        kind = (
+            SecureFileErrorKind.NOT_REGULAR
+            if exc.errno in {errno.ELOOP, errno.ENOTDIR}
+            else SecureFileErrorKind.WRITE_FAILED
+        )
+        failure = SecureFileError(kind)
+    except Exception:
+        failure = SecureFileError(SecureFileErrorKind.WRITE_FAILED)
+    finally:
+        if parent_descriptor is not None:
+            try:
+                os.close(parent_descriptor)
+            except OSError:
+                if failure is None:
+                    failure = SecureFileError(SecureFileErrorKind.UNREADABLE)
+
+    if failure is not None:
+        raise failure
+
+
 __all__ = [
     "FileIdentity",
     "FileSelection",
@@ -806,6 +879,7 @@ __all__ = [
     "inspect_regular_file_no_follow",
     "lexical_absolute_path",
     "open_regular_file_no_follow",
+    "remove_regular_file_no_follow",
     "require_no_extended_acl",
     "sync_parent_directory_no_follow",
 ]

--- a/src/milhouse/spooling/__init__.py
+++ b/src/milhouse/spooling/__init__.py
@@ -21,8 +21,11 @@ from milhouse.spooling.reconcile import (
 )
 from milhouse.spooling.replay import ReplayReport, replay_segments
 from milhouse.spooling.retention import (
+    PrunedSegment,
     RetentionPreview,
+    RetentionResult,
     SegmentRetention,
+    retention_apply,
     retention_preview,
 )
 from milhouse.spooling.segment import (
@@ -46,10 +49,12 @@ __all__ = [
     "ExporterDelivery",
     "OrphanRegistration",
     "ParsedSegment",
+    "PrunedSegment",
     "QuarantinedFile",
     "ReconciliationReport",
     "ReplayReport",
     "RetentionPreview",
+    "RetentionResult",
     "SegmentAnomaly",
     "SegmentHeaderV1",
     "SegmentRecord",
@@ -66,6 +71,7 @@ __all__ = [
     "read_trusted_segment",
     "read_untrusted_segment",
     "replay_segments",
+    "retention_apply",
     "retention_preview",
     "spool_content_sha256",
     "spool_frame_line",

--- a/src/milhouse/spooling/retention.py
+++ b/src/milhouse/spooling/retention.py
@@ -28,9 +28,13 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import NoReturn
+from typing import NoReturn, cast
 
-from milhouse.config.filesystem import SecureFileError, remove_regular_file_no_follow
+from milhouse.config.filesystem import (
+    SecureFileError,
+    lexical_absolute_path,
+    remove_regular_file_no_follow,
+)
 from milhouse.core.clock import TimeError, format_timestamp
 from milhouse.spooling.errors import SpoolError
 from milhouse.spooling.ledger import SegmentRecord, list_segment_records
@@ -42,6 +46,7 @@ from milhouse.state.database import ControlDatabase, _validated_database_path
 from milhouse.state.errors import StateError
 
 _PENDING = "pending"
+_SPOOL = "spool"
 _DELIVERED = "delivered"
 _BARRIER_NAME = "commit.lock"
 _ACTOR = "maintenance"
@@ -143,6 +148,18 @@ def _classify(
             delivered=delivered,
             code=error.code,
         )
+    if not _agrees(parsed, record.day, record.batch_id, record):
+        # A readable file that disagrees with its ledger row is never reclaimable; report it as
+        # disagreeing so the preview matches what apply would do (apply skips it) rather than
+        # overstating the reclaimable estimate.
+        return SegmentRetention(
+            batch_id=record.batch_id,
+            status=STATUS_DISAGREEING,
+            record_count=record.record_count,
+            byte_size=record.byte_size,
+            delivered=delivered,
+            code="MH_SPOOL_VERIFY",
+        )
     expiries = [frame.record.expires_at for frame in parsed.frames]
     if not expiries:
         # A segment with a header but no record frames carries no record-class expiry to reason
@@ -165,8 +182,21 @@ def _classify(
 def _validate_common(database: object, spool_root: object, installation_id: object) -> None:
     if type(database) is not ControlDatabase:
         _fail("MH_SPOOL_RETENTION", "a control database is required")
+    database_path = _validated_database_path(database)
+    if database_path is None:
+        _fail("MH_SPOOL_RETENTION", "a control database is required")
     if not isinstance(spool_root, (str, os.PathLike)):
         _fail("MH_SPOOL_RETENTION", "a spool root path is required")
+    try:
+        resolved_spool = lexical_absolute_path(cast("str | Path", spool_root))
+    except SecureFileError:
+        _fail("MH_SPOOL_RETENTION", "a spool root path is required")
+    # Bind the spool root to this database's state root, exactly as commit/reconciliation do.
+    # Without it a misconfigured spool_root would find every segment 'unreadable' and silently prune
+    # nothing, so expired data at the real spool would never be reclaimed while the operator thinks
+    # retention ran. Fail closed instead.
+    if resolved_spool != database_path.parent.parent / _SPOOL:
+        _fail("MH_SPOOL_RETENTION", "the spool root must be <state_root>/spool")
     if (
         type(installation_id) is not str
         or INSTALLATION_ID_PATTERN.fullmatch(installation_id) is None

--- a/src/milhouse/spooling/retention.py
+++ b/src/milhouse/spooling/retention.py
@@ -24,24 +24,34 @@ to a fixed ``MH_SPOOL_*`` error raised outside the handler.
 from __future__ import annotations
 
 import os
+import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import NoReturn
 
+from milhouse.config.filesystem import SecureFileError, remove_regular_file_no_follow
 from milhouse.core.clock import TimeError, format_timestamp
 from milhouse.spooling.errors import SpoolError
 from milhouse.spooling.ledger import SegmentRecord, list_segment_records
 from milhouse.spooling.reader import INSTALLATION_ID_PATTERN, read_trusted_segment
-from milhouse.state.database import ControlDatabase
+from milhouse.spooling.reconcile import _agrees
+from milhouse.state.audit import record_audit
+from milhouse.state.barrier import GlobalCommitBarrier, _is_bound_barrier
+from milhouse.state.database import ControlDatabase, _validated_database_path
+from milhouse.state.errors import StateError
 
 _PENDING = "pending"
 _DELIVERED = "delivered"
+_BARRIER_NAME = "commit.lock"
+_ACTOR = "maintenance"
+_ACTION_PRUNE = "retention_prune"
 
 STATUS_FULLY_EXPIRED = "fully_expired"
 STATUS_MIXED = "mixed"
 STATUS_LIVE = "live"
 STATUS_UNREADABLE = "unreadable"
+STATUS_DISAGREEING = "disagreeing"
 
 
 def _fail(code: str, message: str) -> NoReturn:
@@ -185,3 +195,205 @@ def retention_preview(
     records = list_segment_records(database)
     segments = tuple(_classify(record, root, installation_id, now) for record in records)
     return RetentionPreview(segments=segments)
+
+
+@dataclass(frozen=True, slots=True)
+class PrunedSegment:
+    """One committed segment removed by a retention apply pass.
+
+    ``file_removed`` is ``False`` when the ledger row was deleted and audited but the durable file
+    could not be unlinked; because the prune is row-first, that leaves a re-registerable orphan the
+    next reconciliation adopts and a later retention pass re-prunes (convergent), never a
+    ledger-row-without-file. ``delivered`` records whether the segment had finished exporting — a
+    pruned undelivered segment is a critical event (data reached its privacy deadline unexported).
+    """
+
+    batch_id: str
+    record_count: int
+    byte_size: int
+    delivered: bool
+    file_removed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionResult:
+    """The outcome of one retention apply pass."""
+
+    pruned: tuple[PrunedSegment, ...]
+    skipped: tuple[SegmentRetention, ...]
+
+    @property
+    def pruned_records(self) -> int:
+        return sum(segment.record_count for segment in self.pruned)
+
+    @property
+    def pruned_bytes(self) -> int:
+        return sum(segment.byte_size for segment in self.pruned)
+
+    @property
+    def undelivered_pruned(self) -> tuple[PrunedSegment, ...]:
+        """Pruned segments that were never delivered — the critical-event cases."""
+
+        return tuple(segment for segment in self.pruned if not segment.delivered)
+
+    @property
+    def orphaned_files(self) -> tuple[PrunedSegment, ...]:
+        """Pruned segments whose durable file could not be unlinked (a re-registerable orphan)."""
+
+        return tuple(segment for segment in self.pruned if not segment.file_removed)
+
+
+def _validate_barrier(database: ControlDatabase, barrier: object) -> None:
+    if type(barrier) is not GlobalCommitBarrier:
+        _fail("MH_SPOOL_RETENTION", "a commit barrier is required")
+    database_path = _validated_database_path(database)
+    if database_path is None or not _is_bound_barrier(
+        barrier, database_path.parent / _BARRIER_NAME
+    ):
+        # Retention prunes under the EXCLUSIVE side; if the barrier is not the control-plane commit
+        # lock, its exclusive hold would not actually exclude the writers that use the real lock, so
+        # a concurrent commit could publish into a segment being pruned. Fail closed.
+        _fail("MH_SPOOL_RETENTION", "the barrier must be the control-plane commit lock")
+
+
+def _prune_segment(
+    database: ControlDatabase,
+    record: SegmentRecord,
+    path: Path,
+    now: datetime,
+    *,
+    delivered: bool,
+) -> PrunedSegment | None:
+    """Delete the ledger row + exporter rows + audit row in one transaction, then unlink the file.
+
+    Row-first: the ledger deletion and its audit commit atomically, and only then is the durable
+    file unlinked. A crash or unlink failure after the commit leaves an orphan file (reconciliation
+    re-registers it, a later retention re-prunes it — convergent), never a row without a file.
+    Returns ``None`` if the transactional deletion itself failed (the segment is left fully intact).
+    """
+
+    outcome = "pruned" if delivered else "pruned_undelivered"
+    reason = "expired" if delivered else "expired_undelivered"
+    failed = False
+    try:
+        with database.transaction() as connection:
+            connection.execute(
+                "DELETE FROM _segment_exporters WHERE batch_id = ?", (record.batch_id,)
+            )
+            connection.execute("DELETE FROM _segments WHERE batch_id = ?", (record.batch_id,))
+            record_audit(
+                connection,
+                now=now,
+                action=_ACTION_PRUNE,
+                actor=_ACTOR,
+                outcome=outcome,
+                resource=record.batch_id,
+                reason=reason,
+                record_count=record.record_count,
+                byte_size=record.byte_size,
+            )
+    except (sqlite3.Error, StateError):
+        failed = True
+    if failed:
+        return None
+    file_removed = True
+    try:
+        remove_regular_file_no_follow(path)
+    except SecureFileError:
+        # The ledger row is already gone; the durable file lingers as a re-registerable orphan.
+        file_removed = False
+    return PrunedSegment(
+        batch_id=record.batch_id,
+        record_count=record.record_count,
+        byte_size=record.byte_size,
+        delivered=delivered,
+        file_removed=file_removed,
+    )
+
+
+def _apply_one(
+    database: ControlDatabase,
+    record: SegmentRecord,
+    root: Path,
+    installation_id: str,
+    now: datetime,
+) -> tuple[PrunedSegment | None, SegmentRetention | None]:
+    """Re-verify one segment under the exclusive hold and prune it iff it is fully expired.
+
+    Returns ``(pruned, None)`` when the segment was pruned, else ``(None, skipped)`` with the
+    classification explaining why it was left in place (live, mixed, unreadable, disagreeing, or a
+    failed transactional prune).
+    """
+
+    delivered = all(exporter.delivery_status == _DELIVERED for exporter in record.exporters)
+    path = root / _PENDING / record.day / f"{record.batch_id}.jsonl"
+
+    def _skip(status: str, code: str | None) -> tuple[None, SegmentRetention]:
+        return None, SegmentRetention(
+            batch_id=record.batch_id,
+            status=status,
+            record_count=record.record_count,
+            byte_size=record.byte_size,
+            delivered=delivered,
+            code=code,
+        )
+
+    try:
+        parsed = read_trusted_segment(path, installation_id=installation_id)
+    except SpoolError as error:
+        return _skip(STATUS_UNREADABLE, error.code)
+    if not _agrees(parsed, record.day, record.batch_id, record):
+        # A file that disagrees with its ledger row may be tampered/corrupt; never prune it — verify
+        # and reconciliation own that anomaly.
+        return _skip(STATUS_DISAGREEING, "MH_SPOOL_VERIFY")
+    expiries = [frame.record.expires_at for frame in parsed.frames]
+    if not expiries or max(expiries) > now:
+        status = STATUS_LIVE if (not expiries or min(expiries) > now) else STATUS_MIXED
+        return _skip(status, None)
+    pruned = _prune_segment(database, record, path, now, delivered=delivered)
+    if pruned is None:
+        return _skip(STATUS_FULLY_EXPIRED, "MH_SPOOL_RETENTION")
+    return pruned, None
+
+
+def retention_apply(
+    database: ControlDatabase,
+    barrier: GlobalCommitBarrier,
+    *,
+    spool_root: str | Path,
+    installation_id: str,
+    now: datetime,
+    confirm: bool,
+) -> RetentionResult:
+    """Prune every fully-expired committed segment under exclusive maintenance authority.
+
+    ``confirm`` must be ``True`` — a preview-then-apply guard, so retention never deletes data on an
+    accidental call. The whole pass runs under ``barrier.exclusive()`` so no writer can publish
+    while segments are pruned. Each segment is re-read and re-verified against its ledger row under
+    the lock; only a segment that agrees and is fully expired (max record ``expires_at`` past
+    ``now``) is pruned, row-first, with an audit row (``pruned`` or ``pruned_undelivered`` for the
+    critical case). Mixed-expiry segments are left for compaction; unreadable or disagreeing
+    segments are left for verify/reconciliation. Every failure normalizes to a fixed ``MH_SPOOL_*``
+    code.
+    """
+
+    _validate_common(database, spool_root, installation_id)
+    _validate_barrier(database, barrier)
+    _require_now(now)
+    if confirm is not True:
+        _fail("MH_SPOOL_RETENTION", "retention apply requires an explicit confirmation")
+    root = Path(spool_root)
+
+    pruned: list[PrunedSegment] = []
+    skipped: list[SegmentRetention] = []
+    with barrier.exclusive():
+        for record in list_segment_records(database):
+            pruned_segment, skipped_segment = _apply_one(
+                database, record, root, installation_id, now
+            )
+            if pruned_segment is not None:
+                pruned.append(pruned_segment)
+            else:
+                assert skipped_segment is not None
+                skipped.append(skipped_segment)
+    return RetentionResult(pruned=tuple(pruned), skipped=tuple(skipped))

--- a/tests/unit/test_config_filesystem_remove.py
+++ b/tests/unit/test_config_filesystem_remove.py
@@ -1,0 +1,239 @@
+"""Tests for the secure descriptor-relative file removal primitive (W03 slice 5b part 2).
+
+``remove_regular_file_no_follow`` unlinks one owner-only, single-link regular file relative to its
+no-follow-opened private parent and fsyncs the parent, refusing a symlink, directory, hard-linked,
+or identity-mismatched leaf, a non-private or symlinked-ancestor parent, and normalizing every fault
+to a fixed :class:`SecureFileError`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import milhouse.config.filesystem as config_filesystem
+from milhouse.config.filesystem import (
+    FileIdentity,
+    SecureFileError,
+    SecureFileErrorKind,
+    remove_regular_file_no_follow,
+)
+
+
+def _private_file(tmp_path: Path, name: str = "segment.jsonl") -> tuple[Path, Path]:
+    directory = tmp_path / "day"
+    directory.mkdir(mode=0o700)
+    os.chmod(directory, 0o700)  # defeat the inherited umask
+    path = directory / name
+    path.write_bytes(b"segment-bytes\n")
+    os.chmod(path, 0o600)
+    return directory, path
+
+
+def test_removes_a_private_regular_file(tmp_path: Path) -> None:
+    _directory, path = _private_file(tmp_path)
+    remove_regular_file_no_follow(path)
+    assert not path.exists()
+
+
+def test_removes_with_a_matching_expected_identity(tmp_path: Path) -> None:
+    _directory, path = _private_file(tmp_path)
+    identity = FileIdentity.from_stat(path.stat())
+    remove_regular_file_no_follow(path, expected_identity=identity)
+    assert not path.exists()
+
+
+def test_refuses_a_mismatched_expected_identity(tmp_path: Path) -> None:
+    _directory, path = _private_file(tmp_path)
+    actual = FileIdentity.from_stat(path.stat())
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(
+            path, expected_identity=FileIdentity(device=actual.device, inode=actual.inode + 1)
+        )
+    assert captured.value.kind is SecureFileErrorKind.CHANGED
+    assert path.exists()  # a swapped-in file is refused, not unlinked
+
+
+def test_refuses_a_missing_file(tmp_path: Path) -> None:
+    directory, _path = _private_file(tmp_path)
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(directory / "absent.jsonl")
+    assert captured.value.kind is SecureFileErrorKind.NOT_FOUND
+
+
+def test_refuses_a_symlink_leaf(tmp_path: Path) -> None:
+    directory, path = _private_file(tmp_path)
+    link = directory / "link.jsonl"
+    link.symlink_to(path)
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(link)
+    assert captured.value.kind is SecureFileErrorKind.NOT_REGULAR
+    assert link.is_symlink() and path.exists()  # neither the link nor its target is removed
+
+
+def test_refuses_a_directory_leaf(tmp_path: Path) -> None:
+    directory, _path = _private_file(tmp_path)
+    subdirectory = directory / "sub"
+    subdirectory.mkdir(mode=0o700)
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(subdirectory)
+    assert captured.value.kind is SecureFileErrorKind.NOT_REGULAR
+    assert subdirectory.is_dir()
+
+
+def test_refuses_a_hard_linked_file(tmp_path: Path) -> None:
+    directory, path = _private_file(tmp_path)
+    os.link(path, directory / "alias.jsonl")  # nlink becomes 2
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(path)
+    assert captured.value.kind is SecureFileErrorKind.NOT_REGULAR
+    assert path.exists()  # unlinking one name would not remove the data
+
+
+def test_refuses_a_non_private_parent(tmp_path: Path) -> None:
+    directory, path = _private_file(tmp_path)
+    os.chmod(directory, 0o755)
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(path)
+    assert captured.value.kind is SecureFileErrorKind.PARENT_UNSAFE
+    assert path.exists()
+
+
+def test_refuses_a_symlinked_ancestor(tmp_path: Path) -> None:
+    real = tmp_path / "real"
+    real.mkdir(mode=0o700)
+    os.chmod(real, 0o700)
+    path = real / "segment.jsonl"
+    path.write_bytes(b"bytes\n")
+    os.chmod(path, 0o600)
+    alias = tmp_path / "alias"
+    alias.symlink_to(real, target_is_directory=True)
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(alias / "segment.jsonl")
+    assert captured.value.kind is SecureFileErrorKind.NOT_REGULAR  # ELOOP on the no-follow chain
+    assert path.exists()
+
+
+def test_security_unsupported_without_no_follow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _directory, path = _private_file(tmp_path)
+    monkeypatch.setattr(config_filesystem.os, "O_NOFOLLOW", 0)
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(path)
+    assert captured.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+    assert path.exists()
+
+
+def test_security_unsupported_without_geteuid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _directory, path = _private_file(tmp_path)
+    monkeypatch.delattr(config_filesystem.os, "geteuid")
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(path)
+    assert captured.value.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED
+
+
+def test_an_unlink_failure_normalizes_to_write_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _directory, path = _private_file(tmp_path)
+    real_unlink = config_filesystem.os.unlink
+
+    def failing_unlink(name: object, *args: object, **kwargs: object) -> None:
+        raise OSError("private-unlink-detail")
+
+    monkeypatch.setattr(config_filesystem.os, "unlink", failing_unlink)
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(path)
+    assert captured.value.kind is SecureFileErrorKind.WRITE_FAILED
+    assert "private" not in str(captured.value)
+    monkeypatch.undo()
+    assert real_unlink is config_filesystem.os.unlink
+
+
+def test_a_value_error_normalizes_to_invalid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _directory, path = _private_file(tmp_path)
+
+    def raising_stat(*args: object, **kwargs: object) -> os.stat_result:
+        raise ValueError("private-value-detail")
+
+    monkeypatch.setattr(config_filesystem.os, "stat", raising_stat)
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(path)
+    assert captured.value.kind is SecureFileErrorKind.INVALID
+    assert "private" not in str(captured.value)
+
+
+def test_an_unexpected_error_normalizes_to_write_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _directory, path = _private_file(tmp_path)
+
+    def raising_stat(*args: object, **kwargs: object) -> os.stat_result:
+        raise RuntimeError("private-runtime-detail")
+
+    monkeypatch.setattr(config_filesystem.os, "stat", raising_stat)
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(path)
+    assert captured.value.kind is SecureFileErrorKind.WRITE_FAILED
+    assert "private" not in str(captured.value)
+
+
+def test_a_close_failure_after_a_successful_unlink_is_unreadable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _directory, path = _private_file(tmp_path)
+    real_chain = config_filesystem._open_directory_chain
+    real_close = config_filesystem.os.close
+    parent_descriptor: int | None = None
+
+    def capture_parent(selected_path: Path, *, nofollow: int) -> tuple[int, str]:
+        nonlocal parent_descriptor
+        parent_descriptor, leaf = real_chain(selected_path, nofollow=nofollow)
+        return parent_descriptor, leaf
+
+    def failing_close(descriptor: int) -> None:
+        real_close(descriptor)
+        if descriptor == parent_descriptor:
+            raise OSError("private-close-detail")
+
+    monkeypatch.setattr(config_filesystem, "_open_directory_chain", capture_parent)
+    monkeypatch.setattr(config_filesystem.os, "close", failing_close)
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(path)
+    assert captured.value.kind is SecureFileErrorKind.UNREADABLE
+    assert not path.exists()  # the unlink itself still succeeded
+    assert "private" not in str(captured.value)
+
+
+def test_a_close_failure_does_not_mask_a_prior_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    directory, _path = _private_file(tmp_path)
+    real_chain = config_filesystem._open_directory_chain
+    real_close = config_filesystem.os.close
+    parent_descriptor: int | None = None
+
+    def capture_parent(selected_path: Path, *, nofollow: int) -> tuple[int, str]:
+        nonlocal parent_descriptor
+        parent_descriptor, leaf = real_chain(selected_path, nofollow=nofollow)
+        return parent_descriptor, leaf
+
+    def failing_close(descriptor: int) -> None:
+        real_close(descriptor)
+        if descriptor == parent_descriptor:
+            raise OSError("private-close-detail")
+
+    monkeypatch.setattr(config_filesystem, "_open_directory_chain", capture_parent)
+    monkeypatch.setattr(config_filesystem.os, "close", failing_close)
+    # The leaf is missing, so the primary failure is NOT_FOUND; a later close failure must not
+    # overwrite it with UNREADABLE.
+    with pytest.raises(SecureFileError) as captured:
+        remove_regular_file_no_follow(directory / "absent.jsonl")
+    assert captured.value.kind is SecureFileErrorKind.NOT_FOUND

--- a/tests/unit/test_spool_reconcile.py
+++ b/tests/unit/test_spool_reconcile.py
@@ -646,11 +646,15 @@ def test_the_package_export_surface_cannot_bypass_mandatory_reconciliation() -> 
     # The slice-5a audit surface (verify_spool) is strictly READ-ONLY: it opens durable files and
     # reads ledger rows to report integrity, mutating nothing and holding no barrier.
     # SegmentVerification/VerifyReport are inert value types.
-    # The slice-5b retention_preview is likewise strictly READ-ONLY: it reads each committed
-    # segment's frames and ledger row to classify record-class expiry and report reclaimable
-    # counts/bytes, mutating nothing and holding no barrier. The mutating retention_apply is NOT
-    # part of this surface yet (it is a follow-up that takes exclusive maintenance authority + a
-    # confirm token). RetentionPreview/SegmentRetention are inert value types.
+    # The slice-5b retention_preview is strictly READ-ONLY: it reads each committed segment's frames
+    # and ledger row to classify record-class expiry and report reclaimable counts/bytes, mutating
+    # nothing and holding no barrier. retention_apply DOES delete fully-expired segment rows, but it
+    # is a declared MAINTENANCE operation on the EXCLUSIVE side (the same authority backup,
+    # migration, and reconciliation take): it validates the barrier is the control-plane commit lock
+    # and acquires barrier.exclusive() itself before any deletion, gated on a confirm token, and
+    # records an audit row per prune. It therefore does not bypass the barrier discipline — it IS
+    # that discipline applied to retention.
+    # RetentionPreview/RetentionResult/SegmentRetention/PrunedSegment are inert value types.
     assert set(spooling.__all__) == {
         "DurableSpool",
         "Exporter",
@@ -658,10 +662,12 @@ def test_the_package_export_surface_cannot_bypass_mandatory_reconciliation() -> 
         "ExporterDelivery",
         "OrphanRegistration",
         "ParsedSegment",
+        "PrunedSegment",
         "QuarantinedFile",
         "ReconciliationReport",
         "ReplayReport",
         "RetentionPreview",
+        "RetentionResult",
         "SegmentAnomaly",
         "SegmentHeaderV1",
         "SegmentRecord",
@@ -678,6 +684,7 @@ def test_the_package_export_surface_cannot_bypass_mandatory_reconciliation() -> 
         "read_trusted_segment",
         "read_untrusted_segment",
         "replay_segments",
+        "retention_apply",
         "retention_preview",
         "spool_content_sha256",
         "spool_frame_line",

--- a/tests/unit/test_spool_retention_apply.py
+++ b/tests/unit/test_spool_retention_apply.py
@@ -307,6 +307,62 @@ def test_rejects_an_unbound_or_invalid_barrier(tmp_path: Path) -> None:
         database.close()
 
 
+def test_rejects_a_spool_root_not_bound_to_the_state_root(tmp_path: Path) -> None:
+    database, barrier, _spool_root, _store = _spool(tmp_path)
+    try:
+        with pytest.raises(SpoolError) as captured:
+            retention_apply(
+                database,
+                barrier,
+                spool_root=tmp_path / "wrong-spool",  # not <state_root>/spool
+                installation_id=_INSTALLATION_ID,
+                now=_APPLY_NOW,
+                confirm=True,
+            )
+        assert captured.value.code == "MH_SPOOL_RETENTION"
+    finally:
+        database.close()
+
+
+class _HostilePath:
+    """A path-like whose __fspath__ raises — an unresolvable spool root."""
+
+    def __fspath__(self) -> str:
+        raise ValueError("hostile fspath")
+
+
+def test_rejects_a_malformed_spool_root_path(tmp_path: Path) -> None:
+    database, barrier, _spool_root, _store = _spool(tmp_path)
+    try:
+        with pytest.raises(SpoolError) as captured:
+            retention_apply(
+                database,
+                barrier,
+                spool_root=_HostilePath(),  # a PathLike that cannot be resolved
+                installation_id=_INSTALLATION_ID,
+                now=_APPLY_NOW,
+                confirm=True,
+            )
+        assert captured.value.code == "MH_SPOOL_RETENTION"
+    finally:
+        database.close()
+
+
+def test_rejects_a_closed_database(tmp_path: Path) -> None:
+    database, barrier, spool_root, _store = _spool(tmp_path)
+    database.close()
+    with pytest.raises(SpoolError) as captured:
+        retention_apply(
+            database,
+            barrier,
+            spool_root=spool_root,
+            installation_id=_INSTALLATION_ID,
+            now=_APPLY_NOW,
+            confirm=True,
+        )
+    assert captured.value.code == "MH_SPOOL_RETENTION"
+
+
 def test_rejects_invalid_common_arguments(tmp_path: Path) -> None:
     database, barrier, spool_root, _store = _spool(tmp_path)
     try:

--- a/tests/unit/test_spool_retention_apply.py
+++ b/tests/unit/test_spool_retention_apply.py
@@ -1,0 +1,393 @@
+"""Behavioural + crash guarantees for destructive retention apply (W03 slice 5b part 2).
+
+retention_apply prunes fully-expired committed segments under exclusive maintenance authority with a
+confirm token. It re-verifies each segment under the lock, prunes row-first (ledger row + audit in
+one transaction, then the durable file), leaves mixed/live/unreadable/disagreeing segments alone,
+and converges after an interrupted prune (a leftover orphan file is re-registered by reconciliation
+and re-pruned on a later pass).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from milhouse.config.filesystem import SecureFileError, SecureFileErrorKind
+from milhouse.domain.records import (
+    CollectorDescriptorV1,
+    EventDataV1,
+    RecordDraftV1,
+    RecordEnvelopeV1,
+    SourceDescriptorV1,
+    TargetDescriptorV1,
+    finalize_record,
+)
+from milhouse.spooling import (
+    DurableSpool,
+    SegmentHeaderV1,
+    SpoolFrameV1,
+    deliver_segment,
+    retention_apply,
+    spool_content_sha256,
+    spool_frame_line,
+)
+from milhouse.spooling import retention as retention_module
+from milhouse.spooling.errors import SpoolError
+from milhouse.state import (
+    GlobalCommitBarrier,
+    initialize_control_state,
+    list_audit,
+    open_control_database,
+)
+
+_INSTALLATION_ID = "mh_in1_00000000000040008000000000000000"
+_NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=UTC)
+_DAY = "2026-07-28"
+_GENERATION = "a" * 64
+_EXPIRED_AT = _NOW + timedelta(hours=1)
+_LIVE_AT = _NOW + timedelta(days=30)
+_APPLY_NOW = _NOW + timedelta(days=1)
+
+
+class _FakeExporter:
+    def __init__(self, exporter_id: str) -> None:
+        self._exporter_id = exporter_id
+
+    @property
+    def exporter_id(self) -> str:
+        return self._exporter_id
+
+    def deliver(self, record, frames) -> None:
+        return None
+
+
+def _envelope(source_event_id: str, expires_at: datetime) -> RecordEnvelopeV1:
+    values: dict[str, object] = {
+        "record_type": "event",
+        "name": "source.event",
+        "occurred_at": _NOW,
+        "observed_at": _NOW + timedelta(seconds=1),
+        "ingested_at": _NOW + timedelta(seconds=2),
+        "expires_at": expires_at,
+        "source_event_id": source_event_id,
+        "operation_id": "operation-1",
+        "collector_run_id": "collector-run-1",
+        "scope": "target",
+        "source": SourceDescriptorV1.model_validate(
+            {
+                "id": "example-source",
+                "type": "source.event",
+                "producer": "collector",
+                "observation_namespace_id": "mh_ns1_00000000000040008000000000000000",
+                "source_generation_digest": "0" * 64,
+                "observation": {"kind": "source.revision", "parts": {"revision": 1}},
+            }
+        ),
+        "collector": CollectorDescriptorV1(
+            id="c", type="site.canary", implementation_version="1.0.0"
+        ),
+        "target": TargetDescriptorV1(
+            id="example-target", name="E", kind="web.service", environment="test"
+        ),
+        "severity": "info",
+        "trust_level": "authenticated",
+        "privacy_class": "internal",
+        "redaction_version": "r1-e1",
+        "data": EventDataV1(category="availability", status="healthy", message="ok"),
+    }
+    return finalize_record(RecordDraftV1.model_validate(values), installation_id=_INSTALLATION_ID)
+
+
+def _frames(batch_id: str, specs: list[tuple[str, datetime]]) -> list[SpoolFrameV1]:
+    return [
+        SpoolFrameV1(batch_id=batch_id, sequence=index, record=_envelope(event_id, expires_at))
+        for index, (event_id, expires_at) in enumerate(specs, start=1)
+    ]
+
+
+def _header(batch_id: str, frames: list[SpoolFrameV1]) -> SegmentHeaderV1:
+    lines = [spool_frame_line(frame) for frame in frames]
+    return SegmentHeaderV1(
+        batch_id=batch_id,
+        config_generation=_GENERATION,
+        scope="target",
+        target_id="example-target",
+        privacy_class="internal",
+        retention_days=30,
+        required_exporters=("clickhouse",),
+        record_count=len(frames),
+        content_sha256=spool_content_sha256(lines),
+    )
+
+
+def _spool(tmp_path: Path):
+    control = tmp_path / "control"
+    control.mkdir(mode=0o700)
+    os.chmod(control, 0o700)
+    database = open_control_database(control / "milhouse.sqlite3")
+    barrier = GlobalCommitBarrier(control / "commit.lock")
+    initialize_control_state(database, barrier=barrier, applied_at=_NOW)
+    spool_root = tmp_path / "spool"
+    spool_root.mkdir(mode=0o700)
+    os.chmod(spool_root, 0o700)
+    store = DurableSpool(
+        database=database, barrier=barrier, spool_root=spool_root, installation_id=_INSTALLATION_ID
+    )
+    return database, barrier, spool_root, store
+
+
+def _commit(store, batch_id: str, specs: list[tuple[str, datetime]]):
+    frames = _frames(batch_id, specs)
+    return store.commit_segment(_header(batch_id, frames), frames, committed_at=_NOW), frames
+
+
+def _segment_file(spool_root: Path, batch_id: str) -> Path:
+    return spool_root / "pending" / _DAY / f"{batch_id}.jsonl"
+
+
+def _segment_rows(database) -> set[str]:
+    return {
+        row[0] for row in database.connection.execute("SELECT batch_id FROM _segments").fetchall()
+    }
+
+
+def _apply(database, barrier, spool_root, *, now=_APPLY_NOW, confirm=True):
+    return retention_apply(
+        database,
+        barrier,
+        spool_root=spool_root,
+        installation_id=_INSTALLATION_ID,
+        now=now,
+        confirm=confirm,
+    )
+
+
+def test_confirm_is_required(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
+        with pytest.raises(SpoolError) as captured:
+            _apply(database, barrier, spool_root, confirm=False)
+        assert captured.value.code == "MH_SPOOL_RETENTION"
+        assert _segment_rows(database) == {"batch-a"}  # nothing pruned
+        assert _segment_file(spool_root, "batch-a").exists()
+    finally:
+        database.close()
+
+
+def test_prunes_a_fully_expired_delivered_segment(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        record, frames = _commit(store, "batch-a", [("a1", _EXPIRED_AT), ("a2", _EXPIRED_AT)])
+        deliver_segment(
+            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}
+        )
+        result = _apply(database, barrier, spool_root)
+        assert [p.batch_id for p in result.pruned] == ["batch-a"]
+        assert result.pruned_records == 2
+        assert result.pruned_bytes == record.byte_size
+        assert result.pruned[0].file_removed is True
+        assert result.pruned[0].delivered is True
+        assert _segment_rows(database) == set()  # ledger row gone
+        assert not _segment_file(spool_root, "batch-a").exists()  # file gone
+        exporter_rows = database.connection.execute(
+            "SELECT count(*) FROM _segment_exporters WHERE batch_id = 'batch-a'"
+        ).fetchone()[0]
+        assert exporter_rows == 0
+        audit = list_audit(database)
+        assert len(audit) == 1
+        assert (audit[0].action, audit[0].outcome, audit[0].resource) == (
+            "retention_prune",
+            "pruned",
+            "batch-a",
+        )
+        assert (audit[0].record_count, audit[0].byte_size) == (2, record.byte_size)
+    finally:
+        database.close()
+
+
+def test_prunes_an_undelivered_expired_segment_as_a_critical_event(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", [("a1", _EXPIRED_AT)])  # never delivered
+        result = _apply(database, barrier, spool_root)
+        assert [p.batch_id for p in result.pruned] == ["batch-a"]
+        assert result.pruned[0].delivered is False
+        assert [p.batch_id for p in result.undelivered_pruned] == ["batch-a"]
+        audit = list_audit(database)
+        assert audit[0].outcome == "pruned_undelivered"  # the critical case
+        assert audit[0].reason == "expired_undelivered"
+    finally:
+        database.close()
+
+
+def test_leaves_live_and_mixed_segments(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-expired", [("e1", _EXPIRED_AT)])
+        _commit(store, "batch-mixed", [("m1", _EXPIRED_AT), ("m2", _LIVE_AT)])
+        _commit(store, "batch-live", [("l1", _LIVE_AT)])
+        result = _apply(database, barrier, spool_root)
+        assert [p.batch_id for p in result.pruned] == ["batch-expired"]
+        skipped = {s.batch_id: s.status for s in result.skipped}
+        assert skipped == {"batch-mixed": "mixed", "batch-live": "live"}
+        # The non-expired segments and their files survive.
+        assert _segment_rows(database) == {"batch-mixed", "batch-live"}
+        assert _segment_file(spool_root, "batch-mixed").exists()
+        assert _segment_file(spool_root, "batch-live").exists()
+    finally:
+        database.close()
+
+
+def test_skips_an_unreadable_segment(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
+        _segment_file(spool_root, "batch-a").unlink()  # the file is gone before apply
+        result = _apply(database, barrier, spool_root)
+        assert result.pruned == ()
+        assert [s.status for s in result.skipped] == ["unreadable"]
+        assert result.skipped[0].code == "MH_SPOOL_NOT_FOUND"
+        assert _segment_rows(database) == {"batch-a"}  # the ledger row is NOT pruned blind
+    finally:
+        database.close()
+
+
+def test_skips_a_ledger_disagreeing_segment(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
+        # Corrupt the ledger's recorded count so the durable file no longer agrees with its row.
+        with database.transaction() as connection:
+            connection.execute("UPDATE _segments SET record_count = 99 WHERE batch_id = 'batch-a'")
+        result = _apply(database, barrier, spool_root)
+        assert result.pruned == ()
+        assert [s.status for s in result.skipped] == ["disagreeing"]
+        assert _segment_file(spool_root, "batch-a").exists()  # never pruned on disagreement
+    finally:
+        database.close()
+
+
+def test_rerun_is_idempotent(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
+        first = _apply(database, barrier, spool_root)
+        assert len(first.pruned) == 1
+        second = _apply(database, barrier, spool_root)
+        assert second.pruned == ()  # nothing left to prune
+        assert second.skipped == ()
+    finally:
+        database.close()
+
+
+def test_rejects_an_unbound_or_invalid_barrier(tmp_path: Path) -> None:
+    database, _barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
+        foreign = GlobalCommitBarrier(tmp_path / "unrelated.lock")
+        with pytest.raises(SpoolError) as unbound:
+            _apply(database, foreign, spool_root)
+        assert unbound.value.code == "MH_SPOOL_RETENTION"
+        with pytest.raises(SpoolError) as bad_type:
+            retention_apply(
+                database,
+                object(),  # type: ignore[arg-type]
+                spool_root=spool_root,
+                installation_id=_INSTALLATION_ID,
+                now=_APPLY_NOW,
+                confirm=True,
+            )
+        assert bad_type.value.code == "MH_SPOOL_RETENTION"
+        assert _segment_rows(database) == {"batch-a"}  # nothing pruned under a bad barrier
+    finally:
+        database.close()
+
+
+def test_rejects_invalid_common_arguments(tmp_path: Path) -> None:
+    database, barrier, spool_root, _store = _spool(tmp_path)
+    try:
+        with pytest.raises(SpoolError) as bad_id:
+            retention_apply(
+                database,
+                barrier,
+                spool_root=spool_root,
+                installation_id="nope",
+                now=_APPLY_NOW,
+                confirm=True,
+            )
+        assert bad_id.value.code == "MH_SPOOL_IDENTITY"
+        with pytest.raises(SpoolError) as bad_now:
+            retention_apply(
+                database,
+                barrier,
+                spool_root=spool_root,
+                installation_id=_INSTALLATION_ID,
+                now=datetime(2026, 7, 28, 12),  # naive
+                confirm=True,
+            )
+        assert bad_now.value.code == "MH_SPOOL_RETENTION"
+    finally:
+        database.close()
+
+
+def test_a_failed_transactional_prune_leaves_the_segment_intact(tmp_path: Path) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
+        # Drop the audit table so the in-transaction record_audit fails AFTER the two DELETEs.
+        # Because the prune is one transaction, the DELETEs roll back and the segment stays intact
+        # (row AND file) — never a half-prune.
+        with database.transaction() as connection:
+            connection.execute("DROP TABLE _audit")
+        result = _apply(database, barrier, spool_root)
+        assert result.pruned == ()
+        assert [s.status for s in result.skipped] == ["fully_expired"]
+        assert result.skipped[0].code == "MH_SPOOL_RETENTION"
+        assert _segment_rows(database) == {"batch-a"}  # the ledger row was rolled back
+        assert _segment_file(spool_root, "batch-a").exists()
+    finally:
+        database.close()
+
+
+def test_an_interrupted_unlink_leaves_a_re_registerable_orphan_that_reconverges(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database, barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
+
+        # Simulate a crash/failure AFTER the ledger row + audit commit but BEFORE the unlink.
+        def failing_remove(*args: object, **kwargs: object) -> None:
+            raise SecureFileError(SecureFileErrorKind.WRITE_FAILED)
+
+        monkeypatch.setattr(retention_module, "remove_regular_file_no_follow", failing_remove)
+        first = _apply(database, barrier, spool_root)
+        assert len(first.pruned) == 1
+        assert first.pruned[0].file_removed is False  # the durable file lingers as an orphan
+        assert [p.batch_id for p in first.orphaned_files] == ["batch-a"]
+        # Row-first: the ledger row is gone but the file remains — NOT a row-without-file.
+        assert _segment_rows(database) == set()
+        assert _segment_file(spool_root, "batch-a").exists()
+
+        # Reconciliation (run on a fresh writer acquisition) re-registers the orphan file.
+        DurableSpool(
+            database=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            installation_id=_INSTALLATION_ID,
+        )
+        assert _segment_rows(database) == {"batch-a"}  # re-registered as a committed segment
+
+        # A later retention pass (unlink working again) re-prunes it to convergence.
+        monkeypatch.undo()
+        second = _apply(database, barrier, spool_root)
+        assert len(second.pruned) == 1
+        assert second.pruned[0].file_removed is True
+        assert _segment_rows(database) == set()
+        assert not _segment_file(spool_root, "batch-a").exists()
+    finally:
+        database.close()

--- a/tests/unit/test_spool_retention_preview.py
+++ b/tests/unit/test_spool_retention_preview.py
@@ -32,6 +32,7 @@ from milhouse.spooling import (
 )
 from milhouse.spooling.errors import SpoolError
 from milhouse.spooling.retention import (
+    STATUS_DISAGREEING,
     STATUS_FULLY_EXPIRED,
     STATUS_LIVE,
     STATUS_MIXED,
@@ -235,6 +236,25 @@ def test_an_unreadable_segment_is_reported_not_prunable(tmp_path: Path) -> None:
         assert segment.code == "MH_SPOOL_NOT_FOUND"
         assert preview.fully_expired == ()  # never treated as reclaimable
         assert [s.batch_id for s in preview.unreadable] == ["batch-a"]
+    finally:
+        database.close()
+
+
+def test_a_ledger_disagreeing_segment_is_not_reclaimable(tmp_path: Path) -> None:
+    database, _barrier, spool_root, store = _spool(tmp_path)
+    try:
+        _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
+        # The durable file is still readable and expired, but the ledger row no longer agrees with
+        # it. Preview must report it disagreeing (matching what apply skips), not fully_expired,
+        # so the reclaimable estimate never overstates.
+        with database.transaction() as connection:
+            connection.execute("UPDATE _segments SET record_count = 99 WHERE batch_id = 'batch-a'")
+        preview = retention_preview(
+            database, spool_root=spool_root, installation_id=_INSTALLATION_ID, now=_PREVIEW_NOW
+        )
+        assert preview.segments[0].status == STATUS_DISAGREEING
+        assert preview.fully_expired == ()
+        assert preview.reclaimable_records == 0
     finally:
         database.close()
 


### PR DESCRIPTION
## W03 slice 5b part 2 — `retention_apply` (destructive prune)

Completes slice 5b: the data-deleting half of retention, on its own PR so the destructive logic gets focused review.

### What landed
- **Secure removal primitive** (`config/filesystem.py`): `remove_regular_file_no_follow(path, *, expected_identity=None)` unlinks one owner-only, single-link regular file relative to its no-follow-opened private parent, then fsyncs the parent. It refuses a symlink/directory/hard-linked/identity-mismatched leaf and a non-private or symlinked-ancestor parent; every fault is a fixed `SecureFileError`.
- **`retention_apply`** (`spooling/retention.py`): prunes fully-expired committed segments under `barrier.exclusive()` (after validating the barrier is the control-plane commit lock and the spool root is bound to the state root), gated on an explicit `confirm` token. Each segment is re-read and re-verified under the lock (reconcile's `_agrees` + recomputed record-class expiry); only a segment that **agrees AND is fully expired** is pruned. Mixed-expiry → left for compaction; unreadable/disagreeing → left for verify/reconciliation.
- **Row-first crash safety**: one transaction deletes the exporter rows + segment row + records the audit row (`pruned`, or `pruned_undelivered` for the critical unexported case), and only then is the durable file unlinked. A crash/unlink failure after commit leaves a **re-registerable orphan file** (reconciliation adopts it, a later pass re-prunes — convergent), never a row-without-file. A failed transaction rolls back atomically.

### Discipline
- `retention.py`, `filesystem.py` at **100% branch** (filesystem stays above the 95% floor). 34 new tests incl. the interrupted-unlink → reconcile → re-prune **convergence proof**, atomic-rollback, confirm-required, barrier/spool-root binding, and the 16 secure-unlink refusal/normalization cases.
- Independent **pre-merge exact-head review** of the destructive core: **no P0/P1** — verified row-first ordering, atomic rollback, only-fully-expired, barrier binding/exclusivity, secure unlink, and crash convergence. Its **P2** (spool-root not bound to the state root → silent no-op) and a **P3** (preview/apply divergence on disagreeing segments) are fixed.
- Full suite green; `test-coverage`, `quality` (incl. mypy) pass; DCO signed.

### Remaining
Slice 5c (audited compaction — mixed-expiry rewrite), then slice 7 (crash/concurrency/failure-injection harness + G03 evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)