### PR TITLE
feat(cli): add spool-only init and health commands (first product slice)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart (pre-alpha)
+
+> **Pre-alpha.** Milhouse is not released and not ready for production use. This quickstart exercises
+> the local, spool-only foundation only: it configures a state root, initializes the control
+> database and installation identity, and reports health. No network, no credentials, no provider
+> calls, and no ClickHouse are involved. Capabilities gated by later work packages
+> (see [implementation-status.md](implementation-status.md)) are not available yet.
+
+## 1. Provide a configuration
+
+Milhouse is config-driven. Start from the checked-in [`config/example.toml`](../config/example.toml)
+and edit the `[paths]` and `[[targets]]` sections for your machine. The `[paths] home` value is your
+**state root** — every durable file lives beneath it.
+
+Point the CLI at your config with `--config PATH`, the `MILHOUSE_CONFIG` environment variable, or the
+platform default config location.
+
+Validate it first (no network, no secret resolution):
+
+```console
+$ milhouse --config ./config.toml config validate
+configuration is valid
+```
+
+## 2. Initialize the local install
+
+`init` is idempotent: it creates the state-root layout (`control/`, `spool/`, `reports/`, `logs/`,
+`backups/`) with owner-only permissions, applies the control-plane database schema under the commit
+barrier, and generates a durable non-secret installation identity.
+
+```console
+$ milhouse --config ./config.toml init
+initialized: directories=state_root, control, spool, reports, logs, backups; schema 10; installation id created
+
+$ milhouse --config ./config.toml init
+already initialized (schema 10)
+```
+
+## 3. Check health
+
+`health` reports whether an initialized install is usable and returns a non-zero exit code when it is
+not (so it composes in scripts). Add `--json` for a stable machine-readable report.
+
+```console
+$ milhouse --config ./config.toml health
+[ok] directory:state_root: present
+[ok] directory:control: present
+[ok] directory:spool: present
+[ok] directory:reports: present
+[ok] directory:logs: present
+[ok] directory:backups: present
+[ok] control_database: schema 10
+[ok] installation_identity: established
+status: healthy
+
+$ milhouse --config ./config.toml health --json
+{"checks": [ ... ], "status": "healthy"}
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---:|---|
+| `0` | Success; `health` reports **healthy**. |
+| `1` | `health` reports **unhealthy**, or `init` could not establish the state root/identity. |
+| `2` | The configuration is missing or invalid. |
+
+## What this is (and is not)
+
+This is a preparatory product vertical built on the accepted W02 (configuration, identity, privacy)
+and W03 (SQLite control state and durable spool) foundations. It is tracked as a roadmap feature and
+does **not** claim the W05 runtime or W06 initialization gates. A spool-only data-flow demo and the
+full CLI surface follow in later increments.

--- a/src/milhouse/cli/bootstrap.py
+++ b/src/milhouse/cli/bootstrap.py
@@ -1,0 +1,259 @@
+"""Config-driven ``init`` and ``health`` bootstrap for the Milhouse CLI.
+
+First runnable product slice (a preparatory vertical on the passed W02 config/identity and W03
+spool/state foundations; it does not claim the W05/W06 gates). ``initialize`` creates the state-root
+layout under restrictive permissions, applies the control-plane schema, and generates a durable
+non-secret installation identity; ``health`` reports whether an initialized install is usable. Both
+are local, spool-only, and credential-free — no network, no secret resolution, no provider calls.
+
+The installation identity here is the record-identity ``mh_in1_`` UUID used in canonical record
+derivation (plan section 4.2), persisted as an owner-only file in the control directory. It is
+distinct from the keyed pseudonym-key lifecycle of plan section 4.7, which amendment A09 keeps
+deferred; this slice never creates or reads that key.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from milhouse.config import RuntimePaths
+from milhouse.config.filesystem import (
+    SecureFileError,
+    create_regular_file_no_follow,
+    open_regular_file_no_follow,
+)
+from milhouse.state import (
+    GlobalCommitBarrier,
+    initialize_control_state,
+    open_control_database,
+    schema_version,
+)
+
+CONTROL_DIRNAME = "control"
+DATABASE_NAME = "milhouse.sqlite3"
+BARRIER_NAME = "commit.lock"
+INSTALLATION_ID_NAME = "installation.id"
+#: The current applied control-schema version (see ``state/schema.py``; A09 returned it to 10).
+EXPECTED_SCHEMA_VERSION = 10
+
+_DIR_MODE = 0o700
+_ID_FILE_MODE = 0o600
+_MAX_ID_BYTES = 64
+_INSTALLATION_ID_PATTERN = re.compile(
+    r"mh_in1_[0-9a-f]{12}4[0-9a-f]{3}[89ab][0-9a-f]{15}", flags=re.ASCII
+)
+
+
+class BootstrapError(Exception):
+    """A stable, privacy-safe bootstrap failure carrying a fixed code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(f"{code}: {message}")
+
+
+@dataclass(frozen=True, slots=True)
+class InitReport:
+    """The outcome of one ``initialize`` pass over a config's runtime paths."""
+
+    created_directories: tuple[str, ...]
+    schema_version: int
+    installation_id_created: bool
+
+    @property
+    def already_initialized(self) -> bool:
+        """Whether the pass changed nothing durable (fully idempotent re-run)."""
+
+        return not self.created_directories and not self.installation_id_created
+
+
+@dataclass(frozen=True, slots=True)
+class HealthCheck:
+    """One named health assertion and its privacy-safe outcome."""
+
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class HealthReport:
+    """The aggregate result of a ``health`` pass. ``status`` is ``healthy`` or ``unhealthy``."""
+
+    checks: tuple[HealthCheck, ...]
+
+    @property
+    def healthy(self) -> bool:
+        return all(check.ok for check in self.checks)
+
+    @property
+    def status(self) -> str:
+        return "healthy" if self.healthy else "unhealthy"
+
+
+def _control_dir(paths: RuntimePaths) -> Path:
+    return paths.state_root / CONTROL_DIRNAME
+
+
+def database_path(paths: RuntimePaths) -> Path:
+    return _control_dir(paths) / DATABASE_NAME
+
+
+def _installation_id_path(paths: RuntimePaths) -> Path:
+    return _control_dir(paths) / INSTALLATION_ID_NAME
+
+
+def _managed_directories(paths: RuntimePaths) -> tuple[tuple[str, Path], ...]:
+    return (
+        ("state_root", paths.state_root),
+        (CONTROL_DIRNAME, _control_dir(paths)),
+        ("spool", paths.spool),
+        ("reports", paths.reports),
+        ("logs", paths.logs),
+        ("backups", paths.backups),
+    )
+
+
+def _ensure_private_directory(path: Path) -> bool:
+    """Create ``path`` (0700) if absent; always tighten its mode. Returns whether it was created."""
+
+    created = not path.exists()
+    try:
+        path.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
+        os.chmod(path, _DIR_MODE)
+    except OSError as error:
+        raise BootstrapError("MH_INIT_DIR", "a state directory could not be created") from error
+    return created
+
+
+def _generate_installation_id() -> str:
+    # uuid4().hex is exactly the mh_in1_ payload shape (version nibble 4, variant [89ab]).
+    return "mh_in1_" + uuid.uuid4().hex
+
+
+def read_installation_id(paths: RuntimePaths) -> str | None:
+    """Return the persisted installation id, or ``None`` if absent/unreadable/malformed."""
+
+    try:
+        opened = open_regular_file_no_follow(_installation_id_path(paths))
+    except SecureFileError:
+        return None
+    descriptor = opened.descriptor
+    try:
+        raw = os.read(descriptor, _MAX_ID_BYTES + 1)
+    except OSError:  # pragma: no cover - defensive: an open fd rarely fails a bounded read
+        return None
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError:  # pragma: no cover - defensive: close of our own fd
+            pass
+    if len(raw) > _MAX_ID_BYTES:
+        return None
+    try:
+        value = raw.decode("ascii").strip()
+    except UnicodeDecodeError:
+        return None
+    return value if _INSTALLATION_ID_PATTERN.fullmatch(value) is not None else None
+
+
+def _ensure_installation_id(paths: RuntimePaths) -> bool:
+    """Persist a fresh installation id iff none is present. Returns whether one was created."""
+
+    if read_installation_id(paths) is not None:
+        return False
+    new_id = _generate_installation_id()
+    try:
+        create_regular_file_no_follow(
+            _installation_id_path(paths),
+            new_id.encode("ascii"),
+            mode=_ID_FILE_MODE,
+            require_private_parent=True,
+        )
+    except SecureFileError as error:  # pragma: no cover - defensive: concurrent-init / IO race
+        # An existing id lost a race with a concurrent init: treat a present valid id as success.
+        if read_installation_id(paths) is not None:
+            return False
+        raise BootstrapError(
+            "MH_INIT_IDENTITY", "the installation identity could not be established"
+        ) from error
+    return True
+
+
+def initialize(paths: RuntimePaths, *, now: datetime) -> InitReport:
+    """Idempotently create the state-root layout, apply the schema, and establish identity.
+
+    Creates ``state_root`` and its ``control``/``spool``/``reports``/``logs``/``backups`` children
+    (0700), opens the control database and applies every unapplied migration under the commit
+    barrier, and generates the installation id if absent. Re-running changes nothing durable.
+    """
+
+    created: list[str] = []
+    for label, directory in _managed_directories(paths):
+        if _ensure_private_directory(directory):
+            created.append(label)
+
+    database = open_control_database(database_path(paths))
+    try:
+        barrier = GlobalCommitBarrier(_control_dir(paths) / BARRIER_NAME)
+        version = initialize_control_state(database, barrier=barrier, applied_at=now)
+    finally:
+        database.close()
+
+    installation_created = _ensure_installation_id(paths)
+    return InitReport(
+        created_directories=tuple(created),
+        schema_version=version,
+        installation_id_created=installation_created,
+    )
+
+
+def _database_check(paths: RuntimePaths) -> HealthCheck:
+    """Report the control-database health without mutating or raising on a bad database."""
+
+    if not database_path(paths).is_file():
+        return HealthCheck("control_database", False, "missing (run milhouse init)")
+    try:
+        database = open_control_database(database_path(paths))
+        try:
+            version = schema_version(database)
+        finally:
+            database.close()
+    except Exception:  # pragma: no cover - defensive: a health probe reports, never raises
+        return HealthCheck("control_database", False, "unreadable")
+    ok = version == EXPECTED_SCHEMA_VERSION
+    detail = f"schema {version}" if ok else f"schema {version}, expected {EXPECTED_SCHEMA_VERSION}"
+    return HealthCheck("control_database", ok, detail)
+
+
+def health(paths: RuntimePaths, *, now: datetime) -> HealthReport:
+    """Report whether an initialized install is usable, without mutating anything."""
+
+    checks: list[HealthCheck] = []
+    for label, directory in _managed_directories(paths):
+        present = directory.is_dir()
+        checks.append(
+            HealthCheck(
+                name=f"directory:{label}",
+                ok=present,
+                detail="present" if present else "missing (run milhouse init)",
+            )
+        )
+
+    checks.append(_database_check(paths))
+
+    identity_present = read_installation_id(paths) is not None
+    checks.append(
+        HealthCheck(
+            "installation_identity",
+            identity_present,
+            "established" if identity_present else "missing (run milhouse init)",
+        )
+    )
+    return HealthReport(checks=tuple(checks))

--- a/src/milhouse/cli/root.py
+++ b/src/milhouse/cli/root.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 
 import click
 from platformdirs import user_config_path, user_data_path
 
 from milhouse import __version__
+from milhouse.cli import bootstrap
 from milhouse.config import (
     ConfigError,
+    RuntimePaths,
     generate_json_schema_bytes,
     load_config,
     resolve_runtime_paths,
@@ -53,6 +57,22 @@ def _platform_data_root() -> Path:
     return user_data_path("milhouse", appauthor=False)
 
 
+def _resolve_paths(state: CliState) -> RuntimePaths:
+    """Load the config and resolve runtime paths, mapping config failure to the exit-2 CLI error."""
+
+    try:
+        config, config_path = load_config(
+            state.config_path, platform_default=_platform_config_file()
+        )
+        return resolve_runtime_paths(
+            config,
+            config_path=config_path,
+            platform_data_root=_platform_data_root(),
+        )
+    except ConfigError as error:
+        raise ConfigCommandError(error) from None
+
+
 @click.group(
     name="milhouse",
     context_settings={"help_option_names": ["-h", "--help"]},
@@ -87,17 +107,7 @@ def config_group() -> None:
 def validate_config_command(state: CliState) -> None:
     """Validate one config without network access or secret resolution."""
 
-    try:
-        config, config_path = load_config(
-            state.config_path, platform_default=_platform_config_file()
-        )
-        resolve_runtime_paths(
-            config,
-            config_path=config_path,
-            platform_data_root=_platform_data_root(),
-        )
-    except ConfigError as error:
-        raise ConfigCommandError(error) from None
+    _resolve_paths(state)
     click.echo("configuration is valid")
 
 
@@ -108,3 +118,78 @@ def config_schema_command() -> None:
     output = click.get_binary_stream("stdout")
     output.write(generate_json_schema_bytes())
     output.flush()
+
+
+class BootstrapCommandError(click.ClickException):
+    """A stable bootstrap failure using the CLI contract's exit code 1."""
+
+    exit_code = 1
+
+    def __init__(self, error: bootstrap.BootstrapError) -> None:
+        self.code = error.code
+        super().__init__(str(error))
+
+
+@main.command(name="init")
+@click.option("--json", "as_json", is_flag=True, help="Emit the result as stable JSON.")
+@click.pass_obj
+def init_command(state: CliState, as_json: bool) -> None:
+    """Initialize the state root, control database, and installation identity (idempotent)."""
+
+    paths = _resolve_paths(state)
+    try:
+        report = bootstrap.initialize(paths, now=datetime.now(UTC))
+    except bootstrap.BootstrapError as error:
+        raise BootstrapCommandError(error) from None
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "created_directories": list(report.created_directories),
+                    "schema_version": report.schema_version,
+                    "installation_id_created": report.installation_id_created,
+                    "already_initialized": report.already_initialized,
+                },
+                sort_keys=True,
+            )
+        )
+        return
+    if report.already_initialized:
+        click.echo(f"already initialized (schema {report.schema_version})")
+        return
+    created = ", ".join(report.created_directories) or "none"
+    identity = "created" if report.installation_id_created else "present"
+    click.echo(
+        f"initialized: directories={created}; schema {report.schema_version}; "
+        f"installation id {identity}"
+    )
+
+
+@main.command(name="health")
+@click.option("--json", "as_json", is_flag=True, help="Emit the report as stable JSON.")
+@click.pass_context
+def health_command(context: click.Context, as_json: bool) -> None:
+    """Report whether the local install is usable; exit non-zero when unhealthy."""
+
+    state = context.ensure_object(CliState)
+    paths = _resolve_paths(state)
+    report = bootstrap.health(paths, now=datetime.now(UTC))
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "status": report.status,
+                    "checks": [
+                        {"name": check.name, "ok": check.ok, "detail": check.detail}
+                        for check in report.checks
+                    ],
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        for check in report.checks:
+            click.echo(f"[{'ok' if check.ok else 'FAIL'}] {check.name}: {check.detail}")
+        click.echo(f"status: {report.status}")
+    if not report.healthy:
+        context.exit(1)

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -1,0 +1,203 @@
+"""Tests for the config-driven ``init``/``health`` bootstrap (first product slice)."""
+
+from __future__ import annotations
+
+import os
+import stat
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from pydantic import TypeAdapter
+
+from milhouse.cli import bootstrap
+from milhouse.cli.root import main
+from milhouse.config import RuntimePaths, load_config, resolve_runtime_paths
+from milhouse.domain.identity import InstallationIdV1
+
+_NOW = datetime(2026, 8, 3, 12, 0, 0, tzinfo=UTC)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLE_CONFIG = (_REPO_ROOT / "config" / "example.toml").read_text(encoding="utf-8")
+_INSTALLATION_ID = TypeAdapter(InstallationIdV1)
+
+
+def _config_file(tmp_path: Path) -> Path:
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    config_file = config_dir / "config.toml"
+    config_file.write_text(_EXAMPLE_CONFIG, encoding="utf-8")
+    return config_file
+
+
+def _paths(tmp_path: Path) -> RuntimePaths:
+    config_file = _config_file(tmp_path)
+    config, config_path = load_config(config_file, platform_default=config_file)
+    return resolve_runtime_paths(
+        config, config_path=config_path, platform_data_root=tmp_path / "platform"
+    )
+
+
+def test_initialize_creates_the_full_layout_schema_and_identity(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    report = bootstrap.initialize(paths, now=_NOW)
+
+    assert set(report.created_directories) == {
+        "state_root",
+        "control",
+        "spool",
+        "reports",
+        "logs",
+        "backups",
+    }
+    assert report.schema_version == bootstrap.EXPECTED_SCHEMA_VERSION == 10
+    assert report.installation_id_created is True
+    assert report.already_initialized is False
+    for _label, directory in bootstrap._managed_directories(paths):
+        assert directory.is_dir()
+        assert stat.S_IMODE(os.stat(directory).st_mode) == 0o700
+    assert bootstrap.database_path(paths).is_file()
+
+
+def test_initialize_is_idempotent(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    first = bootstrap.initialize(paths, now=_NOW)
+    first_id = bootstrap.read_installation_id(paths)
+
+    second = bootstrap.initialize(paths, now=_NOW)
+
+    assert first.installation_id_created is True
+    assert second.created_directories == ()
+    assert second.installation_id_created is False
+    assert second.already_initialized is True
+    assert bootstrap.read_installation_id(paths) == first_id  # identity is stable across runs
+
+
+def test_installation_id_is_a_valid_domain_identity_stored_owner_only(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    bootstrap.initialize(paths, now=_NOW)
+
+    identity = bootstrap.read_installation_id(paths)
+    assert identity is not None
+    _INSTALLATION_ID.validate_python(identity)  # the domain record-identity type accepts it
+    id_file = paths.state_root / "control" / "installation.id"
+    assert stat.S_IMODE(os.stat(id_file).st_mode) == 0o600
+
+
+def test_read_installation_id_is_none_before_init(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    (paths.state_root / "control").mkdir(parents=True)
+    assert bootstrap.read_installation_id(paths) is None
+
+
+def test_read_installation_id_rejects_a_malformed_file(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    control = paths.state_root / "control"
+    control.mkdir(parents=True)
+    (control / "installation.id").write_text("not-a-valid-id", encoding="utf-8")
+    assert bootstrap.read_installation_id(paths) is None
+
+
+def test_read_installation_id_rejects_an_oversized_file(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    control = paths.state_root / "control"
+    control.mkdir(parents=True)
+    (control / "installation.id").write_bytes(b"a" * 200)
+    assert bootstrap.read_installation_id(paths) is None
+
+
+def test_read_installation_id_rejects_non_ascii(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    control = paths.state_root / "control"
+    control.mkdir(parents=True)
+    (control / "installation.id").write_bytes(b"\xff\xfe\xfd\xfc")
+    assert bootstrap.read_installation_id(paths) is None
+
+
+def test_initialize_fails_closed_when_a_directory_cannot_be_created(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    # Put a regular file where the state root must be a directory, so mkdir fails closed.
+    paths.state_root.parent.mkdir(parents=True, exist_ok=True)
+    paths.state_root.write_bytes(b"not a directory")
+    with pytest.raises(bootstrap.BootstrapError) as captured:
+        bootstrap.initialize(paths, now=_NOW)
+    assert captured.value.code == "MH_INIT_DIR"
+
+
+def test_health_is_healthy_after_init(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    bootstrap.initialize(paths, now=_NOW)
+
+    report = bootstrap.health(paths, now=_NOW)
+
+    assert report.healthy is True
+    assert report.status == "healthy"
+    assert {check.name for check in report.checks} >= {
+        "control_database",
+        "installation_identity",
+        "directory:spool",
+    }
+
+
+def test_health_is_unhealthy_before_init(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    report = bootstrap.health(paths, now=_NOW)
+    assert report.healthy is False
+    assert report.status == "unhealthy"
+    names = {check.name for check in report.checks if not check.ok}
+    assert "control_database" in names
+    assert "installation_identity" in names
+
+
+def test_health_flags_a_wrong_schema_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _paths(tmp_path)
+    bootstrap.initialize(paths, now=_NOW)
+    monkeypatch.setattr(bootstrap, "EXPECTED_SCHEMA_VERSION", 999)
+
+    report = bootstrap.health(paths, now=_NOW)
+
+    database_check = next(c for c in report.checks if c.name == "control_database")
+    assert database_check.ok is False
+    assert "expected 999" in database_check.detail
+
+
+# --- CLI surface (exit codes + stable JSON) -------------------------------------------------------
+
+
+def test_cli_init_then_health_json(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+
+    init_result = runner.invoke(main, ["--config", str(config_file), "init"])
+    assert init_result.exit_code == 0
+    assert "initialized" in init_result.output
+
+    health_result = runner.invoke(main, ["--config", str(config_file), "health", "--json"])
+    assert health_result.exit_code == 0
+    assert '"status": "healthy"' in health_result.output
+
+
+def test_cli_health_exits_nonzero_when_unhealthy(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["--config", str(config_file), "health"])
+    assert result.exit_code == 1
+    assert "status: unhealthy" in result.output
+
+
+def test_cli_init_json_is_stable(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["--config", str(config_file), "init", "--json"])
+    assert result.exit_code == 0
+    assert '"schema_version": 10' in result.output
+    assert '"installation_id_created": true' in result.output
+
+
+def test_cli_init_reports_config_error_with_exit_code_two(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.toml"
+    runner = CliRunner()
+    result = runner.invoke(main, ["--config", str(missing), "init"])
+    assert result.exit_code == 2


### PR DESCRIPTION
## Summary

The **first runnable Milhouse product workflow** — a user can now `milhouse init && milhouse health` and get a working, health-checked local install. Refs #109.

- **`milhouse init`** — idempotent: creates the state-root layout (`control/`, `spool/`, `reports/`, `logs/`, `backups/`) with owner-only (`0700`) permissions, applies the control-plane database schema under the commit barrier, and establishes a durable non-secret installation identity (`0600`). Re-running changes nothing.
- **`milhouse health`** — reports whether an initialized install is usable; `--json` for a stable machine-readable report; non-zero exit when unhealthy so it composes in scripts.
- Exit codes: `0` success/healthy · `1` unhealthy / init could not establish state · `2` config missing/invalid.

Verified end-to-end on a real path:
```
$ milhouse --config ./config.toml init
initialized: directories=state_root, control, spool, reports, logs, backups; schema 10; installation id created
$ milhouse --config ./config.toml init
already initialized (schema 10)
$ milhouse --config ./config.toml health --json
{"checks":[...8 checks...],"status":"healthy"}   # exit 0
```
Layout perms confirmed: directories `0700`, control files (`milhouse.sqlite3`, `commit.lock`, `installation.id`) `0600`.

## Design notes

- Built on the accepted **W02** (config/identity/privacy) and **W03** (SQLite control state + durable spool) foundations. This is a **preparatory product vertical**, honestly **not** a W05/W06 gate claim.
- The installation identity here is the **record-identity** `mh_in1_` UUID used in canonical record derivation (plan §4.2), persisted as an owner-only control file. It is distinct from the keyed **pseudonym-key** lifecycle of plan §4.7, which amendment **A09** keeps deferred — this slice never creates or reads that key, and adds **no** migration (control schema stays at v10).

## Validation

- Quality: PASS (ruff, strict mypy on 77 files, config-validation, links 71 files/300 links/80 external probes, workflow, zizmor, skills).
- Coverage: `bootstrap.py` at **100%** (15 targeted tests); the change is purely additive (new module + tests + doc, minimal `root.py` command additions) so the full suite/coverage gate is unaffected — confirmed green in CI.
- New tests: `tests/unit/test_cli_bootstrap.py` (15 tests) — layout/schema/identity, idempotency, id validity + owner-only perms, malformed/oversized/non-ascii id rejection, fail-closed dir creation, health healthy/unhealthy/wrong-schema, and CLI exit codes + stable JSON.

## Follow-up

The spool-only **data-flow demo** (`milhouse demo`: collect → validate → redact → spool → read back) is the next increment on #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
