### PR TITLE
fix(w03): re-remediate the D05 re-review findings (4 P1 + 1 P2)

### DIFF
--- a/src/milhouse/config/filesystem.py
+++ b/src/milhouse/config/filesystem.py
@@ -884,7 +884,12 @@ def remove_regular_file_no_follow(
                     os.close(descriptor)
                 except OSError:
                     if failure is None:
-                        failure = SecureFileError(SecureFileErrorKind.UNREADABLE)
+                        # Reaching the close with no prior failure means the whole body — including
+                        # the unlink — succeeded, so the entry is already gone. A descriptor-close
+                        # failure then leaves durability unconfirmed, never a lingering orphan:
+                        # report commit-uncertain so retention re-inspects rather than asserting the
+                        # file is still present.
+                        failure = SecureFileError(SecureFileErrorKind.COMMIT_UNCERTAIN)
 
     if failure is not None:
         raise failure

--- a/src/milhouse/spooling/exporter.py
+++ b/src/milhouse/spooling/exporter.py
@@ -6,22 +6,34 @@ concrete ClickHouse exporter is W04. The :class:`Exporter` contract is deliberat
 and a ``deliver`` that returns on destination confirmation and raises on any failure.
 
 Delivery is integrity-bound so a terminal ``delivered`` can never be recorded for the wrong data
-(D05): :func:`deliver_segment` binds the barrier to the live control database, reloads the segment's
-authoritative ledger row and rejects a supplied record that does not match it, and requires the
-supplied frames to hash to that row's ``content_sha256`` (with matching batch id and count) before a
-single byte is forwarded — so a caller cannot forward one segment's frames while certifying another.
-It also requires each exporter object to self-identify as the row it delivers, and treats
-the final compare-and-set as authoritative: only a CAS that actually advances the expected row to
-``delivered`` is reported as a new delivery.
+(D05): :func:`deliver_segment` freezes the caller's frames into one immutable tuple, binds the
+barrier to the live control database, reloads the segment's authoritative ledger row and rejects a
+supplied record that does not match it, and requires that exact frozen tuple to hash to the row's
+``content_sha256`` (with matching batch id and count) before a single byte is forwarded — so a
+caller cannot validate one frame set and forward another, nor forward one segment's frames while
+certifying another. It also requires each exporter object to self-identify as the row it delivers.
+
+Delivery is *fenced* and *expiry-aware* (D05 re-review):
+
+* **Fenced.** The whole reload → forward → checkpoint runs under a single ``barrier.shared()`` hold,
+  so privacy-expiry ``retention_apply`` (which prunes under the *exclusive* side) cannot delete a
+  segment mid-delivery. The shared side is held across the destination round-trip; maintenance waits
+  for in-flight deliveries to drain, exactly as a readers-writer lock requires.
+* **Expiry-aware.** A segment with any expired record is withheld — never forwarded — because
+  record-class privacy expiry is a hard upper bound (plan §§4.8-4.9): expired data must never
+  egress, even if retention has not pruned it yet. A mixed-expiry segment waits for audited
+  compaction (slice 5c) rather than leaking its expired records.
 
 The delivery ledger (``_segment_exporters.delivery_status``) is a per-(segment, exporter) state
 machine: ``pending``/``failed`` are retryable, ``delivered`` is terminal. Rule 12 requires the
-exporter checkpoint to advance only after the destination confirms, so delivery is *outside*
-the barrier and, only once ``deliver`` returns, recorded in one shared-barrier compare-and-set that
-never overwrites a ``delivered`` row. A crash between confirmation and the write leaves the row
-retryable, so delivery is at-least-once and exporters MUST be idempotent. Every SQLite or barrier
-failure normalizes to a fixed ``MH_SPOOL_EXPORT`` error, and a misbehaving exporter that raises is
-contained as a failed delivery.
+exporter checkpoint to advance only after the destination confirms, so delivery is recorded, once
+``deliver`` returns, in one compare-and-set that never overwrites a ``delivered`` row. That CAS is
+authoritative: only a CAS that actually advances the expected row is reported as a new delivery, a
+row that is already ``delivered`` is reported ``already_delivered``, and a row that has *vanished*
+(pruned out from under the delivery) is reported ``segment_gone`` — never conflated with a delivery.
+A crash between confirmation and the write leaves the row retryable, so delivery is at-least-once
+and exporters MUST be idempotent. Every SQLite or barrier failure normalizes to a fixed
+``MH_SPOOL_EXPORT`` error, and a misbehaving exporter that raises is contained as a failed delivery.
 """
 
 from __future__ import annotations
@@ -29,8 +41,10 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from typing import NoReturn, Protocol, runtime_checkable
 
+from milhouse.core.clock import TimeError, format_timestamp
 from milhouse.spooling.errors import SpoolError
 from milhouse.spooling.ledger import SegmentRecord, read_segment_record
 from milhouse.spooling.segment import (
@@ -47,12 +61,19 @@ _DELIVERED = "delivered"
 _FAILED = "failed"
 _BARRIER_NAME = "commit.lock"
 
+# Compare-and-set outcomes of the delivery-status write, under the already-held shared barrier.
+_CAS_ADVANCED = "advanced"
+_CAS_ALREADY = "already"
+_CAS_GONE = "gone"
+
 # Attempt outcomes reported back to the caller. The first two mutate the ledger; the rest explain
 # why no delivery was newly recorded for that exporter on this pass.
 OUTCOME_DELIVERED = "delivered"
 OUTCOME_FAILED = "failed"
 OUTCOME_ALREADY_DELIVERED = "already_delivered"
 OUTCOME_NO_EXPORTER = "no_exporter"
+OUTCOME_EXPIRED = "expired"
+OUTCOME_SEGMENT_GONE = "segment_gone"
 
 
 def _fail(code: str, message: str) -> NoReturn:
@@ -79,13 +100,23 @@ class ExporterAttempt:
     outcome: str
 
 
+def _require_now(now: object) -> None:
+    invalid = False
+    try:
+        format_timestamp(now)  # type: ignore[arg-type]  # rejects a naive/out-of-range instant
+    except (OverflowError, TimeError, AttributeError, TypeError):
+        invalid = True
+    if invalid:
+        _fail("MH_SPOOL_EXPORT", "the delivery instant must be an aware in-range UTC instant")
+
+
 def _require_bound_barrier(database: ControlDatabase, barrier: GlobalCommitBarrier) -> None:
     database_path = _validated_database_path(database)
     if database_path is None or not _is_bound_barrier(
         barrier, database_path.parent / _BARRIER_NAME
     ):
-        # Bind the barrier to THIS database's commit lock: the CAS is serialized only if the
-        # shared hold is on the same lock the writers use.
+        # Bind the barrier to THIS database's commit lock: the shared hold only fences maintenance
+        # and serializes the CAS if it is on the same lock the writers and retention use.
         _fail("MH_SPOOL_EXPORT", "the barrier must be the control-plane commit lock")
 
 
@@ -111,6 +142,7 @@ def _require_frames_belong(record: SegmentRecord, frames: Sequence[SpoolFrameV1]
     The definitive check is that the frames' canonical bytes hash to ``content_sha256``;
     the count and batch-id checks give a precise failure for the common wrong-segment case.
     Without this a caller could forward one segment's records while certifying delivery of another.
+    ``frames`` is the already-frozen tuple, so this validates the exact object that is forwarded.
     """
 
     if len(frames) != record.record_count:
@@ -121,36 +153,57 @@ def _require_frames_belong(record: SegmentRecord, frames: Sequence[SpoolFrameV1]
         _fail("MH_SPOOL_EXPORT", "the frames do not match the segment content digest")
 
 
-def _advance_status(
-    database: ControlDatabase,
-    barrier: GlobalCommitBarrier,
-    batch_id: str,
-    exporter_id: str,
-    status: str,
-) -> int:
-    """Compare-and-set the delivery status under the shared barrier; return the affected row count.
+def _segment_is_expired(frames: Sequence[SpoolFrameV1], now: datetime) -> bool:
+    """Return whether ANY record in ``frames`` has reached its ``expires_at`` at ``now``.
 
-    The ``delivery_status != 'delivered'`` guard makes ``delivered`` terminal: a late failure
-    cannot overwrite a confirmed delivery, and re-recording ``delivered`` is a no-op.
-    A zero affected-row count means the expected row was already terminal (or gone), so the caller
-    does not report a new delivery.
+    Record-class privacy expiry is a hard upper bound: a fully-live segment (every record still
+    unexpired) may egress; a mixed or fully-expired one must be withheld until audited compaction
+    (slice 5c) can strip the expired records, so no expired record is ever forwarded. An empty frame
+    set carries no record to reason about and is not expired.
     """
 
-    affected = 0
+    if not frames:
+        return False
+    return min(frame.record.expires_at for frame in frames) <= now
+
+
+def _advance_status_locked(
+    database: ControlDatabase, batch_id: str, exporter_id: str, status: str
+) -> str:
+    """Compare-and-set the delivery status; the caller already holds the shared barrier.
+
+    Returns ``_CAS_ADVANCED`` when this call moved the row to ``status`` (affected exactly one row),
+    ``_CAS_ALREADY`` when the row is already terminal ``delivered`` (the CAS matched nothing), or
+    ``_CAS_GONE`` when the row no longer exists. Distinguishing a vanished row from an
+    already-delivered one is what keeps a segment pruned out from under an in-flight delivery from
+    ever being reported as delivered. The barrier is NOT re-acquired here — nesting ``shared()``
+    under a queued exclusive maintainer could deadlock at the turnstile gate — so the single shared
+    hold taken by :func:`deliver_segment` serializes this CAS against maintenance.
+    """
+
     failed = False
+    result = _CAS_GONE
     try:
-        with barrier.shared(), database.transaction() as connection:
+        with database.transaction() as connection:
             cursor = connection.execute(
                 "UPDATE _segment_exporters SET delivery_status = ? "
                 "WHERE batch_id = ? AND exporter_id = ? AND delivery_status != ?",
                 (status, batch_id, exporter_id, _DELIVERED),
             )
-            affected = cursor.rowcount
+            if cursor.rowcount == 1:
+                result = _CAS_ADVANCED
+            else:
+                row = connection.execute(
+                    "SELECT delivery_status FROM _segment_exporters "
+                    "WHERE batch_id = ? AND exporter_id = ?",
+                    (batch_id, exporter_id),
+                ).fetchone()
+                result = _CAS_GONE if row is None else _CAS_ALREADY
     except (sqlite3.Error, StateError):
         failed = True
     if failed:
         _fail("MH_SPOOL_EXPORT", "the exporter delivery status could not be recorded")
-    return affected
+    return result
 
 
 def _self_identifies(exporter: Exporter, exporter_id: str) -> bool:
@@ -175,21 +228,35 @@ def _attempt_delivery(
     return True
 
 
+def _delivered_outcome(cas_result: str) -> str:
+    if cas_result == _CAS_ADVANCED:
+        return OUTCOME_DELIVERED
+    if cas_result == _CAS_ALREADY:
+        return OUTCOME_ALREADY_DELIVERED
+    # The row vanished (pruned) between reload and CAS: never certify a delivery for it.
+    return OUTCOME_SEGMENT_GONE
+
+
 def deliver_segment(
     database: ControlDatabase,
     barrier: GlobalCommitBarrier,
     record: SegmentRecord,
     frames: Sequence[SpoolFrameV1],
     exporters: Mapping[str, Exporter],
+    *,
+    now: datetime,
 ) -> tuple[ExporterAttempt, ...]:
     """Attempt every not-yet-delivered exporter for ``record`` and record each outcome.
 
-    The barrier is bound to the database, the ledger row is reloaded and the supplied record and
-    frames are validated against it before anything is forwarded, and each exporter object must
-    self-identify. Delivery is attempted outside the barrier; only a confirmed delivery that the
-    compare-and-set actually advances to ``delivered`` (affected-row count of one) is reported as a
-    new delivery. Exporters already ``delivered`` are skipped and an unknown or mis-identified
-    exporter is reported ``no_exporter`` without touching the ledger.
+    The caller's ``frames`` are frozen to one immutable tuple up front, and that exact tuple is both
+    validated against the reloaded ledger row and forwarded. The whole reload → forward → checkpoint
+    runs under one ``barrier.shared()`` hold, so privacy-expiry retention cannot prune a segment
+    mid-delivery. A segment with any expired record is withheld (``expired``) and never forwarded.
+    Delivery is attempted while the shared side is held; only a confirmed delivery whose CAS
+    advances the expected row is reported ``delivered``, an already-terminal row is
+    ``already_delivered``, and a row pruned out from under the delivery is ``segment_gone``.
+    Exporters already ``delivered`` are skipped; an unknown or mis-identified exporter is
+    reported ``no_exporter`` without touching the ledger.
     """
 
     if type(database) is not ControlDatabase:
@@ -200,32 +267,57 @@ def deliver_segment(
         _fail("MH_SPOOL_EXPORT", "a segment record is required")
     if not isinstance(exporters, Mapping):
         _fail("MH_SPOOL_EXPORT", "an exporter mapping is required")
+    _require_now(now)
+    # Freeze the caller-owned sequence to one immutable snapshot BEFORE validating or forwarding, so
+    # a sequence that yields different contents on a second read cannot deliver one batch while the
+    # digest check certified another (D05 re-review).
+    frames = tuple(frames)
+    if any(not isinstance(frame, SpoolFrameV1) for frame in frames):
+        _fail("MH_SPOOL_EXPORT", "a segment frame is malformed")
     _require_bound_barrier(database, barrier)
-    live = _reload_record(database, record)
-    _require_frames_belong(live, frames)
 
     attempts: list[ExporterAttempt] = []
-    for exporter_row in live.exporters:
-        exporter_id = exporter_row.exporter_id
-        if exporter_row.delivery_status == _DELIVERED:
-            attempts.append(ExporterAttempt(live.batch_id, exporter_id, OUTCOME_ALREADY_DELIVERED))
-            continue
-        exporter = exporters.get(exporter_id)
-        if (
-            exporter is None
-            or EXPORTER_ID_PATTERN.fullmatch(exporter_id) is None
-            or not _self_identifies(exporter, exporter_id)
-        ):
-            # Unknown, malformed, or a mis-identified exporter object (one registered under a key it
-            # does not claim as its own id) must never certify delivery.
-            attempts.append(ExporterAttempt(live.batch_id, exporter_id, OUTCOME_NO_EXPORTER))
-            continue
-        delivered = _attempt_delivery(exporter, live, frames)
-        status = _DELIVERED if delivered else _FAILED
-        affected = _advance_status(database, barrier, live.batch_id, exporter_id, status)
-        if delivered:
-            outcome = OUTCOME_DELIVERED if affected == 1 else OUTCOME_ALREADY_DELIVERED
-        else:
-            outcome = OUTCOME_FAILED
-        attempts.append(ExporterAttempt(live.batch_id, exporter_id, outcome))
+    with barrier.shared():
+        live = _reload_record(database, record)
+        _require_frames_belong(live, frames)
+        if _segment_is_expired(frames, now):
+            # Hard privacy expiry: withhold the whole segment. Forward nothing; report each exporter
+            # so the caller sees the segment was withheld (not delivered, not failed).
+            return tuple(
+                ExporterAttempt(
+                    live.batch_id,
+                    row.exporter_id,
+                    OUTCOME_ALREADY_DELIVERED
+                    if row.delivery_status == _DELIVERED
+                    else OUTCOME_EXPIRED,
+                )
+                for row in live.exporters
+            )
+        for exporter_row in live.exporters:
+            exporter_id = exporter_row.exporter_id
+            if exporter_row.delivery_status == _DELIVERED:
+                attempts.append(
+                    ExporterAttempt(live.batch_id, exporter_id, OUTCOME_ALREADY_DELIVERED)
+                )
+                continue
+            exporter = exporters.get(exporter_id)
+            if (
+                exporter is None
+                or EXPORTER_ID_PATTERN.fullmatch(exporter_id) is None
+                or not _self_identifies(exporter, exporter_id)
+            ):
+                # Unknown, malformed, or a mis-identified exporter object (one registered under a
+                # key it does not claim as its own id) must never certify delivery.
+                attempts.append(ExporterAttempt(live.batch_id, exporter_id, OUTCOME_NO_EXPORTER))
+                continue
+            delivered = _attempt_delivery(exporter, live, frames)
+            if delivered:
+                cas_result = _advance_status_locked(
+                    database, live.batch_id, exporter_id, _DELIVERED
+                )
+                outcome = _delivered_outcome(cas_result)
+            else:
+                _advance_status_locked(database, live.batch_id, exporter_id, _FAILED)
+                outcome = OUTCOME_FAILED
+            attempts.append(ExporterAttempt(live.batch_id, exporter_id, outcome))
     return tuple(attempts)

--- a/src/milhouse/spooling/replay.py
+++ b/src/milhouse/spooling/replay.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import NoReturn
 
@@ -84,6 +85,7 @@ def replay_segments(
     spool_root: str | Path,
     installation_id: str,
     exporters: Mapping[str, Exporter],
+    now: datetime,
     delivery_status: str | None = None,
 ) -> ReplayReport:
     """Replay committed segments deterministically, driving idempotent exporter delivery.
@@ -91,7 +93,8 @@ def replay_segments(
     ``delivery_status`` optionally narrows the pass to segments with an exporter in that state (e.g.
     ``"pending"`` to drive only undelivered work); with ``None`` every committed segment is
     replayed, which is the shape the recovery/rebuild path and the G03 double-replay evidence use.
-    The returned record-id stream is identical across runs over an unchanged ledger.
+    The returned record-id stream is identical across runs over an unchanged ledger. ``now`` drives
+    delivery's hard-expiry gate, so replay never re-egresses a segment whose records have expired.
     """
 
     if type(database) is not ControlDatabase:
@@ -125,7 +128,9 @@ def replay_segments(
         _verify_against_ledger(parsed, record)
         segments.append(record.batch_id)
         record_ids.extend(frame.record.record_id for frame in parsed.frames)
-        attempts.extend(deliver_segment(database, barrier, record, parsed.frames, exporters))
+        attempts.extend(
+            deliver_segment(database, barrier, record, parsed.frames, exporters, now=now)
+        )
     return ReplayReport(
         segments=tuple(segments),
         record_ids=tuple(record_ids),

--- a/src/milhouse/state/audit.py
+++ b/src/milhouse/state/audit.py
@@ -2,24 +2,26 @@
 
 Every deliberate maintenance mutation — retention pruning, compaction, purge, restore — records one
 append-only row in ``_audit`` describing what happened in privacy-safe terms: a fixed action code, a
-fixed actor class, a fixed outcome and reason code, an opaque resource identifier, and safe counts.
+fixed actor class, a fixed outcome and reason code, an opaque resource FINGERPRINT, and safe counts.
 An audit row never carries the acted-on raw payload, a secret, a path, a URL, or free text (plan
 section 4.6 ``audit``, ADR 0007).
 
 The public surface is a set of **purpose-specific constructors** (e.g.
 :func:`record_retention_prune`) rather than a free-text sink: each constructor fixes its own
-action/actor/outcome/reason codes as
-constants, so a caller cannot inject arbitrary text into those fields, and validates the only
-caller-supplied value — an opaque resource identifier — against a strict id charset that admits a
-batch/target id but rejects a path, email, URL, prompt, multiline, secret, or raw payload. Recording
-is transaction-scoped: the caller writes the row on the SAME open connection, in the SAME
-transaction as the mutation it attests, so the trail and the state commit or roll back together.
-Every fault
-normalizes to a fixed ``MH_STATE_AUDIT`` code raised outside the handler.
+action/actor/outcome/reason codes as constants, so a caller cannot inject arbitrary text into those
+fields. The one caller-supplied value — the resource id — is charset-validated AND then stored only
+as a SHA-256 fingerprint, so the resource column is structurally incapable of holding a raw string:
+the charset guard alone is not a secrecy proof (a *legal* opaque id can still be secret-shaped, e.g.
+an access key), so fingerprinting is what guarantees no path, email, URL, prompt, secret, or raw
+payload is ever persisted. Recording is transaction-scoped: the caller writes the row on the SAME
+open connection, in the SAME transaction as the mutation it attests, so the trail and the state
+commit or roll back together. Every fault normalizes to a fixed ``MH_STATE_AUDIT`` code raised
+outside the handler.
 """
 
 from __future__ import annotations
 
+import hashlib
 import re
 import sqlite3
 from collections.abc import Sequence
@@ -66,6 +68,19 @@ def _validate_resource(value: object) -> str:
     return value
 
 
+def _resource_fingerprint(value: str) -> str:
+    """Return a stable SHA-256 hex fingerprint of ``value`` for storage in the audit resource.
+
+    The charset guard rejects a path/URL/email/multiline, but a *legal* opaque id can still be a
+    secret-shaped string (an access key like ``AKIAIOSFODNN7EXAMPLE`` is a valid batch-id shape), so
+    the audit trail never stores the caller's raw string — only this fixed-width fingerprint. The
+    stored value is thus structurally incapable of carrying a raw secret, path, or payload, while an
+    operator who holds the real id can still correlate by re-fingerprinting it.
+    """
+
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
 def _validate_count(value: object, subject: str) -> int:
     # ``bool`` is an ``int`` subtype; reject it so a stray flag cannot pose as a count. The upper
     # bound keeps a too-large count from overflowing the signed-64 INTEGER binding at INSERT.
@@ -89,9 +104,9 @@ def _insert_audit(
     """Insert one audit row. Internal: only the typed constructors call it, with fixed codes.
 
     ``action``/``actor``/``outcome``/``reason`` are code constants owned by the calling constructor,
-    never caller free text; ``resource`` and the counts are the constructor's already-validated
-    caller data. Only the timestamp is validated here before the insert; any residual backend fault
-    normalizes to the fixed code.
+    never caller free text; ``resource`` is the already-fingerprinted id and the counts are its
+    already-validated caller data. Only the timestamp is validated here before the insert; any
+    residual backend fault normalizes to the fixed code.
     """
 
     invalid_time = False
@@ -129,10 +144,12 @@ def record_retention_prune(
 ) -> None:
     """Record that retention pruned one committed segment, on the caller's open transaction.
 
-    The action/actor/outcome/reason codes are fixed here, so no free text reaches the audit row; the
-    only caller-supplied value is ``batch_id``, validated as an opaque identifier. ``undelivered``
-    distinguishes the critical case where the segment reached its privacy deadline before it was
-    exported. Call inside the same transaction as the prune so the two commit or roll back together.
+    The action/actor/outcome/reason codes are fixed here, so no free text reaches the audit row. The
+    only caller-supplied value is ``batch_id``: it is charset-validated as an opaque identifier and
+    then stored ONLY as a SHA-256 fingerprint, so the audit trail never persists the caller's raw
+    string even if a legal id is secret-shaped. ``undelivered`` distinguishes the critical case
+    where the segment reached its privacy deadline before it was exported. Call inside the same
+    transaction as the prune so the two commit or roll back together.
     """
 
     if type(undelivered) is not bool:
@@ -147,7 +164,7 @@ def record_retention_prune(
         actor="maintenance",
         outcome="pruned_undelivered" if undelivered else "pruned",
         reason="expired_undelivered" if undelivered else "expired",
-        resource=batch_id,
+        resource=_resource_fingerprint(batch_id),
         record_count=record_count,
         byte_size=byte_size,
     )

--- a/tests/unit/test_config_filesystem_remove.py
+++ b/tests/unit/test_config_filesystem_remove.py
@@ -234,9 +234,12 @@ def test_a_post_unlink_fsync_failure_is_commit_uncertain(
     assert real_fsync is config_filesystem.os.fsync
 
 
-def test_a_close_failure_after_a_successful_unlink_is_unreadable(
+def test_a_close_failure_after_a_successful_unlink_is_commit_uncertain(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # D05 re-review P2: reaching the close with no prior failure means the whole body (including the
+    # unlink) succeeded, so the file is GONE. A descriptor-close failure then leaves only durability
+    # unconfirmed — commit-uncertain — never a lingering orphan, so retention must not re-adopt it.
     _directory, path = _private_file(tmp_path)
     real_chain = config_filesystem._open_directory_chain
     real_close = config_filesystem.os.close
@@ -256,8 +259,8 @@ def test_a_close_failure_after_a_successful_unlink_is_unreadable(
     monkeypatch.setattr(config_filesystem.os, "close", failing_close)
     with pytest.raises(SecureFileError) as captured:
         remove_regular_file_no_follow(path)
-    assert captured.value.kind is SecureFileErrorKind.UNREADABLE
-    assert not path.exists()  # the unlink itself still succeeded
+    assert captured.value.kind is SecureFileErrorKind.COMMIT_UNCERTAIN
+    assert not path.exists()  # the unlink itself still succeeded — the entry is gone, not orphaned
     assert "private" not in str(captured.value)
 
 

--- a/tests/unit/test_spool_exporter.py
+++ b/tests/unit/test_spool_exporter.py
@@ -1,15 +1,17 @@
 """Integrity + state-machine guarantees for the exporter delivery protocol (W03 slice 4; D05 fix).
 
-A terminal ``delivered`` can never be recorded for the wrong data: delivery binds the barrier to the
-live database, reloads the authoritative ledger row, rejects a supplied record that does not match
-it, and requires the supplied frames to hash to that row's content digest (matching batch id and
-count) before anything is forwarded. Each exporter object must self-identify; only a compare-and-
-set that actually advances the expected row is reported as a new delivery.
+A terminal ``delivered`` can never be recorded for the wrong data: delivery freezes the caller's
+frames to one immutable tuple, binds the barrier to the live database, reloads the authoritative
+ledger row, rejects a supplied record that does not match it, and requires that frozen tuple to hash
+to the row's content digest (matching batch id and count) before anything is forwarded. Delivery is
+fenced under one shared-barrier hold so privacy-expiry retention cannot prune mid-delivery, is
+withheld for any expired record, and reports a pruned row as ``segment_gone`` — never as a delivery.
 """
 
 from __future__ import annotations
 
 import os
+from collections.abc import Sequence
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -42,6 +44,7 @@ from milhouse.state import (
     initialize_control_state,
     open_control_database,
 )
+from milhouse.state.errors import StateError
 
 _INSTALLATION_ID = "mh_in1_00000000000040008000000000000000"
 _NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=UTC)
@@ -53,6 +56,7 @@ class _FakeExporter:
         self._exporter_id = exporter_id
         self._fail = fail
         self.deliveries: list[str] = []
+        self.received_frames: tuple[SpoolFrameV1, ...] | None = None
 
     @property
     def exporter_id(self) -> str:
@@ -60,18 +64,19 @@ class _FakeExporter:
 
     def deliver(self, record: SegmentRecord, frames) -> None:
         self.deliveries.append(record.batch_id)
+        self.received_frames = tuple(frames)
         if self._fail:
             raise RuntimeError("destination unavailable")
 
 
-def _envelope(source_event_id: str) -> RecordEnvelopeV1:
+def _envelope(source_event_id: str, *, expires_at: datetime | None = None) -> RecordEnvelopeV1:
     values: dict[str, object] = {
         "record_type": "event",
         "name": "source.event",
         "occurred_at": _NOW,
         "observed_at": _NOW + timedelta(seconds=1),
         "ingested_at": _NOW + timedelta(seconds=2),
-        "expires_at": _NOW + timedelta(days=30),
+        "expires_at": expires_at if expires_at is not None else _NOW + timedelta(days=30),
         "source_event_id": source_event_id,
         "operation_id": "operation-1",
         "collector_run_id": "collector-run-1",
@@ -101,9 +106,13 @@ def _envelope(source_event_id: str) -> RecordEnvelopeV1:
     return finalize_record(RecordDraftV1.model_validate(values), installation_id=_INSTALLATION_ID)
 
 
-def _frames(batch_id: str, event_ids: tuple[str, ...]) -> list[SpoolFrameV1]:
+def _frames(
+    batch_id: str, event_ids: tuple[str, ...], *, expires_at: datetime | None = None
+) -> list[SpoolFrameV1]:
     return [
-        SpoolFrameV1(batch_id=batch_id, sequence=index, record=_envelope(event_id))
+        SpoolFrameV1(
+            batch_id=batch_id, sequence=index, record=_envelope(event_id, expires_at=expires_at)
+        )
         for index, event_id in enumerate(event_ids, start=1)
     ]
 
@@ -141,8 +150,10 @@ def _spool(tmp_path: Path):
     return database, barrier, store
 
 
-def _commit(store, batch_id: str, event_ids: tuple[str, ...], exporters=("clickhouse",)):
-    frames = _frames(batch_id, event_ids)
+def _commit(
+    store, batch_id: str, event_ids: tuple[str, ...], exporters=("clickhouse",), *, expires_at=None
+):
+    frames = _frames(batch_id, event_ids, expires_at=expires_at)
     record = store.commit_segment(_header(batch_id, frames, exporters), frames, committed_at=_NOW)
     return record, frames
 
@@ -164,7 +175,9 @@ def test_delivers_matching_frames_and_records_delivered(tmp_path: Path) -> None:
     try:
         record, frames = _commit(store, "batch-a", ("a1", "a2"))
         exporter = _FakeExporter("clickhouse")
-        attempts = deliver_segment(database, barrier, record, frames, {"clickhouse": exporter})
+        attempts = deliver_segment(
+            database, barrier, record, frames, {"clickhouse": exporter}, now=_NOW
+        )
         assert [(a.exporter_id, a.outcome) for a in attempts] == [("clickhouse", "delivered")]
         assert exporter.deliveries == ["batch-a"]
         assert _status(database, "batch-a", "clickhouse") == "delivered"
@@ -182,6 +195,7 @@ def test_a_failing_exporter_records_failed(tmp_path: Path) -> None:
             record,
             frames,
             {"clickhouse": _FakeExporter("clickhouse", fail=True)},
+            now=_NOW,
         )
         assert [a.outcome for a in attempts] == ["failed"]
         assert _status(database, "batch-a", "clickhouse") == "failed"
@@ -194,8 +208,10 @@ def test_an_already_delivered_exporter_is_skipped_idempotently(tmp_path: Path) -
     try:
         record, frames = _commit(store, "batch-a", ("a1",))
         exporter = _FakeExporter("clickhouse")
-        deliver_segment(database, barrier, record, frames, {"clickhouse": exporter})
-        attempts = deliver_segment(database, barrier, record, frames, {"clickhouse": exporter})
+        deliver_segment(database, barrier, record, frames, {"clickhouse": exporter}, now=_NOW)
+        attempts = deliver_segment(
+            database, barrier, record, frames, {"clickhouse": exporter}, now=_NOW
+        )
         assert [a.outcome for a in attempts] == ["already_delivered"]
         assert exporter.deliveries == ["batch-a"]  # not delivered a second time
     finally:
@@ -211,10 +227,75 @@ def test_frames_from_another_segment_are_refused_and_nothing_is_certified(tmp_pa
         _record_b, frames_b = _commit(store, "batch-b", ("b1",))
         exporter = _FakeExporter("clickhouse")
         with pytest.raises(SpoolError) as captured:
-            deliver_segment(database, barrier, record_a, frames_b, {"clickhouse": exporter})
+            deliver_segment(
+                database, barrier, record_a, frames_b, {"clickhouse": exporter}, now=_NOW
+            )
         assert captured.value.code == "MH_SPOOL_EXPORT"
         assert exporter.deliveries == []  # nothing forwarded
         assert _status(database, "batch-a", "clickhouse") == "pending"  # never certified
+    finally:
+        database.close()
+
+
+def test_a_mutating_frame_sequence_is_frozen_before_validation_and_forwarding(
+    tmp_path: Path,
+) -> None:
+    # D05 re-review: the caller's Sequence must be materialized ONCE, so a sequence that yields
+    # different contents on a later read cannot forward one batch while the digest certified
+    # another.
+    database, barrier, store = _spool(tmp_path)
+    try:
+        record_a, good = _commit(store, "batch-a", ("a1", "a2"))
+        _record_b, bad = _commit(store, "batch-b", ("b1", "b2"))
+
+        class _MutatingFrames(Sequence):
+            def __init__(self) -> None:
+                self._good = tuple(good)
+                self._bad = tuple(bad)
+                self.reads = 0
+
+            def _pick(self):
+                # First two reads (validation) yield the true frames; a later read (the old
+                # forwarding path) would yield another batch — the freeze must prevent that read.
+                return self._good if self.reads < 2 else self._bad
+
+            def __getitem__(self, index):
+                return self._pick()[index]
+
+            def __len__(self) -> int:
+                return len(self._good)
+
+            def __iter__(self):
+                snapshot = self._pick()
+                self.reads += 1
+                return iter(snapshot)
+
+        mutating = _MutatingFrames()
+        exporter = _FakeExporter("clickhouse")
+        attempts = deliver_segment(
+            database, barrier, record_a, mutating, {"clickhouse": exporter}, now=_NOW
+        )
+        assert [a.outcome for a in attempts] == ["delivered"]
+        assert mutating.reads == 1  # materialized exactly once, then never re-read
+        assert exporter.received_frames == tuple(good)  # forwarded the validated snapshot
+    finally:
+        database.close()
+
+
+def test_a_malformed_frame_object_is_refused(tmp_path: Path) -> None:
+    database, barrier, store = _spool(tmp_path)
+    try:
+        record, _frames = _commit(store, "batch-a", ("a1",))
+        with pytest.raises(SpoolError) as captured:
+            deliver_segment(
+                database,
+                barrier,
+                record,
+                [object()],
+                {"clickhouse": _FakeExporter("clickhouse")},
+                now=_NOW,
+            )
+        assert captured.value.code == "MH_SPOOL_EXPORT"
     finally:
         database.close()
 
@@ -227,7 +308,12 @@ def test_same_batch_frames_with_a_different_content_digest_are_refused(tmp_path:
         forged = _frames("batch-a", ("different-event",))
         with pytest.raises(SpoolError) as captured:
             deliver_segment(
-                database, barrier, record_a, forged, {"clickhouse": _FakeExporter("clickhouse")}
+                database,
+                barrier,
+                record_a,
+                forged,
+                {"clickhouse": _FakeExporter("clickhouse")},
+                now=_NOW,
             )
         assert captured.value.code == "MH_SPOOL_EXPORT"
         assert _status(database, "batch-a", "clickhouse") == "pending"
@@ -241,7 +327,12 @@ def test_a_frame_count_mismatch_is_refused(tmp_path: Path) -> None:
         record_a, _frames_a = _commit(store, "batch-a", ("a1", "a2"))
         with pytest.raises(SpoolError) as captured:
             deliver_segment(
-                database, barrier, record_a, [], {"clickhouse": _FakeExporter("clickhouse")}
+                database,
+                barrier,
+                record_a,
+                [],
+                {"clickhouse": _FakeExporter("clickhouse")},
+                now=_NOW,
             )
         assert captured.value.code == "MH_SPOOL_EXPORT"
     finally:
@@ -259,6 +350,7 @@ def test_a_fabricated_or_uncommitted_record_is_refused(tmp_path: Path) -> None:
                 replace(record, content_sha256="d" * 64),
                 frames,
                 {"clickhouse": _FakeExporter("clickhouse")},
+                now=_NOW,
             )
         assert tampered.value.code == "MH_SPOOL_EXPORT"
         with pytest.raises(SpoolError) as ghost:  # a batch id that was never committed
@@ -268,6 +360,7 @@ def test_a_fabricated_or_uncommitted_record_is_refused(tmp_path: Path) -> None:
                 replace(record, batch_id="ghost-1"),
                 frames,
                 {"clickhouse": _FakeExporter("clickhouse")},
+                now=_NOW,
             )
         assert ghost.value.code == "MH_SPOOL_EXPORT"
     finally:
@@ -281,7 +374,9 @@ def test_a_mis_identified_exporter_object_never_certifies(tmp_path: Path) -> Non
         impostor = _FakeExporter(
             "somewhere-else"
         )  # registered under 'clickhouse', claims another id
-        attempts = deliver_segment(database, barrier, record, frames, {"clickhouse": impostor})
+        attempts = deliver_segment(
+            database, barrier, record, frames, {"clickhouse": impostor}, now=_NOW
+        )
         assert [a.outcome for a in attempts] == ["no_exporter"]
         assert impostor.deliveries == []
         assert _status(database, "batch-a", "clickhouse") == "pending"
@@ -293,7 +388,7 @@ def test_an_unsupplied_exporter_is_reported_without_touching_the_ledger(tmp_path
     database, barrier, store = _spool(tmp_path)
     try:
         record, frames = _commit(store, "batch-a", ("a1",))
-        attempts = deliver_segment(database, barrier, record, frames, {})
+        attempts = deliver_segment(database, barrier, record, frames, {}, now=_NOW)
         assert [a.outcome for a in attempts] == ["no_exporter"]
         assert _status(database, "batch-a", "clickhouse") == "pending"
     finally:
@@ -307,7 +402,12 @@ def test_a_wrong_barrier_is_refused(tmp_path: Path) -> None:
         foreign = GlobalCommitBarrier(tmp_path / "unrelated.lock")
         with pytest.raises(SpoolError) as captured:
             deliver_segment(
-                database, foreign, record, frames, {"clickhouse": _FakeExporter("clickhouse")}
+                database,
+                foreign,
+                record,
+                frames,
+                {"clickhouse": _FakeExporter("clickhouse")},
+                now=_NOW,
             )
         assert captured.value.code == "MH_SPOOL_EXPORT"
         assert _status(database, "batch-a", "clickhouse") == "pending"
@@ -315,7 +415,102 @@ def test_a_wrong_barrier_is_refused(tmp_path: Path) -> None:
         database.close()
 
 
-def test_a_zero_row_compare_and_set_is_not_reported_as_a_new_delivery(
+def test_delivery_fences_out_maintenance_exclusive(tmp_path: Path) -> None:
+    # D05 re-review: delivery holds the SHARED barrier across the whole forward, so maintenance
+    # (retention_apply, which prunes under EXCLUSIVE) cannot run while a delivery is in flight.
+    database, barrier, store = _spool(tmp_path)
+    try:
+        record, frames = _commit(store, "batch-a", ("a1",))
+        probe: dict[str, object] = {}
+
+        class _FenceProbe:
+            @property
+            def exporter_id(self) -> str:
+                return "clickhouse"
+
+            def deliver(self, record: SegmentRecord, frames: object) -> None:
+                # While this delivery is in flight the shared side is held; a non-blocking
+                # exclusive acquisition must fail busy, proving retention is fenced out.
+                try:
+                    with barrier.exclusive(blocking=False):
+                        probe["blocked"] = False
+                except StateError as error:
+                    probe["blocked"] = True
+                    probe["code"] = error.code
+
+        attempts = deliver_segment(
+            database, barrier, record, frames, {"clickhouse": _FenceProbe()}, now=_NOW
+        )
+        assert [a.outcome for a in attempts] == ["delivered"]
+        assert probe["blocked"] is True
+        assert probe["code"] == "MH_STATE_BARRIER_BUSY"
+    finally:
+        database.close()
+
+
+def test_an_expired_segment_is_withheld_from_delivery(tmp_path: Path) -> None:
+    # D05 re-review hard-expiry: a segment whose records have reached expires_at must never egress.
+    database, barrier, store = _spool(tmp_path)
+    try:
+        record, frames = _commit(store, "batch-a", ("a1",))
+        exporter = _FakeExporter("clickhouse")
+        after_expiry = _NOW + timedelta(days=31)  # past the records' +30d expiry
+        attempts = deliver_segment(
+            database, barrier, record, frames, {"clickhouse": exporter}, now=after_expiry
+        )
+        assert [a.outcome for a in attempts] == ["expired"]
+        assert exporter.deliveries == []  # nothing forwarded
+        assert _status(database, "batch-a", "clickhouse") == "pending"  # never certified
+    finally:
+        database.close()
+
+
+def test_an_expired_segment_still_reports_its_already_delivered_exporters(tmp_path: Path) -> None:
+    database, barrier, store = _spool(tmp_path)
+    try:
+        record, frames = _commit(store, "batch-a", ("a1",))
+        deliver_segment(
+            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}, now=_NOW
+        )
+        after_expiry = _NOW + timedelta(days=31)
+        again = _FakeExporter("clickhouse")
+        attempts = deliver_segment(
+            database, barrier, record, frames, {"clickhouse": again}, now=after_expiry
+        )
+        assert [a.outcome for a in attempts] == ["already_delivered"]
+        assert again.deliveries == []  # an expired segment forwards nothing
+    finally:
+        database.close()
+
+
+def test_a_segment_pruned_mid_delivery_is_reported_gone_not_delivered(tmp_path: Path) -> None:
+    # D05 re-review: a missing row must never be conflated with an already-delivered one.
+    database, barrier, store = _spool(tmp_path)
+    try:
+        record, frames = _commit(store, "batch-a", ("a1",))
+
+        class _SelfPruning:
+            @property
+            def exporter_id(self) -> str:
+                return "clickhouse"
+
+            def deliver(self, record: SegmentRecord, frames: object) -> None:
+                # Simulate the row being pruned out from under the in-flight delivery.
+                with database.transaction() as connection:
+                    connection.execute(
+                        "DELETE FROM _segment_exporters WHERE batch_id = ?", (record.batch_id,)
+                    )
+
+        attempts = deliver_segment(
+            database, barrier, record, frames, {"clickhouse": _SelfPruning()}, now=_NOW
+        )
+        assert [a.outcome for a in attempts] == ["segment_gone"]
+        assert _status(database, "batch-a", "clickhouse") is None  # row gone, never certified
+    finally:
+        database.close()
+
+
+def test_a_zero_row_compare_and_set_is_reported_already_delivered(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     database, barrier, store = _spool(tmp_path)
@@ -323,17 +518,17 @@ def test_a_zero_row_compare_and_set_is_not_reported_as_a_new_delivery(
         record, frames = _commit(store, "batch-a", ("a1",))
         # Deliver for real so the ledger row is terminal-delivered.
         deliver_segment(
-            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}
+            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}, now=_NOW
         )
         # Force the reload to report the exporter as still pending (a stale snapshot); the attempt
-        # succeeds but the compare-and-set affects zero rows because the row is already delivered,
-        # this pass must NOT claim a new delivery.
+        # succeeds but the compare-and-set affects zero rows because the row is already delivered.
+        # The still-present delivered row must be reported already_delivered, never a new delivery.
         stale = replace(
             record, exporters=(replace(record.exporters[0], delivery_status="pending"),)
         )
         monkeypatch.setattr(exporter_module, "_reload_record", lambda database, record: stale)
         attempts = deliver_segment(
-            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}
+            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}, now=_NOW
         )
         assert [a.outcome for a in attempts] == ["already_delivered"]
         assert _status(database, "batch-a", "clickhouse") == "delivered"
@@ -354,7 +549,12 @@ def test_a_broken_delivery_ledger_write_normalizes_to_a_stable_code(
             connection.execute("DROP TABLE _segment_exporters")
         with pytest.raises(SpoolError) as captured:
             deliver_segment(
-                database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}
+                database,
+                barrier,
+                record,
+                frames,
+                {"clickhouse": _FakeExporter("clickhouse")},
+                now=_NOW,
             )
         assert captured.value.code == "MH_SPOOL_EXPORT"
         assert captured.value.__cause__ is None
@@ -368,19 +568,39 @@ def test_invalid_arguments_are_rejected(tmp_path: Path) -> None:
     try:
         record, frames = _commit(store, "batch-a", ("a1",))
         with pytest.raises(SpoolError) as bad_db:
-            deliver_segment(object(), barrier, record, frames, {})  # type: ignore[arg-type]
+            deliver_segment(object(), barrier, record, frames, {}, now=_NOW)  # type: ignore[arg-type]
         assert bad_db.value.code == "MH_SPOOL_EXPORT"
         with pytest.raises(SpoolError) as bad_barrier:
-            deliver_segment(database, object(), record, frames, {})  # type: ignore[arg-type]
+            deliver_segment(database, object(), record, frames, {}, now=_NOW)  # type: ignore[arg-type]
         assert bad_barrier.value.code == "MH_SPOOL_EXPORT"
         with pytest.raises(SpoolError) as bad_record:
-            deliver_segment(database, barrier, object(), frames, {})  # type: ignore[arg-type]
+            deliver_segment(database, barrier, object(), frames, {}, now=_NOW)  # type: ignore[arg-type]
         assert bad_record.value.code == "MH_SPOOL_EXPORT"
         with pytest.raises(SpoolError) as bad_exporters:
-            deliver_segment(database, barrier, record, frames, None)  # type: ignore[arg-type]
+            deliver_segment(database, barrier, record, frames, None, now=_NOW)  # type: ignore[arg-type]
         assert bad_exporters.value.code == "MH_SPOOL_EXPORT"
+        with pytest.raises(SpoolError) as bad_now:
+            deliver_segment(
+                database,
+                barrier,
+                record,
+                frames,
+                {},
+                now=datetime(2026, 7, 28, 12, 0, 0),  # naive: no tzinfo
+            )
+        assert bad_now.value.code == "MH_SPOOL_EXPORT"
     finally:
         database.close()
+
+
+def test_segment_is_expired_predicate_handles_empty_and_boundaries() -> None:
+    # Directly exercise the hard-expiry predicate, including the empty-frame branch. A record's
+    # expires_at must be after its ingested_at, so "expired" is expressed by evaluating at a later
+    # `now`, never by constructing a past-dated envelope.
+    assert exporter_module._segment_is_expired([], _NOW) is False
+    frames = _frames("batch-a", ("a1",), expires_at=_NOW + timedelta(hours=1))
+    assert exporter_module._segment_is_expired(frames, _NOW) is False  # now is before expiry
+    assert exporter_module._segment_is_expired(frames, _NOW + timedelta(hours=2)) is True
 
 
 def test_an_exporter_whose_id_property_raises_is_contained(tmp_path: Path) -> None:
@@ -396,7 +616,9 @@ def test_an_exporter_whose_id_property_raises_is_contained(tmp_path: Path) -> No
             def deliver(self, record: SegmentRecord, frames: object) -> None:
                 raise AssertionError("must not be called")
 
-        attempts = deliver_segment(database, barrier, record, frames, {"clickhouse": _RaisingId()})
+        attempts = deliver_segment(
+            database, barrier, record, frames, {"clickhouse": _RaisingId()}, now=_NOW
+        )
         assert [a.outcome for a in attempts] == ["no_exporter"]  # contained, not raised
         assert _status(database, "batch-a", "clickhouse") == "pending"
     finally:

--- a/tests/unit/test_spool_replay.py
+++ b/tests/unit/test_spool_replay.py
@@ -148,6 +148,7 @@ def test_replay_visits_segments_in_deterministic_order(tmp_path: Path) -> None:
             spool_root=spool_root,
             installation_id=_INSTALLATION_ID,
             exporters={"clickhouse": _FakeExporter("clickhouse")},
+            now=_NOW,
         )
         assert report.segments == ("batch-a", "batch-b")
         assert report.record_count == 3
@@ -170,6 +171,7 @@ def test_replaying_twice_yields_identical_ids_and_counts(tmp_path: Path) -> None
             spool_root=spool_root,
             installation_id=_INSTALLATION_ID,
             exporters={"clickhouse": exporter},
+            now=_NOW,
         )
         second = replay_segments(
             database,
@@ -177,6 +179,7 @@ def test_replaying_twice_yields_identical_ids_and_counts(tmp_path: Path) -> None
             spool_root=spool_root,
             installation_id=_INSTALLATION_ID,
             exporters={"clickhouse": exporter},
+            now=_NOW,
         )
 
         assert second.record_ids == first.record_ids  # identical logical id stream
@@ -204,6 +207,7 @@ def test_replay_can_narrow_to_pending_delivery(tmp_path: Path) -> None:
             spool_root=spool_root,
             installation_id=_INSTALLATION_ID,
             exporters={"clickhouse": exporter},
+            now=_NOW,
         )
         # Now only pending-delivery segments are in scope — there are none left.
         narrowed = replay_segments(
@@ -212,6 +216,7 @@ def test_replay_can_narrow_to_pending_delivery(tmp_path: Path) -> None:
             spool_root=spool_root,
             installation_id=_INSTALLATION_ID,
             exporters={"clickhouse": exporter},
+            now=_NOW,
             delivery_status="pending",
         )
         assert narrowed.segments == ()
@@ -237,6 +242,7 @@ def test_replay_rejects_a_durable_file_that_drifted_from_the_ledger(tmp_path: Pa
                 spool_root=spool_root,
                 installation_id=_INSTALLATION_ID,
                 exporters={"clickhouse": _FakeExporter("clickhouse")},
+                now=_NOW,
             )
         assert captured.value.code == "MH_SPOOL_REPLAY"
     finally:
@@ -256,6 +262,7 @@ def test_replay_fails_closed_when_a_committed_file_is_missing(tmp_path: Path) ->
                 spool_root=spool_root,
                 installation_id=_INSTALLATION_ID,
                 exporters={"clickhouse": _FakeExporter("clickhouse")},
+                now=_NOW,
             )
         assert (
             captured.value.code == "MH_SPOOL_NOT_FOUND"
@@ -273,6 +280,7 @@ def test_replay_over_an_empty_ledger_is_an_empty_report(tmp_path: Path) -> None:
             spool_root=spool_root,
             installation_id=_INSTALLATION_ID,
             exporters={},
+            now=_NOW,
         )
         assert report.segments == ()
         assert report.record_ids == ()
@@ -291,6 +299,7 @@ def test_replay_rejects_invalid_arguments(tmp_path: Path) -> None:
                 spool_root=spool_root,
                 installation_id=_INSTALLATION_ID,
                 exporters={},
+                now=_NOW,
             )
         assert bad_db.value.code == "MH_SPOOL_REPLAY"
         with pytest.raises(SpoolError) as bad_barrier:
@@ -300,6 +309,7 @@ def test_replay_rejects_invalid_arguments(tmp_path: Path) -> None:
                 spool_root=spool_root,
                 installation_id=_INSTALLATION_ID,
                 exporters={},
+                now=_NOW,
             )
         assert bad_barrier.value.code == "MH_SPOOL_REPLAY"
         with pytest.raises(SpoolError) as bad_id:
@@ -309,6 +319,7 @@ def test_replay_rejects_invalid_arguments(tmp_path: Path) -> None:
                 spool_root=spool_root,
                 installation_id="not-an-installation",
                 exporters={},
+                now=_NOW,
             )
         assert bad_id.value.code == "MH_SPOOL_IDENTITY"
         with pytest.raises(SpoolError) as bad_root:  # a spool root not bound to the state root
@@ -318,6 +329,7 @@ def test_replay_rejects_invalid_arguments(tmp_path: Path) -> None:
                 spool_root=tmp_path / "wrong-spool",
                 installation_id=_INSTALLATION_ID,
                 exporters={},
+                now=_NOW,
             )
         assert bad_root.value.code == "MH_SPOOL_REPLAY"
         with pytest.raises(SpoolError) as bad_root_type:  # a non-path spool root
@@ -327,6 +339,7 @@ def test_replay_rejects_invalid_arguments(tmp_path: Path) -> None:
                 spool_root=None,  # type: ignore[arg-type]
                 installation_id=_INSTALLATION_ID,
                 exporters={},
+                now=_NOW,
             )
         assert bad_root_type.value.code == "MH_SPOOL_REPLAY"
     finally:
@@ -343,5 +356,6 @@ def test_replay_rejects_a_closed_database(tmp_path: Path) -> None:
             spool_root=spool_root,
             installation_id=_INSTALLATION_ID,
             exporters={},
+            now=_NOW,
         )
     assert captured.value.code == "MH_SPOOL_REPLAY"

--- a/tests/unit/test_spool_retention_apply.py
+++ b/tests/unit/test_spool_retention_apply.py
@@ -9,6 +9,7 @@ and re-pruned on a later pass).
 
 from __future__ import annotations
 
+import hashlib
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -185,7 +186,7 @@ def test_prunes_a_fully_expired_delivered_segment(tmp_path: Path) -> None:
     try:
         record, frames = _commit(store, "batch-a", [("a1", _EXPIRED_AT), ("a2", _EXPIRED_AT)])
         deliver_segment(
-            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}
+            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}, now=_NOW
         )
         result = _apply(database, barrier, spool_root)
         assert [p.batch_id for p in result.pruned] == ["batch-a"]
@@ -204,7 +205,7 @@ def test_prunes_a_fully_expired_delivered_segment(tmp_path: Path) -> None:
         assert (audit[0].action, audit[0].outcome, audit[0].resource) == (
             "retention_prune",
             "pruned",
-            "batch-a",
+            hashlib.sha256(b"batch-a").hexdigest(),  # resource stored as a fingerprint (D05)
         )
         assert (audit[0].record_count, audit[0].byte_size) == (2, record.byte_size)
     finally:
@@ -478,7 +479,7 @@ def test_prunes_a_cursor_referenced_delivered_expired_segment(tmp_path: Path) ->
     try:
         record, frames = _commit(store, "batch-a", [("a1", _EXPIRED_AT)])
         deliver_segment(
-            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}
+            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}, now=_NOW
         )
         advance_cursor(
             database, "github", position="page-7", batch_id="batch-a", now=_NOW, expected_revision=0

--- a/tests/unit/test_spool_retention_preview.py
+++ b/tests/unit/test_spool_retention_preview.py
@@ -197,6 +197,7 @@ def test_an_expired_but_undelivered_segment_is_flagged(tmp_path: Path) -> None:
             delivered_record,
             delivered_frames,
             {"clickhouse": _FakeExporter("clickhouse")},
+            now=_NOW,
         )
         _commit(store, "batch-b", [("b1", _EXPIRED_AT)])  # left undelivered
         preview = retention_preview(

--- a/tests/unit/test_spool_verify.py
+++ b/tests/unit/test_spool_verify.py
@@ -164,7 +164,7 @@ def test_the_delivery_watermark_reflects_completed_delivery(tmp_path: Path) -> N
     try:
         record, frames = _commit(store, "batch-a", ("a-1",))
         deliver_segment(
-            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}
+            database, barrier, record, frames, {"clickhouse": _FakeExporter("clickhouse")}, now=_NOW
         )
         report = verify_spool(database, spool_root=spool_root, installation_id=_INSTALLATION_ID)
         assert report.intact is True

--- a/tests/unit/test_state_audit.py
+++ b/tests/unit/test_state_audit.py
@@ -2,13 +2,16 @@
 
 The audit surface is a set of purpose-specific constructors, not a free-text sink: a caller cannot
 put arbitrary text into the action/actor/outcome/reason code fields (they are fixed constants), and
-the only caller-supplied value — the opaque resource id — is validated against an id charset that
-rejects secrets, emails, paths, URLs, prompts, multiline text, and raw payloads before any write.
-Recording is transaction-scoped, so the row commits or rolls back with the mutation it attests.
+the only caller-supplied value — the opaque resource id — is charset-validated (rejecting emails,
+paths, URLs, prompts, multiline text, and raw payloads) AND then stored only as a SHA-256
+fingerprint, so a charset-legal but secret-shaped id (e.g. an access key) is never persisted raw
+(D05 re-review). Recording is transaction-scoped, so the row commits or rolls back with the mutation
+it attests.
 """
 
 from __future__ import annotations
 
+import hashlib
 import os
 from datetime import UTC, datetime
 from pathlib import Path
@@ -38,6 +41,19 @@ _RAW_CANARIES = [
     "line one\nline two",  # multiline
     "raw payload {json: true}",  # raw structured payload
 ]
+
+# Secret-shaped strings that are ALSO legal opaque-id charset (so the charset guard cannot reject
+# them): these must be accepted but stored ONLY as a fingerprint, never raw (D05 re-review).
+_CREDENTIAL_CANARIES = [
+    "AKIAIOSFODNN7EXAMPLE",  # AWS access key id — all alphanumeric, a valid batch-id shape
+    "AKIAIOSFODNN7EXAMPLEQQ",  # a longer access-key variant
+    "ghp_0123456789abcdefABCDEF01",  # GitHub-PAT shape (underscore is charset-legal)
+    "0123456789abcdef0123456789abcdef",  # 32-hex secret-shaped identifier
+]
+
+
+def _fp(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
 def _database(tmp_path: Path):
@@ -92,7 +108,7 @@ def test_records_a_delivered_prune_with_fixed_codes(tmp_path: Path) -> None:
                 action="retention_prune",
                 actor="maintenance",
                 outcome="pruned",
-                resource="batch-1",
+                resource=_fp("batch-1"),
                 reason="expired",
                 record_count=3,
                 byte_size=128,
@@ -134,6 +150,24 @@ def test_a_raw_canary_resource_is_rejected_before_any_write(tmp_path: Path, cana
         database.close()
 
 
+@pytest.mark.parametrize("canary", _CREDENTIAL_CANARIES)
+def test_a_secret_shaped_legal_id_is_fingerprinted_never_stored_raw(
+    tmp_path: Path, canary: str
+) -> None:
+    # D05 re-review: the charset guard alone is not a secrecy proof — an access-key-shaped id is a
+    # legal opaque id. It is accepted, but ONLY its fingerprint is persisted, so the raw
+    # secret-shaped value never reaches control state.
+    database = _database(tmp_path)
+    try:
+        _prune(database, now=_NOW, batch_id=canary, record_count=1, byte_size=1, undelivered=False)
+        row = list_audit(database)[0]
+        assert row.resource == _fp(canary)  # stored as a fixed-width fingerprint
+        assert row.resource != canary  # never the raw value
+        assert canary.encode("utf-8") not in _audit_bytes(database)  # not anywhere in the row bytes
+    finally:
+        database.close()
+
+
 def test_the_action_actor_outcome_reason_codes_cannot_be_influenced(tmp_path: Path) -> None:
     # There is no free-text parameter for the code fields — the constructor fixes them — so a caller
     # can only ever produce the fixed retention codes, never arbitrary text.
@@ -164,7 +198,7 @@ def test_ids_are_monotonic_and_append_ordered(tmp_path: Path) -> None:
             )
         rows = list_audit(database)
         assert [r.id for r in rows] == [1, 2, 3]
-        assert [r.resource for r in rows] == ["batch-1", "batch-2", "batch-3"]
+        assert [r.resource for r in rows] == [_fp("batch-1"), _fp("batch-2"), _fp("batch-3")]
     finally:
         database.close()
 


### PR DESCRIPTION
The independent gate review failed the first D05 remediation (PR #65). This re-remediates every reproduced finding, each with adversarial regression evidence. The ledger was already corrected on `main` by #66.

**This PR is not to be self-merged** — a fresh independent full-SHA review is the acceptance gate (that self-certification was D05 finding 5). Landed only after an independent review passes.

## The four P1s
1. **Frame-snapshot TOCTOU** — `deliver_segment` freezes the caller's frames to one immutable tuple up front and both validates and forwards *that exact tuple*; a `Sequence` yielding different contents on a later read can no longer forward one batch while the digest certified another. Malformed frame objects are rejected. *(test: a mutating sequence is materialized exactly once and the validated snapshot is what's forwarded.)*
2. **Delivery races privacy-expiry retention** — the whole reload → forward → checkpoint runs under a single `barrier.shared()` hold (the CAS no longer re-acquires the barrier, which could deadlock at the writer-preference gate), so `retention_apply` (exclusive) cannot prune mid-delivery. Delivery is also **expiry-aware**: a segment with any expired record is withheld (`expired`), never forwarded — enforcing hard privacy-expiry even before retention runs. `deliver_segment`/`replay_segments` now take an explicit `now`. *(tests: exclusive maintenance is fenced out during an in-flight delivery; an expired segment is withheld.)*
3. **Missing row conflated with delivered** — the delivery-status CAS distinguishes a vanished row (`segment_gone`) from an already-terminal one (`already_delivered`), so a segment pruned out from under a delivery is never certified delivered. *(test: a self-pruning exporter → `segment_gone`.)*
4. **Audit charset ≠ secret rejection** — `record_retention_prune` stores the resource **only as a SHA-256 fingerprint**, so `_audit` can never hold a raw caller string even when a legal opaque id is secret-shaped (an access key is a valid batch-id shape). *(tests: all-alphanumeric credential canaries incl. `AKIAIOSFODNN7EXAMPLE` are fingerprinted, never stored raw.)*

## The P2
- **Post-unlink orphan misclassification** — a descriptor-close failure after a successful unlink now maps to `COMMIT_UNCERTAIN` (the file is gone), not `UNREADABLE`, so retention reports it uncertain rather than re-adopting a non-existent orphan.

## Evidence
Full local gates green: `test` (4602 passed / 1 skipped), `test-coverage` (line 97.95% / branch 96.92%, every touched critical file ≥95%), `quality` (ruff, mypy, docs 74/76, validators). DCO signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)