### PR TITLE
feat(cli): add spool-only demo data-flow command (completes first slice)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,17 +57,37 @@ $ milhouse --config ./config.toml health --json
 {"checks": [ ... ], "status": "healthy"}
 ```
 
+## 4. Run the spool-only demo
+
+`demo` exercises the whole local data path end to end without any network, credentials, or ClickHouse:
+it builds one synthetic "site canary healthy" event, classifies it into a canonical record, writes it
+to the durable spool through the commit barrier, and reads it back through the trusted reader to
+verify it round-trips. It initializes the state root first if needed, and each run spools a fresh
+uniquely-named segment (it never mutates or deletes prior spool data).
+
+```console
+$ milhouse --config ./config.toml demo
+demo: spooled 1 record(s) to 2026-08-03/demo-5897ecb7364a4b3f; read-back ok
+
+$ milhouse --config ./config.toml demo --json
+{"batch_id": "demo-...", "day": "2026-08-03", "read_back_ok": true, "records_spooled": 1}
+```
+
+The spooled segment is a self-describing JSONL file under `<state root>/spool/pending/<day>/`, with a
+header (frame/schema versions, batch id, config-generation digest, privacy/retention class, required
+exporters, record count, and the ordered-frame SHA-256) followed by the redacted record frame.
+
 ## Exit codes
 
 | Code | Meaning |
 |---:|---|
-| `0` | Success; `health` reports **healthy**. |
-| `1` | `health` reports **unhealthy**, or `init` could not establish the state root/identity. |
+| `0` | Success; `health` reports **healthy**; `demo` spooled and read back its record. |
+| `1` | `health` reports **unhealthy**, or `init`/`demo` could not establish or exercise the state root. |
 | `2` | The configuration is missing or invalid. |
 
 ## What this is (and is not)
 
 This is a preparatory product vertical built on the accepted W02 (configuration, identity, privacy)
 and W03 (SQLite control state and durable spool) foundations. It is tracked as a roadmap feature and
-does **not** claim the W05 runtime or W06 initialization gates. A spool-only data-flow demo and the
-full CLI surface follow in later increments.
+does **not** claim the W05 runtime or W06 initialization gates. The full CLI surface, real collectors,
+and ClickHouse-backed query follow in later work packages.

--- a/src/milhouse/cli/demo.py
+++ b/src/milhouse/cli/demo.py
@@ -1,0 +1,152 @@
+"""Spool-only ``demo`` for the Milhouse CLI: a credential-free end-to-end data-flow.
+
+Builds one synthetic canary event, redaction-classifies it as a canonical record, writes it to the
+durable spool through the W03 commit barrier, then reads it back through the trusted reader and
+verifies it round-trips. No network, no providers, no ClickHouse — the whole flow is local and
+spool-only. This is a preparatory product vertical on the accepted W02 (records/identity) and W03
+(durable spool) foundations; it does not claim the W05 runtime or W06 gates.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from milhouse.cli import bootstrap
+from milhouse.config import RuntimePaths
+from milhouse.domain.records import (
+    CollectorDescriptorV1,
+    EventDataV1,
+    RecordDraftV1,
+    RecordEnvelopeV1,
+    SourceDescriptorV1,
+    TargetDescriptorV1,
+    finalize_record,
+)
+from milhouse.spooling import (
+    DurableSpool,
+    SegmentHeaderV1,
+    SpoolFrameV1,
+    read_trusted_segment,
+    spool_content_sha256,
+    spool_frame_line,
+)
+from milhouse.state import GlobalCommitBarrier, open_control_database
+
+#: A fixed synthetic configuration-generation digest for the demo segment (64 lowercase hex).
+_DEMO_CONFIG_GENERATION = "d" * 64
+_DEMO_NAMESPACE = "mh_ns1_00000000000040008000000000000000"
+_DEMO_RETENTION_DAYS = 30
+
+
+@dataclass(frozen=True, slots=True)
+class DemoReport:
+    """The outcome of one spool-only demo pass."""
+
+    batch_id: str
+    day: str
+    records_spooled: int
+    read_back_ok: bool
+
+
+def _demo_record(installation_id: str, *, now: datetime) -> RecordEnvelopeV1:
+    """Finalize one synthetic 'site canary healthy' event into a canonical record."""
+
+    source = SourceDescriptorV1.model_validate(
+        {
+            "id": "demo-canary-source",
+            "type": "source.event",
+            "producer": "collector",
+            "observation_namespace_id": _DEMO_NAMESPACE,
+            "source_generation_digest": "0" * 64,
+            "observation": {"kind": "source.revision", "parts": {"revision": 1}},
+        }
+    )
+    values: dict[str, object] = {
+        "record_type": "event",
+        "name": "source.event",
+        "occurred_at": now,
+        "observed_at": now + timedelta(seconds=1),
+        "ingested_at": now + timedelta(seconds=2),
+        "expires_at": now + timedelta(days=_DEMO_RETENTION_DAYS),
+        "source_event_id": "demo-canary-1",
+        "operation_id": "demo-operation-1",
+        "collector_run_id": "demo-run-1",
+        "scope": "target",
+        "source": source,
+        "collector": CollectorDescriptorV1(
+            id="demo-canary", type="site.canary", implementation_version="1.0.0"
+        ),
+        "target": TargetDescriptorV1(
+            id="demo-target", name="Demo Target", kind="web.service", environment="demo"
+        ),
+        "severity": "info",
+        "trust_level": "authenticated",
+        "privacy_class": "internal",
+        "redaction_version": "r1-e1",
+        "data": EventDataV1(category="availability", status="healthy", message="ok"),
+    }
+    return finalize_record(RecordDraftV1.model_validate(values), installation_id=installation_id)
+
+
+def _demo_header(batch_id: str, frames: list[SpoolFrameV1]) -> SegmentHeaderV1:
+    lines = [spool_frame_line(frame) for frame in frames]
+    return SegmentHeaderV1(
+        batch_id=batch_id,
+        config_generation=_DEMO_CONFIG_GENERATION,
+        scope="target",
+        target_id="demo-target",
+        privacy_class="internal",
+        retention_days=_DEMO_RETENTION_DAYS,
+        required_exporters=("clickhouse",),
+        record_count=len(frames),
+        content_sha256=spool_content_sha256(lines),
+    )
+
+
+def run_demo(paths: RuntimePaths, *, now: datetime) -> DemoReport:
+    """Initialize if needed, spool one synthetic record through the barrier, and read it back.
+
+    Returns a :class:`DemoReport`; raises :class:`bootstrap.BootstrapError` if the installation
+    identity cannot be established. Each run spools a fresh uniquely-named segment so it is always
+    re-runnable, and never mutates or deletes prior spool data.
+    """
+
+    bootstrap.initialize(paths, now=now)
+    installation_id = bootstrap.read_installation_id(paths)
+    if installation_id is None:  # pragma: no cover - initialize established it just above
+        raise bootstrap.BootstrapError(
+            "MH_DEMO_IDENTITY", "the installation identity is not available"
+        )
+
+    batch_id = "demo-" + uuid.uuid4().hex[:16]
+    record = _demo_record(installation_id, now=now)
+    frames = [SpoolFrameV1(batch_id=batch_id, sequence=1, record=record)]
+    header = _demo_header(batch_id, frames)
+
+    control = paths.state_root / bootstrap.CONTROL_DIRNAME
+    database = open_control_database(bootstrap.database_path(paths))
+    try:
+        barrier = GlobalCommitBarrier(control / bootstrap.BARRIER_NAME)
+        store = DurableSpool(
+            database=database,
+            barrier=barrier,
+            spool_root=paths.spool,
+            installation_id=installation_id,
+        )
+        committed = store.commit_segment(header, frames, committed_at=now)
+        segment_path = paths.spool / "pending" / committed.day / f"{batch_id}.jsonl"
+        parsed = read_trusted_segment(segment_path, installation_id=installation_id)
+        read_back_ok = (
+            len(parsed.frames) == committed.record_count == len(frames)
+            and parsed.frames[0].record.record_id == record.record_id
+        )
+        return DemoReport(
+            batch_id=batch_id,
+            day=committed.day,
+            records_spooled=committed.record_count,
+            read_back_ok=read_back_ok,
+        )
+    finally:
+        database.close()

--- a/src/milhouse/cli/root.py
+++ b/src/milhouse/cli/root.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 
 import click
 from platformdirs import user_config_path, user_data_path
 
 from milhouse import __version__
-from milhouse.cli import bootstrap
+from milhouse.cli import bootstrap, demo
 from milhouse.config import (
     ConfigError,
     RuntimePaths,
@@ -19,6 +18,7 @@ from milhouse.config import (
     load_config,
     resolve_runtime_paths,
 )
+from milhouse.core.clock import SystemClock
 
 
 @dataclass(frozen=True, slots=True, repr=False)
@@ -138,7 +138,7 @@ def init_command(state: CliState, as_json: bool) -> None:
 
     paths = _resolve_paths(state)
     try:
-        report = bootstrap.initialize(paths, now=datetime.now(UTC))
+        report = bootstrap.initialize(paths, now=SystemClock().now())
     except bootstrap.BootstrapError as error:
         raise BootstrapCommandError(error) from None
     if as_json:
@@ -173,7 +173,7 @@ def health_command(context: click.Context, as_json: bool) -> None:
 
     state = context.ensure_object(CliState)
     paths = _resolve_paths(state)
-    report = bootstrap.health(paths, now=datetime.now(UTC))
+    report = bootstrap.health(paths, now=SystemClock().now())
     if as_json:
         click.echo(
             json.dumps(
@@ -192,4 +192,38 @@ def health_command(context: click.Context, as_json: bool) -> None:
             click.echo(f"[{'ok' if check.ok else 'FAIL'}] {check.name}: {check.detail}")
         click.echo(f"status: {report.status}")
     if not report.healthy:
+        context.exit(1)
+
+
+@main.command(name="demo")
+@click.option("--json", "as_json", is_flag=True, help="Emit the result as stable JSON.")
+@click.pass_context
+def demo_command(context: click.Context, as_json: bool) -> None:
+    """Run a credential-free, spool-only end-to-end data-flow demo."""
+
+    state = context.ensure_object(CliState)
+    paths = _resolve_paths(state)
+    try:
+        report = demo.run_demo(paths, now=SystemClock().now())
+    except bootstrap.BootstrapError as error:
+        raise BootstrapCommandError(error) from None
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "batch_id": report.batch_id,
+                    "day": report.day,
+                    "records_spooled": report.records_spooled,
+                    "read_back_ok": report.read_back_ok,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        outcome = "ok" if report.read_back_ok else "FAILED"
+        click.echo(
+            f"demo: spooled {report.records_spooled} record(s) to "
+            f"{report.day}/{report.batch_id}; read-back {outcome}"
+        )
+    if not report.read_back_ok:
         context.exit(1)

--- a/tests/unit/test_cli_demo.py
+++ b/tests/unit/test_cli_demo.py
@@ -1,0 +1,108 @@
+"""Tests for the spool-only ``demo`` data-flow command."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from milhouse.cli import bootstrap, demo
+from milhouse.cli.root import main
+from milhouse.config import RuntimePaths, load_config, resolve_runtime_paths
+
+_NOW = datetime(2026, 8, 3, 12, 0, 0, tzinfo=UTC)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLE_CONFIG = (_REPO_ROOT / "config" / "example.toml").read_text(encoding="utf-8")
+
+
+def _config_file(tmp_path: Path) -> Path:
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    config_file = config_dir / "config.toml"
+    config_file.write_text(_EXAMPLE_CONFIG, encoding="utf-8")
+    return config_file
+
+
+def _paths(tmp_path: Path) -> RuntimePaths:
+    config_file = _config_file(tmp_path)
+    config, config_path = load_config(config_file, platform_default=config_file)
+    return resolve_runtime_paths(
+        config, config_path=config_path, platform_data_root=tmp_path / "platform"
+    )
+
+
+def test_demo_spools_one_record_and_reads_it_back(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+
+    report = demo.run_demo(paths, now=_NOW)
+
+    assert report.records_spooled == 1
+    assert report.read_back_ok is True
+    assert report.batch_id.startswith("demo-")
+    assert report.day == "2026-08-03"
+    segment = paths.spool / "pending" / report.day / f"{report.batch_id}.jsonl"
+    assert segment.is_file()
+
+
+def test_demo_initializes_a_fresh_state_root(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    # No prior init: demo must establish the control plane and identity itself.
+    assert not bootstrap.database_path(paths).is_file()
+
+    demo.run_demo(paths, now=_NOW)
+
+    assert bootstrap.database_path(paths).is_file()
+    assert bootstrap.read_installation_id(paths) is not None
+
+
+def test_demo_is_rerunnable_with_distinct_segments(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+
+    first = demo.run_demo(paths, now=_NOW)
+    second = demo.run_demo(paths, now=_NOW)
+
+    assert first.batch_id != second.batch_id
+    assert first.read_back_ok and second.read_back_ok
+    day_dir = paths.spool / "pending" / first.day
+    spooled = {p.stem for p in day_dir.glob("demo-*.jsonl")}
+    assert {first.batch_id, second.batch_id} <= spooled
+
+
+def test_demo_record_is_bound_to_the_installation_identity(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    bootstrap.initialize(paths, now=_NOW)
+    installation_id = bootstrap.read_installation_id(paths)
+    assert installation_id is not None
+
+    # Building the record with the established identity succeeds and derives a record id.
+    record = demo._demo_record(installation_id, now=_NOW)
+    assert record.record_id.startswith("mh_")
+
+
+# --- CLI surface ---------------------------------------------------------------------------------
+
+
+def test_cli_demo_reports_success(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["--config", str(config_file), "demo"])
+    assert result.exit_code == 0
+    assert "read-back ok" in result.output
+    assert "spooled 1 record" in result.output
+
+
+def test_cli_demo_json_is_stable(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["--config", str(config_file), "demo", "--json"])
+    assert result.exit_code == 0
+    assert '"read_back_ok": true' in result.output
+    assert '"records_spooled": 1' in result.output
+
+
+def test_cli_demo_reports_config_error_with_exit_code_two(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.toml"
+    runner = CliRunner()
+    result = runner.invoke(main, ["--config", str(missing), "demo"])
+    assert result.exit_code == 2


### PR DESCRIPTION
## Summary

Completes the **first runnable product slice** (Closes #109). With `milhouse init` + `milhouse health` (PR #111) and now **`milhouse demo`**, a user can run the whole local data path end to end:

```
$ milhouse --config ./config.toml demo
demo: spooled 1 record(s) to 2026-08-03/demo-5897ecb7364a4b3f; read-back ok
$ milhouse --config ./config.toml demo --json
{"batch_id":"demo-...","day":"2026-08-03","read_back_ok":true,"records_spooled":1}
```

`demo` builds one synthetic "site canary healthy" event → classifies it into a canonical record → writes it to the durable spool through the commit barrier → reads it back through the trusted reader and verifies the record round-trips. No network, credentials, or ClickHouse. It initializes the state root first if needed, and each run spools a fresh uniquely-named segment (never mutating or deleting prior spool data). The spooled segment is a real self-describing JSONL file with a header (versions, batch id, config-generation digest, privacy/retention class, exporters, record count, ordered-frame SHA-256) plus the redacted record frame.

## Changes

- `src/milhouse/cli/demo.py` — `run_demo` + the synthetic record/segment builders, on the W02 domain (`finalize_record`) and W03 spool (`DurableSpool.commit_segment` → `read_trusted_segment`).
- `src/milhouse/cli/root.py` — the `demo` command, and `init`/`health`/`demo` now source time from the canonical **`SystemClock`** (aware UTC, truncated to milliseconds) which the domain record contract requires (raw `datetime.now` sub-millisecond precision is rejected).
- `tests/unit/test_cli_demo.py` — 7 tests: spool + read-back, fresh-state init, re-runnable distinct segments, identity-bound record, CLI exit codes + stable JSON (`demo.py` 100% covered).
- `docs/quickstart.md` — the demo walkthrough.

## Design notes

Preparatory product vertical on the accepted **W02**/**W03** foundations — honestly **not** a W05 runtime or W06 gate claim, and it adds **no** migration or stored-contract change. The demo's canary event is fully synthetic; the record is bound to the installation identity established by `init`.

## Validation

- Quality: PASS (ruff, strict mypy, config-validation, links 71 files/300 links/80 probes, workflow, zizmor, skills).
- Coverage: PASS (exit 0) — `line 97.87% / branch 96.84%`, 57 critical files; `demo.py` 100% covered (full suite green).
- Verified live end-to-end (`demo`, `demo --json`, re-run, health-after-demo, on-disk segment inspected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
