### PR TITLE
chore(repo): enforce worktree hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,28 @@ select one dependency-ready work package
 `milhouse-feedback` is a normalized evidence input to assigned application work; it is never
 permission to inspect raw telemetry or feedback sources.
 
+## Worktree hygiene
+
+Run `./scripts/run_make.py worktree-check` before beginning development. The primary checkout is
+always `clean-main`: it remains on `main`, has no uncommitted entries, and exactly matches the local
+`origin/main` tracking ref. Fetch before relying on that comparison. Codex and Claude make changes
+only in explicitly named task worktrees. The normal maximum is the primary plus one active task
+worktree per agent.
+
+- The agent that creates a task worktree owns removing it after its PR merges, closes, or is
+  superseded.
+- A task never ends with unidentified changes. Commit them, preserve them in a named stash with its
+  recovery hash, or report the exact blocker.
+- Use only these state names: `clean-main`, `active`, `recovery-stashed`, and `blocked`.
+- Every runtime handoff states the worktree path, branch, exact head, dirty count, PR, owner, and
+  state. Private machine paths and stash metadata belong in the private handoff, never in committed
+  repository files.
+- Use `python3 -I scripts/check_worktree_hygiene.py --expect LABEL=PATH` to verify an active handoff
+  registration and add `--strict` before closing a task. A dirty secondary worktree is always
+  reported and requires classification.
+- Audit obsolete local branches separately. Delete one only after proving it merged or was
+  superseded and contains no required unique work.
+
 ## Safety and authority boundaries
 
 - Never persist, summarize, attach, or commit raw prompts, responses, transcripts, session histories,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,12 @@ canonical script rather than reconstructing its safety checks as a manual sync c
 See [Contributor setup](docs/setup.md), [Development workflow](docs/development.md), and
 [Dependency policy](docs/dependencies.md) before changing the toolchain or lock.
 
+Before starting a task, run `./scripts/run_make.py worktree-check`. Keep the primary checkout clean,
+on `main`, and synchronized with `origin/main`; make changes only in a named task worktree. The
+worktree creator owns its cleanup after merge, closure, or supersession. Handoffs privately identify
+the path, branch, exact head, dirty count, PR, owner, and one precise state: `clean-main`, `active`,
+`recovery-stashed`, or `blocked`. Do not commit private machine paths or stash metadata.
+
 Do not use live provider credentials or production data in tests. Use synthetic fixtures and deterministic clocks.
 
 ## Contribution rules

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifneq ($(strip $(findstring i,$(_MILHOUSE_SHORT_MAKEFLAGS))$(findstring n,$(_MIL
 $(error Milhouse gates refuse make dry-run, ignore-error, question, or touch modes)
 endif
 
-_MILHOUSE_TARGETS := setup lock lock-check format format-check lint type-check test test-coverage \
+_MILHOUSE_TARGETS := setup worktree-check lock lock-check format format-check lint type-check test test-coverage \
 	identity-portability \
 	repo-check docs-check workflow-check skill-check quality build package-check \
 	artifact-smoke audit license-check private-identifier-check secret-scan \
@@ -35,6 +35,9 @@ $(_MILHOUSE_TARGETS): override UV_RUN := $(UV) run --locked --all-groups --all-e
 
 setup:
 	./setup.sh
+
+worktree-check:
+	$(PYTHON) -I scripts/check_worktree_hygiene.py
 
 lock:
 	$(UV) lock
@@ -121,6 +124,7 @@ test-coverage:
 		--critical 'scripts/check_dco.py' \
 		--critical 'scripts/check_links.py' \
 		--critical 'scripts/check_private_identifiers.py' \
+		--critical 'scripts/check_worktree_hygiene.py' \
 		--critical 'scripts/gitleaks.py' \
 		--critical 'scripts/prepare_environment.py' \
 		--critical 'scripts/required_ci.py' \

--- a/docs/agents-and-tools.md
+++ b/docs/agents-and-tools.md
@@ -50,6 +50,14 @@ and hidden state; the primary agent integrates and verifies the combined tree. R
 read-only. Selecting a skill grants no source, GitHub, provider, external-model, tag, publication, or
 messaging authority.
 
+Local development follows the canonical [worktree hygiene contract](../AGENTS.md#worktree-hygiene).
+The primary checkout is a clean, synchronized `main`; agent changes live in named task worktrees;
+and the creator removes each task worktree when its PR merges, closes, or is superseded. Run
+`./scripts/run_make.py worktree-check` before starting work. Invoke
+`python3 -I scripts/check_worktree_hygiene.py --expect LABEL=PATH` for active handoff registrations
+and add `--strict` at task close. Runtime handoffs use the precise states `clean-main`, `active`,
+`recovery-stashed`, or `blocked` and do not commit private machine paths.
+
 The [engineering journal](engineering-journal.md) is the public, human-readable output of selected
 `merged_verified` milestones. It summarizes only protected public evidence and cannot pass a gate,
 publish a package, claim release readiness, or expose raw/private inputs.

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,6 +62,7 @@ for bounded direct dependency ranges or a maintenance/license/security assessmen
 | Canonical command | Purpose |
 |---|---|
 | `./scripts/run_make.py setup` | Safely synchronize every development group and extra from the existing lock with restrictive environment permissions. |
+| `./scripts/run_make.py worktree-check` | Read-only local preflight for a clean synchronized primary, bounded task worktrees, live registrations, and classified secondary dirtiness; invoke `python3 -I scripts/check_worktree_hygiene.py --expect LABEL=PATH` directly for an expected registration and add `--strict` at task close. |
 | `./scripts/run_make.py lock` | Intentionally resolve and rewrite `uv.lock` with exact uv. |
 | `./scripts/run_make.py lock-check` | Fail if project metadata and the checked-in lock disagree. |
 | `./scripts/run_make.py format` | Apply Ruff formatting to owned Python source and tests. |

--- a/scripts/check_worktree_hygiene.py
+++ b/scripts/check_worktree_hygiene.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Report whether a local Milhouse checkout follows the worktree contract."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+HEAD_PATTERN = re.compile(r"[0-9a-f]{40,64}\Z")
+EXPECTED_PATTERN = re.compile(r"[a-z][a-z0-9-]{0,63}\Z")
+MAIN_BRANCH = "refs/heads/main"
+
+
+class HygieneError(ValueError):
+    """Raised when local Git state cannot be audited safely."""
+
+
+@dataclass(frozen=True)
+class Worktree:
+    """One parsed Git worktree registration."""
+
+    path: Path
+    head: str
+    branch: str | None
+    prunable: bool = False
+    dirty_count: int | None = None
+
+
+@dataclass(frozen=True)
+class ExpectedWorktree:
+    """One caller-named worktree registration expected to exist."""
+
+    label: str
+    path: Path
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One privacy-safe worktree audit result."""
+
+    severity: str
+    label: str
+    message: str
+
+
+def fail(message: str) -> NoReturn:
+    """Exit without printing a machine-local path."""
+
+    print(f"worktree-hygiene: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def _decode(raw: bytes, field: str) -> str:
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise HygieneError(f"Git returned a non-UTF-8 {field}") from exc
+
+
+def parse_worktrees(raw: bytes) -> tuple[Worktree, ...]:
+    """Parse ``git worktree list --porcelain -z`` output."""
+
+    if not raw or not raw.endswith(b"\0\0"):
+        raise HygieneError("Git returned malformed worktree metadata")
+    worktrees: list[Worktree] = []
+    for record in raw.split(b"\0\0"):
+        if not record:
+            continue
+        fields: dict[bytes, bytes] = {}
+        markers: set[bytes] = set()
+        for item in record.split(b"\0"):
+            key, separator, value = item.partition(b" ")
+            if not key or key in fields or key in markers:
+                raise HygieneError("Git returned malformed worktree metadata")
+            if separator:
+                fields[key] = value
+            else:
+                markers.add(key)
+        try:
+            raw_path = fields[b"worktree"]
+            raw_head = fields[b"HEAD"]
+        except KeyError as exc:
+            raise HygieneError("Git omitted required worktree metadata") from exc
+        head = _decode(raw_head, "worktree head")
+        if not HEAD_PATTERN.fullmatch(head):
+            raise HygieneError("Git returned an invalid worktree head")
+        raw_branch = fields.get(b"branch")
+        branch = _decode(raw_branch, "worktree branch") if raw_branch is not None else None
+        if branch is None and b"detached" not in markers and b"bare" not in markers:
+            raise HygieneError("Git omitted the worktree branch state")
+        worktrees.append(
+            Worktree(
+                path=Path(os.fsdecode(raw_path)),
+                head=head,
+                branch=branch,
+                prunable=b"prunable" in fields or b"prunable" in markers,
+            )
+        )
+    if not worktrees:
+        raise HygieneError("Git returned no worktree registrations")
+    if len({os.path.normcase(os.path.realpath(item.path)) for item in worktrees}) != len(worktrees):
+        raise HygieneError("Git returned duplicate worktree registrations")
+    return tuple(worktrees)
+
+
+def count_status_entries(raw: bytes) -> int:
+    """Count entries in ``git status --porcelain=v1 -z`` output."""
+
+    if not raw:
+        return 0
+    if not raw.endswith(b"\0"):
+        raise HygieneError("Git returned malformed worktree status")
+    entries = raw.split(b"\0")
+    count = 0
+    index = 0
+    while index < len(entries) - 1:
+        entry = entries[index]
+        if len(entry) < 4 or entry[2:3] != b" ":
+            raise HygieneError("Git returned malformed worktree status")
+        status = entry[:2]
+        count += 1
+        index += 1
+        if b"R" in status or b"C" in status:
+            if index >= len(entries) - 1 or not entries[index]:
+                raise HygieneError("Git omitted a renamed worktree path")
+            index += 1
+    return count
+
+
+def _git(repository: Path, arguments: Sequence[str], *, timeout: int = 30) -> bytes:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+            "LC_ALL": "C",
+        }
+    )
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-c",
+                "core.fsmonitor=false",
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-C",
+                os.fspath(repository),
+                *arguments,
+            ],
+            capture_output=True,
+            check=False,
+            env=environment,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise HygieneError("Git could not complete the worktree audit") from exc
+    if completed.returncode != 0:
+        raise HygieneError("Git could not complete the worktree audit")
+    return completed.stdout
+
+
+def collect_worktrees(repository: Path) -> tuple[tuple[Worktree, ...], str]:
+    """Collect registration, status, and local protected-main state."""
+
+    parsed = parse_worktrees(_git(repository, ["worktree", "list", "--porcelain", "-z"]))
+    raw_origin = _git(repository, ["rev-parse", "--verify", "origin/main^{commit}"])
+    origin_main = _decode(raw_origin, "origin/main head").strip()
+    if not HEAD_PATTERN.fullmatch(origin_main):
+        raise HygieneError("Git returned an invalid origin/main head")
+
+    collected: list[Worktree] = []
+    for item in parsed:
+        dirty_count: int | None = None
+        if item.path.is_dir() and not item.prunable:
+            try:
+                raw_status = _git(
+                    item.path,
+                    [
+                        "status",
+                        "--porcelain=v1",
+                        "-z",
+                        "--untracked-files=normal",
+                        "--ignore-submodules=all",
+                    ],
+                )
+                dirty_count = count_status_entries(raw_status)
+            except HygieneError:
+                dirty_count = None
+        collected.append(
+            Worktree(
+                path=item.path,
+                head=item.head,
+                branch=item.branch,
+                prunable=item.prunable,
+                dirty_count=dirty_count,
+            )
+        )
+    return tuple(collected), origin_main
+
+
+def _normalized(path: Path) -> str:
+    return os.path.normcase(os.path.realpath(path))
+
+
+def _label(index: int, worktree: Worktree) -> str:
+    if index == 0:
+        return "primary"
+    branch = worktree.branch
+    if branch is not None and branch.startswith("refs/heads/"):
+        return f"task-{index} branch={branch.removeprefix('refs/heads/')}"
+    return f"task-{index} detached"
+
+
+def audit_worktrees(
+    worktrees: Sequence[Worktree],
+    origin_main: str,
+    *,
+    maximum: int,
+    expected: Sequence[ExpectedWorktree] = (),
+) -> tuple[Finding, ...]:
+    """Evaluate worktree state without exposing registered paths."""
+
+    if not worktrees:
+        raise HygieneError("no worktree registrations are available")
+    findings: list[Finding] = []
+    primary = worktrees[0]
+    if primary.branch != MAIN_BRANCH:
+        findings.append(Finding("ERROR", "primary", "state=blocked; branch is not main"))
+    if primary.head != origin_main:
+        findings.append(
+            Finding("ERROR", "primary", "state=blocked; main is stale against origin/main")
+        )
+    if primary.dirty_count is None:
+        findings.append(Finding("ERROR", "primary", "state=blocked; status could not be verified"))
+    elif primary.dirty_count:
+        findings.append(
+            Finding(
+                "ERROR",
+                "primary",
+                f"state=blocked; dirty={primary.dirty_count}; primary must be clean-main",
+            )
+        )
+    if len(worktrees) > maximum:
+        findings.append(
+            Finding(
+                "ERROR",
+                "registry",
+                f"registered={len(worktrees)} exceeds maximum={maximum}",
+            )
+        )
+
+    registered = {_normalized(item.path) for item in worktrees}
+    for expected_item in expected:
+        if _normalized(expected_item.path) not in registered:
+            findings.append(
+                Finding(
+                    "ERROR",
+                    expected_item.label,
+                    "expected worktree registration is missing",
+                )
+            )
+
+    for index, worktree in enumerate(worktrees):
+        label = _label(index, worktree)
+        if worktree.prunable or not worktree.path.is_dir():
+            findings.append(Finding("ERROR", label, "registration is missing or prunable"))
+            continue
+        if index == 0:
+            continue
+        if worktree.dirty_count is None:
+            findings.append(Finding("ERROR", label, "state=blocked; status could not be verified"))
+        elif worktree.dirty_count:
+            findings.append(
+                Finding(
+                    "WARNING",
+                    label,
+                    f"dirty={worktree.dirty_count}; classify as active, "
+                    "recovery-stashed, or blocked",
+                )
+            )
+        if worktree.branch is None:
+            findings.append(Finding("WARNING", label, "state=blocked; task worktree is detached"))
+    return tuple(findings)
+
+
+def parse_expected(value: str) -> ExpectedWorktree:
+    """Parse a privacy-safe ``LABEL=PATH`` expectation."""
+
+    label, separator, raw_path = value.partition("=")
+    if not separator or not EXPECTED_PATTERN.fullmatch(label) or not raw_path:
+        raise argparse.ArgumentTypeError("expected worktree must use LABEL=PATH")
+    return ExpectedWorktree(label, Path(raw_path))
+
+
+def parse_args(arguments: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-worktrees",
+        type=int,
+        default=3,
+        help="maximum primary-plus-task registrations (default: 3)",
+    )
+    parser.add_argument(
+        "--expect",
+        action="append",
+        default=[],
+        metavar="LABEL=PATH",
+        type=parse_expected,
+        help="require a named path to appear in Git's worktree registry",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat dirty or detached task-worktree warnings as errors",
+    )
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if arguments is None else arguments)
+    if args.max_worktrees < 1:
+        fail("--max-worktrees must be positive")
+    repository = Path(__file__).resolve().parent.parent
+    try:
+        worktrees, origin_main = collect_worktrees(repository)
+        findings = audit_worktrees(
+            worktrees,
+            origin_main,
+            maximum=args.max_worktrees,
+            expected=args.expect,
+        )
+    except (HygieneError, OSError) as exc:
+        fail(str(exc))
+
+    errors = 0
+    warnings = 0
+    for finding in findings:
+        severity = "ERROR" if args.strict and finding.severity == "WARNING" else finding.severity
+        if severity == "ERROR":
+            errors += 1
+        else:
+            warnings += 1
+        print(f"worktree-hygiene: {severity} {finding.label}: {finding.message}")
+    if errors:
+        print(
+            f"worktree-hygiene: FAIL errors={errors} warnings={warnings} "
+            f"registered={len(worktrees)}"
+        )
+        return 1
+    print(
+        f"worktree-hygiene: PASS state=clean-main registered={len(worktrees)} warnings={warnings}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/security/test_makefile_safety.py
+++ b/tests/security/test_makefile_safety.py
@@ -58,6 +58,7 @@ CRITICAL_COVERAGE_FILES = {
     "scripts/check_dco.py",
     "scripts/check_links.py",
     "scripts/check_private_identifiers.py",
+    "scripts/check_worktree_hygiene.py",
     "scripts/gitleaks.py",
     "scripts/prepare_environment.py",
     "scripts/required_ci.py",

--- a/tests/unit/test_tool_worktree_hygiene.py
+++ b/tests/unit/test_tool_worktree_hygiene.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import check_worktree_hygiene as hygiene
+
+HEAD = "a" * 40
+ORIGIN = "b" * 40
+
+
+def worktree_record(path: Path, *, head: str = HEAD, branch: str | None = "main") -> bytes:
+    fields = [f"worktree {path}".encode(), f"HEAD {head}".encode()]
+    fields.append(f"branch refs/heads/{branch}".encode() if branch else b"detached")
+    return b"\0".join(fields) + b"\0\0"
+
+
+def snapshot(
+    path: Path,
+    *,
+    head: str = HEAD,
+    branch: str | None = "refs/heads/main",
+    prunable: bool = False,
+    dirty: int | None = 0,
+) -> hygiene.Worktree:
+    return hygiene.Worktree(path, head, branch, prunable, dirty)
+
+
+def test_parse_worktrees_preserves_branch_detached_and_prunable_state(tmp_path: Path) -> None:
+    primary = tmp_path / "primary"
+    task = tmp_path / "task"
+    raw = worktree_record(primary) + (
+        f"worktree {task}\0HEAD {ORIGIN}\0detached\0prunable metadata missing\0\0".encode()
+    )
+
+    parsed = hygiene.parse_worktrees(raw)
+
+    assert parsed == (
+        hygiene.Worktree(primary, HEAD, "refs/heads/main"),
+        hygiene.Worktree(task, ORIGIN, None, prunable=True),
+    )
+
+
+@pytest.mark.parametrize(
+    "raw, message",
+    (
+        (b"", "malformed"),
+        (b"worktree /repo\0HEAD " + HEAD.encode(), "malformed"),
+        (b"HEAD " + HEAD.encode() + b"\0detached\0\0", "omitted required"),
+        (b"worktree /repo\0HEAD invalid\0detached\0\0", "invalid worktree head"),
+        (b"worktree /repo\0HEAD " + HEAD.encode() + b"\0\0", "omitted the worktree branch"),
+        (
+            b"worktree /repo\0worktree /other\0HEAD " + HEAD.encode() + b"\0detached\0\0",
+            "malformed",
+        ),
+        (
+            b"worktree /repo\0HEAD " + HEAD.encode() + b"\0branch \xff\0\0",
+            "non-UTF-8",
+        ),
+    ),
+)
+def test_parse_worktrees_rejects_malformed_metadata(raw: bytes, message: str) -> None:
+    with pytest.raises(hygiene.HygieneError, match=message):
+        hygiene.parse_worktrees(raw)
+
+
+def test_parse_worktrees_rejects_duplicate_paths(tmp_path: Path) -> None:
+    raw = worktree_record(tmp_path) + worktree_record(tmp_path, branch=None)
+
+    with pytest.raises(hygiene.HygieneError, match="duplicate"):
+        hygiene.parse_worktrees(raw)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    (
+        (b"", 0),
+        (b" M file\0?? new\0", 2),
+        (b"R  new\0old\0 M other\0", 2),
+        (b" C copy\0source\0", 1),
+    ),
+)
+def test_count_status_entries(raw: bytes, expected: int) -> None:
+    assert hygiene.count_status_entries(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, message",
+    (
+        (b" M file", "malformed"),
+        (b"invalid\0", "malformed"),
+        (b"R  new\0", "omitted"),
+    ),
+)
+def test_count_status_entries_rejects_malformed_status(raw: bytes, message: str) -> None:
+    with pytest.raises(hygiene.HygieneError, match=message):
+        hygiene.count_status_entries(raw)
+
+
+def test_clean_primary_and_task_pass(tmp_path: Path) -> None:
+    primary = tmp_path / "primary"
+    task = tmp_path / "task"
+    primary.mkdir()
+    task.mkdir()
+    worktrees = (
+        snapshot(primary),
+        snapshot(task, branch="refs/heads/codex/task"),
+    )
+
+    assert hygiene.audit_worktrees(worktrees, HEAD, maximum=3) == ()
+
+
+def test_audit_reports_every_blocking_primary_and_registry_state(tmp_path: Path) -> None:
+    primary = tmp_path / "primary"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    primary.mkdir()
+    first.mkdir()
+    worktrees = (
+        snapshot(primary, head=HEAD, branch="refs/heads/topic", dirty=2),
+        snapshot(first, branch=None, dirty=1),
+        snapshot(second, branch="refs/heads/claude/task", prunable=True, dirty=None),
+    )
+
+    findings = hygiene.audit_worktrees(worktrees, ORIGIN, maximum=2)
+
+    assert [(item.severity, item.label, item.message) for item in findings] == [
+        ("ERROR", "primary", "state=blocked; branch is not main"),
+        ("ERROR", "primary", "state=blocked; main is stale against origin/main"),
+        ("ERROR", "primary", "state=blocked; dirty=2; primary must be clean-main"),
+        ("ERROR", "registry", "registered=3 exceeds maximum=2"),
+        (
+            "WARNING",
+            "task-1 detached",
+            "dirty=1; classify as active, recovery-stashed, or blocked",
+        ),
+        ("WARNING", "task-1 detached", "state=blocked; task worktree is detached"),
+        (
+            "ERROR",
+            "task-2 branch=claude/task",
+            "registration is missing or prunable",
+        ),
+    ]
+
+
+def test_audit_reports_unreadable_status_and_missing_expectation(tmp_path: Path) -> None:
+    primary = tmp_path / "primary"
+    task = tmp_path / "task"
+    missing = tmp_path / "missing"
+    primary.mkdir()
+    task.mkdir()
+    worktrees = (
+        snapshot(primary, dirty=None),
+        snapshot(task, branch="refs/heads/codex/task", dirty=None),
+    )
+
+    findings = hygiene.audit_worktrees(
+        worktrees,
+        HEAD,
+        maximum=3,
+        expected=(
+            hygiene.ExpectedWorktree("codex", task),
+            hygiene.ExpectedWorktree("claude", missing),
+        ),
+    )
+
+    assert findings == (
+        hygiene.Finding("ERROR", "primary", "state=blocked; status could not be verified"),
+        hygiene.Finding("ERROR", "claude", "expected worktree registration is missing"),
+        hygiene.Finding(
+            "ERROR",
+            "task-1 branch=codex/task",
+            "state=blocked; status could not be verified",
+        ),
+    )
+
+
+def test_collect_worktrees_adds_status_counts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    primary = tmp_path / "primary"
+    task = tmp_path / "task"
+    primary.mkdir()
+    task.mkdir()
+    metadata = worktree_record(primary) + worktree_record(task, branch="codex/task")
+
+    def fake_git(repository: Path, arguments: list[str], *, timeout: int = 30) -> bytes:
+        assert timeout == 30
+        if arguments[:2] == ["worktree", "list"]:
+            return metadata
+        if arguments[0] == "rev-parse":
+            return f"{HEAD}\n".encode()
+        if repository == primary:
+            return b""
+        if repository == task:
+            return b" M changed\0?? new\0"
+        raise AssertionError(arguments)
+
+    monkeypatch.setattr(hygiene, "_git", fake_git)
+
+    worktrees, origin = hygiene.collect_worktrees(tmp_path)
+
+    assert origin == HEAD
+    assert [item.dirty_count for item in worktrees] == [0, 2]
+
+
+def test_collect_worktrees_marks_failed_or_prunable_status_unknown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    metadata = worktree_record(primary).replace(b"\0\0", b"\0prunable gone\0\0")
+
+    def fake_git(repository: Path, arguments: list[str], *, timeout: int = 30) -> bytes:
+        if arguments[:2] == ["worktree", "list"]:
+            return metadata
+        if arguments[0] == "rev-parse":
+            return f"{HEAD}\n".encode()
+        raise hygiene.HygieneError("failed")
+
+    monkeypatch.setattr(hygiene, "_git", fake_git)
+
+    worktrees, _ = hygiene.collect_worktrees(tmp_path)
+
+    assert worktrees[0].dirty_count is None
+
+
+def test_collect_worktrees_rejects_invalid_origin_head(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_git(repository: Path, arguments: list[str], *, timeout: int = 30) -> bytes:
+        if arguments[:2] == ["worktree", "list"]:
+            return worktree_record(tmp_path)
+        return b"invalid\n"
+
+    monkeypatch.setattr(hygiene, "_git", fake_git)
+
+    with pytest.raises(hygiene.HygieneError, match="invalid origin/main"):
+        hygiene.collect_worktrees(tmp_path)
+
+
+def test_git_sanitizes_environment_and_rejects_failures(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, object] = {}
+
+    def run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        captured["command"] = command
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout=b"result")
+
+    monkeypatch.setattr(subprocess, "run", run)
+
+    assert hygiene._git(tmp_path, ["status"]) == b"result"
+    assert captured["command"][-1] == "status"  # type: ignore[index]
+    environment = captured["env"]
+    assert isinstance(environment, dict)
+    assert environment["GIT_OPTIONAL_LOCKS"] == "0"
+    assert environment["GIT_CONFIG_NOSYSTEM"] == "1"
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=b"", stderr=b"private"),
+    )
+    with pytest.raises(hygiene.HygieneError, match="could not complete"):
+        hygiene._git(tmp_path, ["status"])
+
+    def timeout(*args: object, **kwargs: object) -> SimpleNamespace:
+        raise subprocess.TimeoutExpired("git", 30)
+
+    monkeypatch.setattr(subprocess, "run", timeout)
+    with pytest.raises(hygiene.HygieneError, match="could not complete"):
+        hygiene._git(tmp_path, ["status"])
+
+
+@pytest.mark.parametrize("value", ("missing", "UPPER=/tmp/task", "label=", "=path"))
+def test_parse_expected_rejects_unsafe_labels(value: str) -> None:
+    with pytest.raises(Exception, match="LABEL=PATH"):
+        hygiene.parse_expected(value)
+
+
+def test_main_reports_warnings_and_strict_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    primary = tmp_path / "primary"
+    task = tmp_path / "task"
+    primary.mkdir()
+    task.mkdir()
+    worktrees = (
+        snapshot(primary),
+        snapshot(task, branch="refs/heads/codex/task", dirty=1),
+    )
+    monkeypatch.setattr(hygiene, "collect_worktrees", lambda repository: (worktrees, HEAD))
+
+    assert hygiene.main([]) == 0
+    output = capsys.readouterr().out
+    assert "WARNING task-1 branch=codex/task" in output
+    assert "PASS state=clean-main registered=2 warnings=1" in output
+
+    assert hygiene.main(["--strict"]) == 1
+    output = capsys.readouterr().out
+    assert "ERROR task-1 branch=codex/task" in output
+    assert "FAIL errors=1 warnings=0 registered=2" in output
+
+
+def test_main_rejects_nonpositive_limit_and_collection_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as nonpositive:
+        hygiene.main(["--max-worktrees", "0"])
+    assert nonpositive.value.code == 1
+    assert "must be positive" in capsys.readouterr().err
+
+    def fail_collection(repository: Path) -> tuple[tuple[hygiene.Worktree, ...], str]:
+        raise hygiene.HygieneError("audit unavailable")
+
+    monkeypatch.setattr(hygiene, "collect_worktrees", fail_collection)
+    with pytest.raises(SystemExit) as unavailable:
+        hygiene.main([])
+    assert unavailable.value.code == 1
+    assert "audit unavailable" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Enforces the worktree-hygiene contract as repository policy plus a read-only preflight checker. Closes the environment handoff so product work can proceed from a clean, synchronized primary.

- Documents the `clean-main` / `active` / `recovery-stashed` / `blocked` state model in `AGENTS.md`, `CONTRIBUTING.md`, `docs/agents-and-tools.md`, and `docs/development.md`.
- Adds `scripts/check_worktree_hygiene.py`: a read-only checker for a clean synchronized primary, bounded task worktrees (primary + one per agent), live `--expect LABEL=PATH` registrations, and classified secondary dirtiness. Output is privacy-safe — it emits labels, never machine-local paths or stash metadata.
- Wires `worktree-check` into the Makefile target list and `./scripts/run_make.py worktree-check`; supports `--expect` and `--strict`.
- Adds the checker to the critical-file 95% branch-coverage set (Makefile `--critical` + `tests/security/test_makefile_safety.py`) with `tests/unit/test_tool_worktree_hygiene.py`.

## Validation

- Locked setup (uv 0.11.29): PASS
- Quality (lock, format, lint, strict mypy, repo/link/workflow/skill validation, zizmor): PASS
- Full suite: 4,801 passed, 1 skipped; line 97.79% / branch 96.87%; 60 critical files ≥95% branch (checker 96%)
- `git diff --check`: PASS
- `secret-scan` (tree + history + private-identifiers): PASS

## Notes

- Non-blocking follow-up: the suite emits 13 non-fatal pytest temp-dir cleanup warnings from existing spool tests. Tracked separately; did not fail the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
