### PR TITLE
feat(cli): add local inspect commands (spool, events, doctor)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -77,12 +77,30 @@ The spooled segment is a self-describing JSONL file under `<state root>/spool/pe
 header (frame/schema versions, batch id, config-generation digest, privacy/retention class, required
 exporters, record count, and the ordered-frame SHA-256) followed by the redacted record frame.
 
+## 5. Inspect what you spooled
+
+These commands are read-only and report privacy-safe **metadata only** — never the raw record
+payload — consistent with the local-query egress policy.
+
+```console
+$ milhouse --config ./config.toml spool list
+2026-08-03/demo-4eaebcb4...  records=1 bytes=1854 class=internal origin=committed delivered=False
+
+$ milhouse --config ./config.toml events
+mh_bkjjxhze...  event/source.event occurred=2026-08-03T21:12:51.732Z expires=... target=demo-target class=internal severity=info
+
+$ milhouse --config ./config.toml spool show demo-4eaebcb4...   # one segment's header + record metadata
+$ milhouse --config ./config.toml doctor                        # health + spool totals; nonzero exit on a problem
+```
+
+Add `--json` to any of them for a stable machine-readable form.
+
 ## Exit codes
 
 | Code | Meaning |
 |---:|---|
-| `0` | Success; `health` reports **healthy**; `demo` spooled and read back its record. |
-| `1` | `health` reports **unhealthy**, or `init`/`demo` could not establish or exercise the state root. |
+| `0` | Success; `health`/`doctor` report **healthy**; `demo` spooled and read back its record. |
+| `1` | `health`/`doctor` report a problem; `init`/`demo` could not establish or exercise the state root; or an inspect command was run before `init`. |
 | `2` | The configuration is missing or invalid. |
 
 ## What this is (and is not)

--- a/src/milhouse/cli/root.py
+++ b/src/milhouse/cli/root.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import click
 from platformdirs import user_config_path, user_data_path
 
 from milhouse import __version__
-from milhouse.cli import bootstrap, demo
+from milhouse.cli import bootstrap, demo, views
 from milhouse.config import (
     ConfigError,
     RuntimePaths,
@@ -226,4 +226,141 @@ def demo_command(context: click.Context, as_json: bool) -> None:
             f"{report.day}/{report.batch_id}; read-back {outcome}"
         )
     if not report.read_back_ok:
+        context.exit(1)
+
+
+def _require_installation_id(paths: RuntimePaths) -> str:
+    installation_id = bootstrap.read_installation_id(paths)
+    if installation_id is None:
+        raise BootstrapCommandError(
+            bootstrap.BootstrapError("MH_NOT_INITIALIZED", "run milhouse init first")
+        )
+    return installation_id
+
+
+@main.group(name="spool")
+def spool_group() -> None:
+    """Inspect committed spool segments (read-only)."""
+
+
+@spool_group.command(name="list")
+@click.option("--json", "as_json", is_flag=True, help="Emit the listing as stable JSON.")
+@click.pass_obj
+def spool_list_command(state: CliState, as_json: bool) -> None:
+    """List every committed spool segment with privacy-safe metadata."""
+
+    paths = _resolve_paths(state)
+    segments = views.list_segments(paths)
+    if as_json:
+        click.echo(json.dumps([asdict(segment) for segment in segments], sort_keys=True))
+        return
+    if not segments:
+        click.echo("no committed segments")
+        return
+    for segment in segments:
+        click.echo(
+            f"{segment.day}/{segment.batch_id}  records={segment.record_count} "
+            f"bytes={segment.byte_size} class={segment.privacy_class} "
+            f"origin={segment.origin} delivered={segment.delivered}"
+        )
+
+
+@spool_group.command(name="show")
+@click.argument("batch_id")
+@click.option("--json", "as_json", is_flag=True, help="Emit the detail as stable JSON.")
+@click.pass_context
+def spool_show_command(context: click.Context, batch_id: str, as_json: bool) -> None:
+    """Show one segment's header summary and per-record metadata."""
+
+    state = context.ensure_object(CliState)
+    paths = _resolve_paths(state)
+    installation_id = _require_installation_id(paths)
+    detail = views.show_segment(paths, batch_id, installation_id)
+    if detail is None:
+        click.echo(f"no segment {batch_id}")
+        context.exit(1)
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "summary": asdict(detail.summary),
+                    "readable": detail.readable,
+                    "events": [asdict(event) for event in detail.events],
+                },
+                sort_keys=True,
+            )
+        )
+        return
+    summary = detail.summary
+    click.echo(
+        f"segment {summary.day}/{summary.batch_id}: records={summary.record_count} "
+        f"bytes={summary.byte_size} class={summary.privacy_class} origin={summary.origin} "
+        f"delivered={summary.delivered} readable={detail.readable}"
+    )
+    for event in detail.events:
+        click.echo(
+            f"  {event.record_id} {event.record_type}/{event.name} "
+            f"occurred={event.occurred_at} expires={event.expires_at} "
+            f"target={event.target_id} severity={event.severity}"
+        )
+
+
+@main.command(name="events")
+@click.option("--json", "as_json", is_flag=True, help="Emit the events as stable JSON.")
+@click.pass_context
+def events_command(context: click.Context, as_json: bool) -> None:
+    """Read spooled records back and list their privacy-safe metadata."""
+
+    state = context.ensure_object(CliState)
+    paths = _resolve_paths(state)
+    installation_id = _require_installation_id(paths)
+    events = views.read_events(paths, installation_id)
+    if as_json:
+        click.echo(json.dumps([asdict(event) for event in events], sort_keys=True))
+        return
+    if not events:
+        click.echo("no spooled records")
+        return
+    for event in events:
+        click.echo(
+            f"{event.record_id} {event.record_type}/{event.name} "
+            f"occurred={event.occurred_at} expires={event.expires_at} "
+            f"target={event.target_id} class={event.privacy_class} severity={event.severity}"
+        )
+
+
+@main.command(name="doctor")
+@click.option("--json", "as_json", is_flag=True, help="Emit the diagnostic as stable JSON.")
+@click.pass_context
+def doctor_command(context: click.Context, as_json: bool) -> None:
+    """Run a richer redacted diagnostic (health plus spool totals); exit non-zero on a problem."""
+
+    state = context.ensure_object(CliState)
+    paths = _resolve_paths(state)
+    report = views.doctor(paths, now=SystemClock().now())
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "ok": report.ok,
+                    "health": {
+                        "status": report.health.status,
+                        "checks": [asdict(check) for check in report.health.checks],
+                    },
+                    "segment_count": report.segment_count,
+                    "record_count": report.record_count,
+                    "spool_readable": report.spool_readable,
+                },
+                sort_keys=True,
+            )
+        )
+    else:
+        for check in report.health.checks:
+            click.echo(f"[{'ok' if check.ok else 'FAIL'}] {check.name}: {check.detail}")
+        click.echo(
+            f"spool: segments={report.segment_count} records={report.record_count} "
+            f"readable={report.spool_readable}"
+        )
+        click.echo(f"status: {'ok' if report.ok else 'problem'}")
+    if not report.ok:
         context.exit(1)

--- a/src/milhouse/cli/views.py
+++ b/src/milhouse/cli/views.py
@@ -1,0 +1,196 @@
+"""Read-only local views over spooled state for the Milhouse CLI (W06 inspect commands).
+
+``spool list`` / ``spool show``, ``events``, and ``doctor`` read the durable spool and control
+ledger and report privacy-safe *metadata only* — never the raw record payload — consistent with the
+local-query egress policy (plan section 4.7). Everything here is local and read-only: no network, no
+mutation, no secret resolution. A preparatory W06 vertical on the accepted W02/W03 foundations; it
+does not claim a gate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from milhouse.cli import bootstrap
+from milhouse.config import RuntimePaths
+from milhouse.core.clock import format_timestamp
+from milhouse.spooling import ParsedSegment, SpoolError, read_trusted_segment
+from milhouse.spooling.ledger import (
+    SegmentRecord,
+    list_segment_records,
+    read_segment_record,
+)
+from milhouse.state import open_control_database
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentSummary:
+    """Privacy-safe ledger summary of one committed spool segment."""
+
+    batch_id: str
+    day: str
+    record_count: int
+    byte_size: int
+    privacy_class: str
+    scope: str
+    target_id: str | None
+    origin: str
+    delivered: bool
+
+
+@dataclass(frozen=True, slots=True)
+class EventSummary:
+    """Privacy-safe metadata for one spooled record (no raw payload)."""
+
+    batch_id: str
+    record_id: str
+    record_type: str
+    name: str
+    occurred_at: str
+    expires_at: str
+    target_id: str | None
+    privacy_class: str
+    severity: str
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentDetail:
+    """One segment's summary plus its per-record metadata, when the file is readable."""
+
+    summary: SegmentSummary
+    readable: bool
+    events: tuple[EventSummary, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class DoctorReport:
+    """A richer redacted diagnostic: health plus spool totals."""
+
+    health: bootstrap.HealthReport
+    segment_count: int
+    record_count: int
+    spool_readable: bool
+
+    @property
+    def ok(self) -> bool:
+        return self.health.healthy and self.spool_readable
+
+
+def _delivered(record: SegmentRecord) -> bool:
+    return bool(record.exporters) and all(
+        exporter.delivery_status == "delivered" for exporter in record.exporters
+    )
+
+
+def _summary(record: SegmentRecord) -> SegmentSummary:
+    return SegmentSummary(
+        batch_id=record.batch_id,
+        day=record.day,
+        record_count=record.record_count,
+        byte_size=record.byte_size,
+        privacy_class=record.privacy_class,
+        scope=record.scope,
+        target_id=record.target_id,
+        origin=record.origin,
+        delivered=_delivered(record),
+    )
+
+
+def _segment_path(paths: RuntimePaths, record: SegmentRecord) -> Path:
+    return paths.spool / "pending" / record.day / f"{record.batch_id}.jsonl"
+
+
+def _segments(paths: RuntimePaths) -> tuple[SegmentRecord, ...]:
+    database = open_control_database(bootstrap.database_path(paths))
+    try:
+        return list_segment_records(database)
+    finally:
+        database.close()
+
+
+def _events_of(record: SegmentRecord, parsed: ParsedSegment) -> list[EventSummary]:
+    events: list[EventSummary] = []
+    for frame in parsed.frames:
+        envelope = frame.record
+        events.append(
+            EventSummary(
+                batch_id=record.batch_id,
+                record_id=envelope.record_id,
+                record_type=envelope.record_type,
+                name=envelope.name,
+                occurred_at=format_timestamp(envelope.occurred_at),
+                expires_at=format_timestamp(envelope.expires_at),
+                target_id=envelope.target.id if envelope.target is not None else None,
+                privacy_class=envelope.privacy_class,
+                severity=envelope.severity,
+            )
+        )
+    return events
+
+
+def list_segments(paths: RuntimePaths) -> tuple[SegmentSummary, ...]:
+    """Return a privacy-safe summary of every committed segment in the ledger."""
+
+    return tuple(_summary(record) for record in _segments(paths))
+
+
+def read_events(paths: RuntimePaths, installation_id: str) -> tuple[EventSummary, ...]:
+    """Read every committed segment back through the trusted reader; return record metadata.
+
+    An unreadable or disagreeing segment is skipped rather than raising, so one bad file never hides
+    the rest.
+    """
+
+    events: list[EventSummary] = []
+    for record in _segments(paths):
+        try:
+            parsed = read_trusted_segment(
+                _segment_path(paths, record), installation_id=installation_id
+            )
+        except SpoolError:
+            continue
+        events.extend(_events_of(record, parsed))
+    return tuple(events)
+
+
+def show_segment(paths: RuntimePaths, batch_id: str, installation_id: str) -> SegmentDetail | None:
+    """Return one segment's summary and record metadata, or ``None`` if it is not in the ledger."""
+
+    database = open_control_database(bootstrap.database_path(paths))
+    try:
+        record = read_segment_record(database, batch_id)
+    finally:
+        database.close()
+    if record is None:
+        return None
+    try:
+        parsed = read_trusted_segment(_segment_path(paths, record), installation_id=installation_id)
+    except SpoolError:
+        return SegmentDetail(summary=_summary(record), readable=False, events=())
+    return SegmentDetail(
+        summary=_summary(record), readable=True, events=tuple(_events_of(record, parsed))
+    )
+
+
+def doctor(paths: RuntimePaths, *, now: datetime) -> DoctorReport:
+    """Report health plus spool totals, never mutating and never raising on a bad spool."""
+
+    health = bootstrap.health(paths, now=now)
+    segment_count = 0
+    record_count = 0
+    spool_readable = True
+    if bootstrap.database_path(paths).is_file():
+        try:
+            records = _segments(paths)
+            segment_count = len(records)
+            record_count = sum(record.record_count for record in records)
+        except Exception:  # pragma: no cover - defensive: a diagnostic reports, never raises
+            spool_readable = False
+    return DoctorReport(
+        health=health,
+        segment_count=segment_count,
+        record_count=record_count,
+        spool_readable=spool_readable,
+    )

--- a/tests/unit/test_cli_views.py
+++ b/tests/unit/test_cli_views.py
@@ -1,0 +1,179 @@
+"""Tests for the read-only local inspect surface: spool/events/doctor."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from milhouse.cli import bootstrap, demo, views
+from milhouse.cli.root import main
+from milhouse.config import RuntimePaths, load_config, resolve_runtime_paths
+
+_NOW = datetime(2026, 8, 3, 12, 0, 0, tzinfo=UTC)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLE_CONFIG = (_REPO_ROOT / "config" / "example.toml").read_text(encoding="utf-8")
+
+
+def _config_file(tmp_path: Path) -> Path:
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    config_file = config_dir / "config.toml"
+    config_file.write_text(_EXAMPLE_CONFIG, encoding="utf-8")
+    return config_file
+
+
+def _paths(tmp_path: Path) -> RuntimePaths:
+    config_file = _config_file(tmp_path)
+    config, config_path = load_config(config_file, platform_default=config_file)
+    return resolve_runtime_paths(
+        config, config_path=config_path, platform_data_root=tmp_path / "platform"
+    )
+
+
+def test_list_segments_reports_spooled_segments(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    first = demo.run_demo(paths, now=_NOW)
+    demo.run_demo(paths, now=_NOW)
+
+    segments = views.list_segments(paths)
+
+    assert len(segments) == 2
+    batch_ids = {segment.batch_id for segment in segments}
+    assert first.batch_id in batch_ids
+    one = next(segment for segment in segments if segment.batch_id == first.batch_id)
+    assert one.record_count == 1
+    assert one.privacy_class == "internal"
+    assert one.origin == "committed"
+    assert one.byte_size > 0
+
+
+def test_list_segments_is_empty_before_any_spooling(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    bootstrap.initialize(paths, now=_NOW)
+    assert views.list_segments(paths) == ()
+
+
+def test_read_events_returns_record_metadata(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    demo.run_demo(paths, now=_NOW)
+    installation_id = bootstrap.read_installation_id(paths)
+    assert installation_id is not None
+
+    events = views.read_events(paths, installation_id)
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.record_id.startswith("mh_")
+    assert event.record_type == "event"
+    assert event.name == "source.event"
+    assert event.target_id == "demo-target"
+    assert event.privacy_class == "internal"
+    assert event.occurred_at.endswith("Z")
+
+
+def test_read_events_skips_an_unreadable_segment(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    report = demo.run_demo(paths, now=_NOW)
+    installation_id = bootstrap.read_installation_id(paths)
+    assert installation_id is not None
+    # Corrupt the durable file: the trusted reader rejects it and the event is skipped, not raised.
+    segment = paths.spool / "pending" / report.day / f"{report.batch_id}.jsonl"
+    segment.write_bytes(b"not a valid segment")
+
+    assert views.read_events(paths, installation_id) == ()
+
+
+def test_show_segment_returns_detail_and_none_for_missing(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    report = demo.run_demo(paths, now=_NOW)
+    installation_id = bootstrap.read_installation_id(paths)
+    assert installation_id is not None
+
+    detail = views.show_segment(paths, report.batch_id, installation_id)
+    assert detail is not None
+    assert detail.readable is True
+    assert detail.summary.batch_id == report.batch_id
+    assert len(detail.events) == 1
+
+    assert views.show_segment(paths, "demo-does-not-exist", installation_id) is None
+
+
+def test_show_segment_reports_an_unreadable_file(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    report = demo.run_demo(paths, now=_NOW)
+    installation_id = bootstrap.read_installation_id(paths)
+    assert installation_id is not None
+    (paths.spool / "pending" / report.day / f"{report.batch_id}.jsonl").write_bytes(b"corrupt")
+
+    detail = views.show_segment(paths, report.batch_id, installation_id)
+    assert detail is not None
+    assert detail.readable is False
+    assert detail.events == ()
+
+
+def test_doctor_reports_health_and_spool_totals(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    demo.run_demo(paths, now=_NOW)
+    demo.run_demo(paths, now=_NOW)
+
+    report = views.doctor(paths, now=_NOW)
+
+    assert report.ok is True
+    assert report.segment_count == 2
+    assert report.record_count == 2
+    assert report.spool_readable is True
+
+
+def test_doctor_is_unhealthy_before_init(tmp_path: Path) -> None:
+    paths = _paths(tmp_path)
+    report = views.doctor(paths, now=_NOW)
+    assert report.ok is False
+    assert report.segment_count == 0
+
+
+# --- CLI surface ---------------------------------------------------------------------------------
+
+
+def test_cli_spool_list_and_events_and_doctor(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "demo"])
+
+    listing = runner.invoke(main, ["--config", str(config_file), "spool", "list"])
+    assert listing.exit_code == 0
+    assert "records=1" in listing.output
+
+    events = runner.invoke(main, ["--config", str(config_file), "events", "--json"])
+    assert events.exit_code == 0
+    assert '"record_type": "event"' in events.output
+
+    doctor = runner.invoke(main, ["--config", str(config_file), "doctor"])
+    assert doctor.exit_code == 0
+    assert "status: ok" in doctor.output
+
+
+def test_cli_spool_list_empty(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+    result = runner.invoke(main, ["--config", str(config_file), "spool", "list"])
+    assert result.exit_code == 0
+    assert "no committed segments" in result.output
+
+
+def test_cli_events_requires_init(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(main, ["--config", str(config_file), "events"])
+    assert result.exit_code == 1
+
+
+def test_cli_spool_show_missing_exits_nonzero(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+    result = runner.invoke(main, ["--config", str(config_file), "spool", "show", "demo-nope"])
+    assert result.exit_code == 1
+    assert "no segment" in result.output


### PR DESCRIPTION
## Summary

Adds read-only **local inspect commands**, building directly on the merged `init`/`health`/`demo` slice — users can now *see* the records they spooled. Closes #113.

- **`milhouse spool list`** — every committed segment with privacy-safe metadata (day/batch id, record count, bytes, class, origin, delivered).
- **`milhouse spool show BATCH_ID`** — one segment's header summary + per-record metadata.
- **`milhouse events`** — reads spooled records back through the trusted reader and lists their metadata (record id, type/name, occurred/expires, target, class, severity).
- **`milhouse doctor`** — a richer redacted diagnostic: health checks + spool totals; non-zero exit on a problem.

Verified live end-to-end (spooled 2 demo records, then listed/read/showed them):
```
$ milhouse spool list
2026-08-03/demo-4eae...  records=1 bytes=1854 class=internal origin=committed delivered=False
$ milhouse events
mh_bkjjxhze...  event/source.event occurred=2026-08-03T21:12:51.732Z expires=... target=demo-target class=internal severity=info
$ milhouse doctor
... spool: segments=2 records=2 readable=True / status: ok
```

## Privacy & scope

Everything is **local and read-only** — no network, no mutation, no secret resolution. It reports **privacy-safe metadata only** (structural fields), **never the raw record payload**, consistent with the local-query egress policy (plan §4.7); an unreadable/disagreeing segment is skipped or flagged, never raised. A preparatory **W06** vertical on the accepted W02/W03 foundations — **not** a gate claim, and no migration or stored-contract change. Every command supports `--json`; inspect before `init` exits `1`.

## Validation

- Quality: PASS (ruff, strict mypy on 6 CLI files, config-validation, links, workflow, zizmor, skills).
- Coverage: PASS (exit 0) — `line 97.80% / branch 96.60%`, 57 critical files; `views.py` 100% covered (full suite green).
- Tests: `tests/unit/test_cli_views.py` (12) — listing (with/empty), read-back metadata, unreadable-segment skip, missing/unreadable segment, doctor totals, and CLI exit codes + stable JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
