### PR TITLE
feat(storage): W04 enforce one installation per ClickHouse (fail-closed ownership guard) (#127)

### DIFF
--- a/ops/clickhouse/README.md
+++ b/ops/clickhouse/README.md
@@ -33,6 +33,36 @@ $ milhouse --config ./config.toml storage status    # read-only: applied vs pend
 $ milhouse --config ./config.toml storage migrate    # apply the packaged migrations
 ```
 
+## One ClickHouse per installation (enforced)
+
+Milhouse's single-writer correctness rests on a machine-local commit barrier that fences exactly one
+installation's writers. That barrier cannot see a **second** installation — a different state root,
+clone, or host — pointed at the **same** ClickHouse, so two installations sharing one destination
+would silently comingle and corrupt each other's data. The supported model is therefore **one
+ClickHouse per installation**, and it is **enforced fail-closed**:
+
+- `storage migrate` **claims** the destination for the local installation (a single-owner
+  `_installation` row). A first migrate stamps ownership; a re-run by the same installation verifies.
+- `storage export`, `storage backup`, and `storage restore` **refuse to run** unless the destination
+  is owned by the local installation. A second installation pointed at a claimed destination — or a
+  restore of another installation's backup, whose restored owner row names that other installation —
+  fails closed with `MH_STORAGE_OWNERSHIP` (exit 1) rather than writing or comingling data.
+- An **unclaimed** destination (never migrated) likewise refuses export/backup: run `storage migrate`
+  first.
+- On **upgrade of a pre-existing destination** (one migrated before this guard existed, so it has no
+  `_installation` row yet), the **first** installation to `storage migrate` claims it — ownership is
+  attributed to whoever migrates first, not retroactively to the original writer. In the supported
+  one-per-destination model that is the sole rightful install; a destination that was already
+  (incorrectly) shared is taken back by the rightful owner with `--reclaim`.
+
+To **deliberately re-point** an installation at a new ClickHouse host (or take over a destination that
+was claimed by an installation you are decommissioning), migrate with `--reclaim`, which supersedes
+the prior owner:
+
+```console
+$ milhouse --config ./config.toml storage migrate --reclaim    # take ownership of this destination
+```
+
 ## Back up and restore (native BACKUP/RESTORE)
 
 This deployment provisions a ClickHouse `backups` disk in `config.d/backups.xml` (declared under
@@ -51,6 +81,12 @@ $ milhouse --config ./config.toml storage restore nightly_2026_08_10     # RESTO
   `storage restore` refuses (issuing no drop and no restore) if the analytical database already holds
   a schema. Restore into a clean/fresh state root, or after intentionally dropping the lost database.
   In-place **overwrite with rollback is deferred to W16** — this command never overwrites live data.
+- **A foreign or failed restore leaves the destination populated.** If the restored backup was taken
+  by a *different* installation (its `_installation` owner row names another install), `storage
+  restore` fails closed (`MH_STORAGE_RESTORE`, exit 1) **after** the native `RESTORE` has already
+  materialized that data into the (empty) target. Recovering the clean precondition is a **manual
+  `DROP DATABASE`** — automatic rollback of a failed/foreign restore is deferred to W16. (Restoring
+  your OWN backup verifies its owner row and proceeds.)
 - **Retention and permissions.** The `backups` volume grows with each archive; rotate and remove old
   archives on your own schedule (there is no automatic pruning here). The directory is written by the
   ClickHouse server user inside the container and is loopback-only — never exposed off-host. Treat

--- a/src/milhouse/cli/root.py
+++ b/src/milhouse/cli/root.py
@@ -502,9 +502,14 @@ def storage_plan_command(state: CliState, as_json: bool) -> None:
 
 
 @storage_group.command(name="migrate")
+@click.option(
+    "--reclaim",
+    is_flag=True,
+    help="Take ownership of a destination currently claimed by another installation.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit the result as stable JSON.")
 @click.pass_obj
-def storage_migrate_command(state: CliState, as_json: bool) -> None:
+def storage_migrate_command(state: CliState, reclaim: bool, as_json: bool) -> None:
     """Apply every pending migration in order under the exclusive commit barrier; refuse a tamper.
 
     The whole apply runs while THIS installation's control-plane commit lock is held EXCLUSIVELY, so
@@ -516,13 +521,25 @@ def storage_migrate_command(state: CliState, as_json: bool) -> None:
     altered applied checksum is still refused. Requires an initialized control plane (the commit
     lock lives under its control dir).
 
+    After the migrations apply (so the ``_installation`` control table exists), this CLAIMS the
+    destination for THIS installation: "one ClickHouse per installation" is the supported model, and
+    the claim makes the local commit barrier a correct single-writer exclusion. A first migrate
+    stamps the local installation as owner; a re-run by the same installation verifies (a no-op). A
+    destination already owned by a DIFFERENT installation is refused fail-closed (exit 1) UNLESS
+    ``--reclaim`` is given — a deliberate re-point (moving this install to a new ClickHouse host),
+    which supersedes the prior owner. On UPGRADE of a pre-existing destination migrated before this
+    guard existed (no ``_installation`` row yet), the first install to migrate claims it — ownership
+    is attributed to whoever migrates first, not retroactively to the original writer; in the
+    supported one-per-destination model that is the sole rightful install, and a destination already
+    (incorrectly) shared is taken back by the rightful owner with ``--reclaim``.
+
     NOTE: this fence holds only because ``storage export`` is the SOLE production ClickHouse writer
     and it delivers under ``barrier.shared()``. ANY future ClickHouse writer MUST likewise take the
     shared side of this same commit lock, or it could race a migration and lose data.
     """
 
     paths = _resolve_paths(state)
-    _require_installation_id(paths)  # the commit lock lives under an initialized control dir
+    installation_id = _require_installation_id(paths)  # the commit lock lives under a control dir
     database, client = _storage_client(state)
     barrier = GlobalCommitBarrier(
         paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
@@ -532,10 +549,27 @@ def storage_migrate_command(state: CliState, as_json: bool) -> None:
             result = storage.migrate(
                 client, database, now=SystemClock().now(), milhouse_version=__version__
             )
+            # The migrations above provisioned ``_installation``; read the prior owner (to report
+            # claimed vs verified vs reclaimed), then stamp/verify this installation's ownership.
+            prior_owner = storage.read_owner(client, database)
+            storage.claim(
+                client,
+                database,
+                installation_id=installation_id,
+                now=SystemClock().now(),
+                milhouse_version=__version__,
+                reclaim=reclaim,
+            )
     except storage.StorageError as error:
         raise StorageCommandError(error) from None
     finally:
         client.close()
+    if prior_owner is None:
+        ownership = "claimed"
+    elif prior_owner == installation_id:
+        ownership = "verified"
+    else:
+        ownership = "reclaimed"
     if as_json:
         click.echo(
             json.dumps(
@@ -544,6 +578,7 @@ def storage_migrate_command(state: CliState, as_json: bool) -> None:
                     "applied_now": list(result.applied_now),
                     "already_applied": list(result.already_applied),
                     "current_version": result.current_version,
+                    "ownership": ownership,
                 },
                 sort_keys=True,
             )
@@ -552,7 +587,7 @@ def storage_migrate_command(state: CliState, as_json: bool) -> None:
     click.echo(
         f"migrate: applied {len(result.applied_now)} migration(s) "
         f"({len(result.already_applied)} already applied); "
-        f"schema at version {result.current_version}"
+        f"schema at version {result.current_version}; ownership {ownership}"
     )
 
 
@@ -577,13 +612,17 @@ def storage_backup_command(state: CliState, destination: str, as_json: bool) -> 
     """
 
     paths = _resolve_paths(state)
-    _require_installation_id(paths)  # the commit lock lives under an initialized control dir
+    installation_id = _require_installation_id(paths)  # the commit lock lives under a control dir
     database, client = _storage_client(state)
     barrier = GlobalCommitBarrier(
         paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
     )
     try:
         with barrier.exclusive():
+            # Refuse to back up a destination this installation does not own (fail closed): the
+            # supported model is one ClickHouse per installation, and a foreign or unclaimed
+            # destination is not this installation's data to snapshot.
+            storage.require_owner(client, database, installation_id=installation_id)
             snapshot = storage.snapshot_state(client, database)
             client.command(storage.backup_statement(database, destination))
     except storage.StorageError as error:
@@ -631,8 +670,11 @@ def storage_restore_command(context: click.Context, source: str, as_json: bool) 
     (``reconcile_delivered``) — every spool segment the surviving SQLite ledger marks ``delivered``
     to ``clickhouse`` has all of its record ids PRESENT in the restored store (a subset check, not
     full record-id-set equality — that stricter proof needs the W16 backup manifest).
-    Feedback-state parity is deferred to G16. Requires an initialized control plane; any mismatch
-    exits non-zero with the fixed ``MH_STORAGE_RESTORE`` code.
+    Feedback-state parity is deferred to G16. It ALSO fails closed if the restored ``_installation``
+    owner row names a DIFFERENT installation (a cross-installation restore is unsupported): the
+    foreign data has already materialized into the (proven-empty) target and the clean precondition
+    is recovered by a manual ``DROP DATABASE`` (automatic rollback is W16). Requires an initialized
+    control plane; any mismatch exits non-zero with the fixed ``MH_STORAGE_RESTORE``.
 
     OFFLINE/LIVE boundary: this proves the barrier fence, the empty-target guard, the statements,
     the schema-validity + bounded-reconcile wiring, and the exit codes offline against a fake
@@ -670,6 +712,25 @@ def storage_restore_command(context: click.Context, source: str, as_json: bool) 
                     raise storage.StorageError(
                         "MH_STORAGE_RESTORE",
                         "the restore did not bring the current analytical schema",
+                    )
+                # The restored database carries the backup's ``_installation`` owner row (migration
+                # 0006 is at the current head gated just above, so the row is present). A restore of
+                # THIS installation's own backup verifies and proceeds; a restore of ANOTHER
+                # installation's backup is refused fail-closed. This deliberately does NOT route
+                # through ``require_owner``: that error's "--reclaim on migrate" guidance is WRONG
+                # for a restore -- reclaiming would ADOPT the foreign backup, the very comingling
+                # this guard prevents. The foreign slice has already materialized into the target
+                # proven empty above, and in-place overwrite/rollback is W16, so the clean
+                # precondition is recovered by a manual DROP DATABASE (named in the error and
+                # ops/clickhouse/README.md), never by an automatic drop here.
+                restored_owner = storage.read_owner(client, database)
+                if restored_owner != installation_id:
+                    raise storage.StorageError(
+                        "MH_STORAGE_RESTORE",
+                        "the restored backup was taken by a different installation; a "
+                        "cross-installation restore is not supported -- DROP this database to "
+                        "restore the empty precondition, then restore a backup taken by this "
+                        "installation",
                     )
                 restored = storage.snapshot_state(client, database)
                 storage.reconcile_delivered(
@@ -735,6 +796,18 @@ def storage_export_command(context: click.Context, as_json: bool) -> None:
     try:
         database, client = _storage_client(state)
         try:
+            # Refuse to deliver to a destination this installation does not own (fail closed): the
+            # supported model is one ClickHouse per installation, so a second install pointed at a
+            # claimed destination — or an unclaimed one — must not write it. This read barrier makes
+            # the local commit barrier a correct single-writer exclusion.
+            #
+            # Placed BEFORE the shared commit barrier (which replay_segments takes internally) on
+            # purpose: the only actor sharing this per-state-root barrier is THIS install, whose id
+            # is our own, so it cannot reclaim the destination away from itself; a DIFFERENT install
+            # has its own barrier and is fenced by this op-time check regardless of ordering. So
+            # — unlike backup/restore, which check inside their exclusive scope because they hold it
+            # the whole operation — the placement here is a correctness no-op vs the barrier.
+            storage.require_owner(client, database, installation_id=installation_id)
             barrier = GlobalCommitBarrier(
                 paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
             )

--- a/src/milhouse/resources/manifest.json
+++ b/src/milhouse/resources/manifest.json
@@ -9,6 +9,7 @@
     "storage/migrations/0002_records.sql",
     "storage/migrations/0003_feedback.sql",
     "storage/migrations/0004_views.sql",
-    "storage/migrations/0005_feedback_transition_dedup.sql"
+    "storage/migrations/0005_feedback_transition_dedup.sql",
+    "storage/migrations/0006_installation_ownership.sql"
   ]
 }

--- a/src/milhouse/storage/__init__.py
+++ b/src/milhouse/storage/__init__.py
@@ -19,6 +19,7 @@ from milhouse.storage.client import (
 from milhouse.storage.delivery import CLICKHOUSE_EXPORTER_ID, ClickHouseExporter
 from milhouse.storage.errors import StorageError
 from milhouse.storage.exporter import ExportSummary, export_records
+from milhouse.storage.ownership import claim, read_owner, require_owner
 from milhouse.storage.repository import (
     FeedbackStateRow,
     StoredRecordV1,
@@ -52,13 +53,16 @@ __all__ = [
     "StoredRecordV1",
     "backup_statement",
     "build_client",
+    "claim",
     "export_records",
     "fetch_current_feedback",
     "fetch_current_records",
     "fetch_record_ids",
     "migrate",
     "plan",
+    "read_owner",
     "reconcile_delivered",
+    "require_owner",
     "restore_statement",
     "snapshot_state",
     "status",

--- a/src/milhouse/storage/errors.py
+++ b/src/milhouse/storage/errors.py
@@ -10,10 +10,11 @@ class StorageError(MilhouseValueError):
 
     Codes: ``MH_STORAGE_MIGRATION`` (migration ledger/checksum/ordering), ``MH_STORAGE_CLIENT``
     (client construction or a driver fault), ``MH_STORAGE_CONFIG`` (missing/invalid storage config
-    or credentials), ``MH_STORAGE_BACKUP`` (native-backup snapshot or statement building), and
+    or credentials), ``MH_STORAGE_BACKUP`` (native-backup snapshot or statement building),
     ``MH_STORAGE_RESTORE`` (a restore-round-trip verification, cross-store reconciliation, or
-    restore statement building). The message never carries a secret, a credential, a raw driver
-    payload, or a machine-local path.
+    restore statement building), and ``MH_STORAGE_OWNERSHIP`` (a ClickHouse destination is owned by
+    another installation, or is unclaimed, when a single-owner claim or write was required). The
+    message never carries a secret, a credential, a raw driver payload, or a machine-local path.
     """
 
     def __init__(self, code: str, message: str) -> None:

--- a/src/milhouse/storage/migrations/0006_installation_ownership.sql
+++ b/src/milhouse/storage/migrations/0006_installation_ownership.sql
@@ -1,0 +1,24 @@
+-- 0006_installation_ownership: enforce ONE installation per ClickHouse destination (fail-closed).
+-- Milhouse's single-writer correctness rests on the local control-plane commit barrier, which fences
+-- exactly one installation's ClickHouse writers. That barrier is a machine-local lock: it cannot see
+-- a SECOND installation -- a different state root, clone, or host -- pointed at the SAME ClickHouse,
+-- so two installations could each believe they hold the single writer while silently comingling and
+-- corrupting each other's analytical data. This table records the ONE installation that owns this
+-- destination: a single logical row at id = 1 holding the owning installation id, the instant it was
+-- claimed, and the Milhouse version that claimed it. storage migrate stamps it (--reclaim supersedes
+-- a prior owner to deliberately re-point an install at a new host), and storage export/backup/restore
+-- refuse to run unless this destination is owned by the local installation. ReplacingMergeTree keyed
+-- on claimed_at collapses to the single newest claim, so a reclaim is one more insert that supersedes
+-- on merge -- never a second logical owner; a FINAL read observes the current owner before merges run.
+-- The {database} placeholder is substituted by the runner with the validated configuration identifier;
+-- the table is created idempotently so a re-run after a partial apply is safe. Retention is never
+-- shortened and no live row is dropped.
+CREATE TABLE IF NOT EXISTS {database}._installation
+(
+    id UInt8,
+    installation_id String,
+    claimed_at DateTime64(3, 'UTC'),
+    milhouse_version String
+)
+ENGINE = ReplacingMergeTree(claimed_at)
+ORDER BY id;

--- a/src/milhouse/storage/ownership.py
+++ b/src/milhouse/storage/ownership.py
@@ -1,0 +1,181 @@
+"""Installation-ownership guard for the ClickHouse analytical store (W04, plan section 4.5).
+
+Milhouse's single-writer correctness rests on the local control-plane commit barrier
+(:class:`~milhouse.state.GlobalCommitBarrier`), which serializes exactly ONE installation's
+ClickHouse writers. That barrier is a machine-local lock: it cannot fence a SECOND installation --
+a different state root, clone, or host -- pointed at the SAME ClickHouse. Two such installs would
+each hold the single-writer lock while silently comingling and corrupting each other's data. The
+supported model is therefore "one ClickHouse per installation", and this module makes it an
+enforced, fail-closed invariant: a second installation is REFUSED rather than allowed to corrupt
+the store.
+
+Migration ``0006`` provisions the single-owner control table ``{database}._installation`` -- one
+logical row at ``id = 1`` under ``ReplacingMergeTree(claimed_at)`` so the newest claim supersedes on
+merge -- and this API reads and stamps it over the same small
+:class:`~milhouse.storage.client.ClickHouseClient` seam the runner uses, so its logic is fully
+unit-testable against a fake client with no network:
+
+* :func:`read_owner` -- the current owning installation id, or ``None`` when the destination is
+  unclaimed (no database or ``_installation`` table, or an empty table). It never raises on an
+  unmigrated destination, mirroring the runner's existence-guarded ledger read, so a fresh
+  deployment can be probed safely.
+* :func:`claim` -- stamp the local installation as owner (``storage migrate``). An unclaimed
+  destination is stamped; an already-owned destination is a no-op for the SAME id; a DIFFERENT id
+  fails closed ``MH_STORAGE_OWNERSHIP`` unless ``reclaim`` is set, which inserts a superseding claim
+  to deliberately re-point an installation at a new destination.
+* :func:`require_owner` -- the read barrier every write/restore op takes
+  (``storage export``/``backup``/``restore``). A DIFFERENT owner OR an unclaimed destination fails
+  closed ``MH_STORAGE_OWNERSHIP``.
+
+Every failure is a fixed, privacy-safe :class:`~milhouse.storage.errors.StorageError` carrying the
+``MH_STORAGE_OWNERSHIP`` code and no secret, credential, driver payload, or machine-local path. The
+owning installation id is the non-secret ``mh_in1_`` record-identity id (plan section 4.2); it is
+validated as a bounded token before it is written, because -- like a database name -- it is a
+structural literal in the single-row claim statement and cannot be server-side parameter-bound.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from milhouse.core.clock import TimeError, truncate_to_milliseconds
+from milhouse.storage._identifiers import require_identifier
+from milhouse.storage.client import ClickHouseClient
+from milhouse.storage.errors import StorageError
+
+_OWNERSHIP_CODE = "MH_STORAGE_OWNERSHIP"
+_INSTALLATION_TABLE = "_installation"
+#: The single logical owner row's fixed primary key; ReplacingMergeTree keeps only the newest claim.
+_OWNER_ROW_ID = 1
+#: The non-secret ``mh_in1_`` record-identity shape (plan section 4.2): the prefix plus a uuid4 hex
+#: payload. Validated before interpolation so only this bounded token can ever reach the claim
+#: statement -- a malformed or hostile id fails closed rather than forming part of a statement.
+_INSTALLATION_ID = re.compile(r"mh_in1_[0-9a-f]{32}", flags=re.ASCII)
+
+_OTHER_OWNER_MESSAGE = (
+    "this ClickHouse destination is owned by another installation; "
+    "use --reclaim on migrate to take ownership"
+)
+_UNCLAIMED_MESSAGE = "the ClickHouse destination is unclaimed; run `storage migrate` first"
+
+
+def _validate_database(database: object) -> str:
+    return require_identifier(
+        database,
+        code=_OWNERSHIP_CODE,
+        message="a bounded ClickHouse database identifier is required",
+    )
+
+
+def _validate_installation_id(installation_id: object) -> str:
+    if type(installation_id) is not str or _INSTALLATION_ID.fullmatch(installation_id) is None:
+        raise StorageError(_OWNERSHIP_CODE, "a valid installation id is required")
+    return installation_id
+
+
+def _timestamp(now: datetime) -> str:
+    try:
+        normalized = truncate_to_milliseconds(now)
+    except (TimeError, OverflowError, AttributeError, TypeError):
+        raise StorageError(
+            _OWNERSHIP_CODE, "the ownership timestamp must be an aware in-range UTC instant"
+        ) from None
+    return normalized.strftime("%Y-%m-%d %H:%M:%S.") + f"{normalized.microsecond // 1000:03d}"
+
+
+def _database_exists(client: ClickHouseClient, database: str) -> bool:
+    rows = client.query(f"SELECT count() FROM system.databases WHERE name = '{database}'")
+    return bool(rows) and int(rows[0][0]) > 0
+
+
+def _table_exists(client: ClickHouseClient, database: str, table: str) -> bool:
+    rows = client.query(
+        f"SELECT count() FROM system.tables WHERE database = '{database}' AND name = '{table}'"
+    )
+    return bool(rows) and int(rows[0][0]) > 0
+
+
+def read_owner(client: ClickHouseClient, database: str) -> str | None:
+    """Return the installation id that owns ``database``, or ``None`` if it is unclaimed.
+
+    Returns ``None`` -- never raises -- when the database or the ``_installation`` table does not
+    exist yet (an unmigrated/absent destination) or the table holds no claim, mirroring the runner's
+    existence-guarded ledger read. Otherwise it reads the single owner row through ``FINAL`` so the
+    newest claim is observed even before a ReplacingMergeTree merge has run. The database name is
+    validated as a bounded identifier (it is structural and cannot be parameter-bound); no value is
+    interpolated by this read.
+    """
+
+    database = _validate_database(database)
+    if not _database_exists(client, database) or not _table_exists(
+        client, database, _INSTALLATION_TABLE
+    ):
+        return None
+    rows = client.query(
+        f"SELECT installation_id FROM {database}.{_INSTALLATION_TABLE} FINAL "
+        f"WHERE id = {_OWNER_ROW_ID}"
+    )
+    if not rows:
+        return None
+    owner = str(rows[0][0])
+    return owner or None
+
+
+def claim(
+    client: ClickHouseClient,
+    database: str,
+    *,
+    installation_id: str,
+    now: datetime,
+    milhouse_version: str,
+    reclaim: bool = False,
+) -> None:
+    """Stamp ``installation_id`` as the owner of ``database``; fail closed on a conflicting owner.
+
+    Called by ``storage migrate`` AFTER the migrations apply, so the ``_installation`` table exists.
+    An unclaimed destination is stamped with the claim row. An already-owned destination is a no-op
+    when the recorded owner is the SAME installation. A DIFFERENT recorded owner fails closed
+    ``MH_STORAGE_OWNERSHIP`` UNLESS ``reclaim`` is set (a re-point to a new host), in which case a
+    superseding claim row is inserted and the ReplacingMergeTree keeps it as the current owner.
+
+    The single-row claim is written with :meth:`~milhouse.storage.client.ClickHouseClient.command`
+    exactly as the migration ledger writes its rows; the ``installation_id`` is validated as a
+    bounded ``mh_in1_`` token first, so only that token -- not untrusted content -- is interpolated.
+    """
+
+    database = _validate_database(database)
+    installation_id = _validate_installation_id(installation_id)
+    current = read_owner(client, database)
+    if current is not None:
+        if current == installation_id:
+            return  # already owned by this installation; nothing to stamp
+        if not reclaim:
+            raise StorageError(_OWNERSHIP_CODE, _OTHER_OWNER_MESSAGE)
+    stamp = _timestamp(now)
+    columns = "id, installation_id, claimed_at, milhouse_version"
+    values = f"({_OWNER_ROW_ID}, '{installation_id}', '{stamp}', '{milhouse_version}')"
+    client.command(f"INSERT INTO {database}.{_INSTALLATION_TABLE} ({columns}) VALUES {values}")
+
+
+def require_owner(client: ClickHouseClient, database: str, *, installation_id: str) -> None:
+    """Fail closed unless ``database`` is owned by the local ``installation_id``.
+
+    The read barrier ``storage export``/``backup``/``restore`` take before touching the store: a
+    DIFFERENT owner or an UNCLAIMED destination raises ``MH_STORAGE_OWNERSHIP`` (with the
+    "use --reclaim on migrate" or "run ``storage migrate`` first" guidance), and returns ``None``
+    only when the local installation owns it. This is what refuses a second installation pointed at
+    another installation's ClickHouse -- including a restore of another installation's backup, whose
+    restored ``_installation`` row names that other owner.
+    """
+
+    database = _validate_database(database)
+    installation_id = _validate_installation_id(installation_id)
+    owner = read_owner(client, database)
+    if owner is None:
+        raise StorageError(_OWNERSHIP_CODE, _UNCLAIMED_MESSAGE)
+    if owner != installation_id:
+        raise StorageError(_OWNERSHIP_CODE, _OTHER_OWNER_MESSAGE)
+
+
+__all__ = ["claim", "read_owner", "require_owner"]

--- a/src/milhouse/storage/schema.py
+++ b/src/milhouse/storage/schema.py
@@ -22,6 +22,7 @@ _MIGRATION_FILES: tuple[tuple[int, str, str], ...] = (
     (3, "feedback", "0003_feedback.sql"),
     (4, "views", "0004_views.sql"),
     (5, "feedback_transition_dedup", "0005_feedback_transition_dedup.sql"),
+    (6, "installation_ownership", "0006_installation_ownership.sql"),
 )
 
 

--- a/tests/live/test_clickhouse_smoke.py
+++ b/tests/live/test_clickhouse_smoke.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -39,12 +39,15 @@ from milhouse.storage import (
     StorageError,
     backup_statement,
     build_client,
+    claim,
     export_records,
     fetch_current_feedback,
     fetch_current_records,
     migrate,
     plan,
+    read_owner,
     reconcile_delivered,
+    require_owner,
     restore_statement,
     snapshot_state,
     status,
@@ -107,8 +110,8 @@ def test_live_fresh_migrate_status_idempotent_and_checksum_enforcement() -> None
         assert plan(client, _SMOKE_DB).current_version == 0  # fresh deployment
 
         result = migrate(client, _SMOKE_DB, now=datetime.now(UTC), milhouse_version="live-smoke")
-        assert result.current_version == 5  # migrated to the full schema
-        assert status(client, _SMOKE_DB).current_version == 5  # status reports it
+        assert result.current_version == 6  # migrated to the full schema
+        assert status(client, _SMOKE_DB).current_version == 6  # status reports it
 
         again = migrate(client, _SMOKE_DB, now=datetime.now(UTC), milhouse_version="live-smoke")
         assert again.applied_now == ()  # idempotent
@@ -263,7 +266,7 @@ def test_live_native_backup_restore_round_trips_and_reconciles(tmp_path: Path) -
         )
 
         source = snapshot_state(client, _SMOKE_DB)
-        assert source.migration_version == 5
+        assert source.migration_version == 6
         assert record.record_id in source.record_ids
 
         # Drive the real DR restore SEQUENCE the ``storage restore`` command performs (backup → DROP
@@ -289,4 +292,51 @@ def test_live_native_backup_restore_round_trips_and_reconciles(tmp_path: Path) -
         client.command(f"DROP DATABASE IF EXISTS {_SMOKE_DB}")
         if control is not None:
             control.close()
+        client.close()
+
+
+@_requires_live
+def test_live_installation_ownership_claims_and_rejects_a_cross_installation() -> None:
+    # The installation-ownership guard against a REAL ClickHouse: a fresh migrate provisions the
+    # ``_installation`` table, a claim stamps the owner, the same installation verifies, and a
+    # DIFFERENT installation is refused fail-closed for both a require-check and a claim — unless it
+    # deliberately reclaims, which supersedes the prior owner (ReplacingMergeTree(claimed_at)).
+    client = build_client(_config(), _secrets())
+    id_a = "mh_in1_" + "a" * 32
+    id_b = "mh_in1_" + "b" * 32
+    try:
+        client.command(f"DROP DATABASE IF EXISTS {_SMOKE_DB}")
+        now = datetime.now(UTC)
+        migrate(client, _SMOKE_DB, now=now, milhouse_version="live-smoke")
+        assert read_owner(client, _SMOKE_DB) is None  # migrated but unclaimed
+
+        claim(client, _SMOKE_DB, installation_id=id_a, now=now, milhouse_version="live-smoke")
+        assert read_owner(client, _SMOKE_DB) == id_a
+        require_owner(client, _SMOKE_DB, installation_id=id_a)  # the owner is admitted (no raise)
+        # A same-id re-claim is an idempotent no-op.
+        claim(client, _SMOKE_DB, installation_id=id_a, now=now, milhouse_version="live-smoke")
+        assert read_owner(client, _SMOKE_DB) == id_a
+
+        # A different installation is refused fail-closed on both the read barrier and a claim.
+        with pytest.raises(StorageError) as required:
+            require_owner(client, _SMOKE_DB, installation_id=id_b)
+        assert required.value.code == "MH_STORAGE_OWNERSHIP"
+        with pytest.raises(StorageError) as claimed:
+            claim(client, _SMOKE_DB, installation_id=id_b, now=now, milhouse_version="live-smoke")
+        assert claimed.value.code == "MH_STORAGE_OWNERSHIP"
+        assert read_owner(client, _SMOKE_DB) == id_a  # unchanged by the refused claim
+
+        # A deliberate --reclaim supersedes the prior owner; a strictly later claimed_at wins.
+        claim(
+            client,
+            _SMOKE_DB,
+            installation_id=id_b,
+            now=now + timedelta(seconds=1),
+            milhouse_version="live-smoke",
+            reclaim=True,
+        )
+        assert read_owner(client, _SMOKE_DB) == id_b
+        require_owner(client, _SMOKE_DB, installation_id=id_b)
+    finally:
+        client.command(f"DROP DATABASE IF EXISTS {_SMOKE_DB}")
         client.close()

--- a/tests/packaging/test_package_resources.py
+++ b/tests/packaging/test_package_resources.py
@@ -22,6 +22,7 @@ def test_typed_resource_inventory_is_installed() -> None:
         "storage/migrations/0003_feedback.sql",
         "storage/migrations/0004_views.sql",
         "storage/migrations/0005_feedback_transition_dedup.sql",
+        "storage/migrations/0006_installation_ownership.sql",
     }
     for migration in (
         "0001_core",
@@ -29,5 +30,6 @@ def test_typed_resource_inventory_is_installed() -> None:
         "0003_feedback",
         "0004_views",
         "0005_feedback_transition_dedup",
+        "0006_installation_ownership",
     ):
         assert package_root.joinpath("storage", "migrations", f"{migration}.sql").is_file()

--- a/tests/packaging/test_storage_migrations_packaged.py
+++ b/tests/packaging/test_storage_migrations_packaged.py
@@ -12,6 +12,7 @@ _MIGRATION_FILES = (
     "0003_feedback.sql",
     "0004_views.sql",
     "0005_feedback_transition_dedup.sql",
+    "0006_installation_ownership.sql",
 )
 
 

--- a/tests/unit/_storage_fakes.py
+++ b/tests/unit/_storage_fakes.py
@@ -2,10 +2,18 @@
 
 It recognizes exactly the query/command shapes the storage layer emits — ``system.databases`` /
 ``system.tables`` existence probes, the ledger SELECT, ``CREATE DATABASE``/``CREATE TABLE``/
-``CREATE VIEW`` DDL, the ledger ``INSERT``, the native ``BACKUP``/``RESTORE``/``DROP DATABASE``
-commands, and the raw ``SELECT record_id FROM <db>.records`` shape — and records the resulting
-state, so the runner's ordering/checksum/non-mutation logic AND the backup verification core can be
-exercised with no network.
+``CREATE VIEW`` DDL, the ledger ``INSERT``, the ``_installation`` ownership SELECT/INSERT, the
+native ``BACKUP``/``RESTORE``/``DROP DATABASE`` commands, and the raw
+``SELECT record_id FROM <db>.records`` shape — and records the resulting state, so the runner's
+ordering/checksum/non-mutation logic, the installation-ownership guard, AND the backup verification
+core can be exercised with no network.
+
+The single-owner ``_installation`` table is modelled per client instance as the current owning
+installation id per database (the ``owners`` map), so one shared fake stands in for one ClickHouse
+destination that two distinct installations can be pointed at — the exact shape the ownership guard
+must distinguish. A later ``_installation`` INSERT supersedes the owner, mirroring
+``ReplacingMergeTree(claimed_at)`` keeping the newest claim, and the owner travels with a
+``BACKUP``/``RESTORE`` of the database slice.
 
 Backup fidelity is modelled only at the level of logical STATE — which databases/tables exist, the
 migration ledger rows, and the ``insert()`` calls (hence each ``records`` row's ``record_id``). A
@@ -30,11 +38,15 @@ _LEDGER_SELECT = re.compile(r"SELECT version, name, checksum FROM (\w+)\._migrat
 # ``\brecords\b`` matches the raw records table but NOT ``records_current`` (``_`` is a word
 # character, so no word boundary falls between ``records`` and ``_current``).
 _RECORD_IDS = re.compile(r"SELECT record_id FROM (\w+)\.records\b")
+_OWNER_SELECT = re.compile(r"SELECT installation_id FROM (\w+)\._installation FINAL")
 _CREATE_DB = re.compile(r"CREATE DATABASE IF NOT EXISTS (\w+)")
 _CREATE_OBJ = re.compile(r"CREATE (?:TABLE|VIEW) IF NOT EXISTS (\w+)\.(\w+)")
 _INSERT = re.compile(
     r"INSERT INTO (\w+)\._migrations \([^)]*\) VALUES "
     r"\((\d+), '([^']*)', '([^']*)', '[^']*', '[^']*'\)"
+)
+_OWNER_INSERT = re.compile(
+    r"INSERT INTO (\w+)\._installation \([^)]*\) VALUES \(\d+, '([^']*)', '[^']*', '[^']*'\)"
 )
 _BACKUP = re.compile(r"BACKUP DATABASE (\w+) TO Disk\('\w+', '(\w+)'\)")
 _RESTORE = re.compile(r"RESTORE DATABASE (\w+) FROM Disk\('\w+', '(\w+)'\)")
@@ -54,6 +66,9 @@ class FakeClickHouseClient:
         self.tables: set[tuple[str, str]] = set()
         # database -> {version: (name, checksum)}
         self.ledger: dict[str, dict[int, tuple[str, str]]] = {}
+        # database -> current owning installation id (the single-owner ``_installation`` row); a
+        # later INSERT supersedes it, mirroring ReplacingMergeTree(claimed_at) keeping the newest.
+        self.owners: dict[str, str] = {}
         self.commands: list[str] = []
         # every insert() call: (database, table, rows, column_names)
         self.inserts: list[Insert] = []
@@ -75,6 +90,7 @@ class FakeClickHouseClient:
             "exists": database in self.databases,
             "tables": {table for table in self.tables if table[0] == database},
             "ledger": dict(self.ledger.get(database, {})),
+            "owner": self.owners.get(database),
             "inserts": [row for row in self.inserts if row[0] == database],
         }
 
@@ -82,10 +98,13 @@ class FakeClickHouseClient:
         self.databases.discard(database)
         self.tables = {table for table in self.tables if table[0] != database}
         self.ledger.pop(database, None)
+        self.owners.pop(database, None)
         self.inserts = [row for row in self.inserts if row[0] != database]
 
     def _apply_snapshot(self, database: str, snapshot: _DatabaseSnapshot | None) -> None:
-        # RESTORE replaces the database slice with the backed-up one (drop, then re-materialize).
+        # RESTORE replaces the database slice with the backed-up one (drop, then re-materialize). A
+        # backup's ``_installation`` owner travels with it, so restoring another install's backup
+        # materializes THAT installation's owner — exactly what the restore guard must reject.
         self._drop_database(database)
         if snapshot is None:
             return  # restoring an unknown archive materializes nothing (empty slice)
@@ -94,6 +113,8 @@ class FakeClickHouseClient:
         self.tables |= set(snapshot["tables"])
         if snapshot["ledger"]:
             self.ledger[database] = dict(snapshot["ledger"])
+        if snapshot["owner"] is not None:
+            self.owners[database] = snapshot["owner"]
         self.inserts.extend(snapshot["inserts"])
 
     def command(self, statement: str) -> None:
@@ -110,6 +131,11 @@ class FakeClickHouseClient:
         if insert is not None:
             db, version, name, checksum = insert.groups()
             self.ledger.setdefault(db, {})[int(version)] = (name, checksum)
+            return
+        owner_insert = _OWNER_INSERT.search(statement)
+        if owner_insert is not None:
+            # A later claim supersedes the owner (ReplacingMergeTree(claimed_at) keeps the newest).
+            self.owners[owner_insert.group(1)] = owner_insert.group(2)
             return
         backup = _BACKUP.search(statement)
         if backup is not None:
@@ -152,6 +178,10 @@ class FakeClickHouseClient:
         record_ids = _RECORD_IDS.search(statement)
         if record_ids is not None:
             return [[value] for value in self._record_ids(record_ids.group(1))]
+        owner = _OWNER_SELECT.search(statement)
+        if owner is not None:
+            claimed = self.owners.get(owner.group(1))
+            return [[claimed]] if claimed is not None else []
         raise AssertionError(f"unexpected query: {statement}")
 
     def _record_ids(self, database: str) -> list[str]:

--- a/tests/unit/test_cli_storage.py
+++ b/tests/unit/test_cli_storage.py
@@ -31,18 +31,34 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _EXAMPLE_CONFIG = (_REPO_ROOT / "config" / "example.toml").read_text(encoding="utf-8")
 
 
-def _config(tmp_path: Path, *, enabled: bool = True) -> Path:
+def _config(
+    tmp_path: Path, *, enabled: bool = True, subdir: str = "cfg", home: str = "../data"
+) -> Path:
     # Drop the secret env-file reference (the client/secrets are stubbed in these tests).
     text = _EXAMPLE_CONFIG.replace('env_files = ["../.env"]', "env_files = []")
     if not enabled:
         text = text.replace(
             "[storage.clickhouse]\nenabled = true", "[storage.clickhouse]\nenabled = false"
         )
-    config_dir = tmp_path / "cfg"
+    if home != "../data":
+        text = text.replace('home = "../data"', f'home = "{home}"')
+    config_dir = tmp_path / subdir
     config_dir.mkdir()
     config_file = config_dir / "config.toml"
     config_file.write_text(text, encoding="utf-8")
     return config_file
+
+
+def _second_config(tmp_path: Path) -> Path:
+    # A SECOND installation (its own state root ``tmp_path/data2``) sharing the same monkeypatched
+    # fake ClickHouse — the shape the guard must distinguish: one destination, two installs.
+    return _config(tmp_path, subdir="cfg2", home="../data2")
+
+
+def _run_migrate(config: Path) -> Result:
+    # Claim/verify ownership of the (fake) ClickHouse by applying the migrations — the realistic
+    # precondition for export/backup/restore now that those refuse an unclaimed/foreign destination.
+    return CliRunner().invoke(main, ["--config", str(config), "storage", "migrate"])
 
 
 def _paths(config: Path) -> RuntimePaths:
@@ -116,16 +132,17 @@ def test_cli_storage_status_then_migrate(tmp_path: Path, _stub: FakeClickHouseCl
 
     status = runner.invoke(main, ["--config", str(config), "storage", "status"])
     assert status.exit_code == 0
-    assert "pending=5" in status.output
+    assert "pending=6" in status.output
     assert _stub.databases == set()  # status did not mutate
 
     migrated = runner.invoke(main, ["--config", str(config), "storage", "migrate"])
     assert migrated.exit_code == 0
-    assert "version 5" in migrated.output
+    assert "version 6" in migrated.output
+    assert "ownership claimed" in migrated.output  # a first migrate stamps this install as owner
 
     after = runner.invoke(main, ["--config", str(config), "storage", "status", "--json"])
     assert after.exit_code == 0
-    assert '"current_version": 5' in after.output
+    assert '"current_version": 6' in after.output
 
 
 def test_cli_storage_plan_is_read_only(tmp_path: Path, _stub: FakeClickHouseClient) -> None:
@@ -141,8 +158,9 @@ def test_cli_storage_migrate_json(tmp_path: Path, _stub: FakeClickHouseClient) -
     _init_paths(config)  # migrate fences under the commit barrier (needs init)
     result = CliRunner().invoke(main, ["--config", str(config), "storage", "migrate", "--json"])
     assert result.exit_code == 0
-    assert '"applied_now": [1, 2, 3, 4, 5]' in result.output
-    assert '"current_version": 5' in result.output
+    assert '"applied_now": [1, 2, 3, 4, 5, 6]' in result.output
+    assert '"current_version": 6' in result.output
+    assert '"ownership": "claimed"' in result.output
 
 
 def test_cli_storage_migrate_requires_an_initialized_control_plane(
@@ -207,7 +225,7 @@ def test_cli_storage_migrate_is_fenced_by_the_exclusive_commit_barrier(
     result = captured["result"]
     assert isinstance(result, Result)
     assert result.exit_code == 0
-    assert "version 5" in result.output  # it did migrate, once unblocked
+    assert "version 6" in result.output  # it did migrate, once unblocked
 
 
 def test_cli_storage_disabled_is_an_error(tmp_path: Path, _stub: FakeClickHouseClient) -> None:
@@ -252,6 +270,7 @@ def test_cli_storage_export_delivers_committed_segments(
 ) -> None:
     config = _config(tmp_path)
     _spool_one_pending_segment(config)
+    assert _run_migrate(config).exit_code == 0  # claim ownership before exporting
 
     result = CliRunner().invoke(main, ["--config", str(config), "storage", "export"])
 
@@ -268,6 +287,7 @@ def test_cli_storage_export_over_an_empty_ledger_is_zero(
     # An initialized install with no committed segments drains nothing and writes nothing.
     config = _config(tmp_path)
     assert CliRunner().invoke(main, ["--config", str(config), "init"]).exit_code == 0
+    assert _run_migrate(config).exit_code == 0  # claim ownership before exporting
 
     result = CliRunner().invoke(main, ["--config", str(config), "storage", "export", "--json"])
 
@@ -284,6 +304,7 @@ def test_cli_storage_export_is_idempotent_already_delivered_no_reinsert(
 ) -> None:
     config = _config(tmp_path)
     _spool_one_pending_segment(config)
+    assert _run_migrate(config).exit_code == 0  # claim ownership before exporting
     assert CliRunner().invoke(main, ["--config", str(config), "storage", "export"]).exit_code == 0
     inserts_after_first = len(_stub.inserts)
 
@@ -310,6 +331,9 @@ def test_cli_storage_export_failed_delivery_is_fail_loud_and_nonzero(
     monkeypatch.setattr(root.storage, "build_client", lambda config, secrets: raising)
     config = _config(tmp_path)
     _spool_one_pending_segment(config)
+    # Migrate claims ownership over the raising client (its DDL/ledger/claim run via command(), not
+    # broken by the raising subclass — only insert() raises), so export reaches delivery.
+    assert _run_migrate(config).exit_code == 0
 
     result = CliRunner().invoke(main, ["--config", str(config), "storage", "export"])
 
@@ -333,14 +357,19 @@ def test_cli_storage_export_recovers_a_failed_segment_on_the_next_run(
     # Outage: the insert raises → the segment is left retryable "failed", export exits non-zero.
     raising = _RaisingClient()
     monkeypatch.setattr(root.storage, "build_client", lambda config, secrets: raising)
+    assert (
+        _run_migrate(config).exit_code == 0
+    )  # claim ownership (command-based, survives the outage)
     outage = CliRunner().invoke(main, ["--config", str(config), "storage", "export"])
     assert outage.exit_code == 1
     assert "failed=1" in outage.output
     assert raising.inserts == []
 
-    # Recovery: a healthy client on the next run redelivers the previously-failed segment once.
+    # Recovery: a healthy client on the next run redelivers the previously-failed segment once. It
+    # models the SAME recovered ClickHouse, so it too is migrated + claimed by this installation.
     healthy = FakeClickHouseClient()
     monkeypatch.setattr(root.storage, "build_client", lambda config, secrets: healthy)
+    assert _run_migrate(config).exit_code == 0
     recovered = CliRunner().invoke(main, ["--config", str(config), "storage", "export"])
     assert recovered.exit_code == 0
     assert (
@@ -358,6 +387,7 @@ def test_cli_storage_export_notes_expired_withheld_segments(
     # must be observable: an informational stderr NOTE, so the withholding is never silent.
     config = _config(tmp_path)
     _spool_one_pending_segment(config)  # records expire ~30 days after real now
+    assert _run_migrate(config).exit_code == 0  # claim ownership before exporting
     # Export far past the records' expiry so the hard-expiry gate withholds the segment.
     future = datetime.now(UTC) + timedelta(days=60)
     monkeypatch.setattr(root, "SystemClock", lambda: _FixedClock(future))
@@ -379,6 +409,7 @@ def test_cli_storage_export_reports_a_segment_with_an_empty_exporter_set_as_unha
     # attempts.
     config = _config(tmp_path)
     _commit_segment(_init_paths(config), "batch-no-obligation", ())
+    assert _run_migrate(config).exit_code == 0  # claim ownership before exporting
 
     result = CliRunner().invoke(main, ["--config", str(config), "storage", "export"])
 
@@ -397,6 +428,7 @@ def test_cli_storage_export_reports_a_segment_with_only_another_exporter_as_unha
     # pinned so the drain is deterministic (the attempt is ``no_exporter``, never ``expired``).
     config = _config(tmp_path)
     _commit_segment(_init_paths(config), "batch-webhook-only", ("webhook",))
+    assert _run_migrate(config).exit_code == 0  # claim ownership before exporting
     monkeypatch.setattr(root, "SystemClock", lambda: _FixedClock(NOW))
 
     result = CliRunner().invoke(main, ["--config", str(config), "storage", "export"])
@@ -419,6 +451,7 @@ def test_cli_storage_export_mixed_delivered_and_unhandled_scopes_records_and_exi
     paths = _init_paths(config)
     _commit_segment(paths, "batch-clickhouse", ("clickhouse",))
     _commit_segment(paths, "batch-no-obligation", ())
+    assert _run_migrate(config).exit_code == 0  # claim ownership before exporting
     monkeypatch.setattr(root, "SystemClock", lambda: _FixedClock(NOW))
 
     result = CliRunner().invoke(main, ["--config", str(config), "storage", "export"])
@@ -449,6 +482,7 @@ def test_cli_storage_export_records_count_is_confirmed_egress_only(
     # (a) The insert raises before any row lands → the segment is failed and CONFIRMED records is 0.
     raising = _RaisingClient()
     monkeypatch.setattr(root.storage, "build_client", lambda config, secrets: raising)
+    assert _run_migrate(config).exit_code == 0  # claim ownership before exporting
     text_a = CliRunner().invoke(main, ["--config", str(config), "storage", "export"])
     assert text_a.exit_code == 1
     assert (
@@ -469,9 +503,11 @@ def test_cli_storage_export_records_count_is_confirmed_egress_only(
     assert raising.inserts == []
 
     # (b) A healthy retry delivers the SAME segment → its records now appear in the confirmed count
-    # exactly once (as delivered now, then already_delivered on the idempotent re-run).
+    # exactly once (delivered now, then already_delivered on the idempotent re-run). The recovered
+    # ClickHouse is migrated + claimed by this installation before the retry.
     healthy = FakeClickHouseClient()
     monkeypatch.setattr(root.storage, "build_client", lambda config, secrets: healthy)
+    assert _run_migrate(config).exit_code == 0
     text_b = CliRunner().invoke(main, ["--config", str(config), "storage", "export"])
     assert text_b.exit_code == 0
     assert (
@@ -602,7 +638,7 @@ def test_cli_storage_backup_then_dr_restore_into_empty_db(
     assert _json_payload(backup.output) == {
         "database": "milhouse",
         "destination": "backup_one",
-        "migration_version": 5,
+        "migration_version": 6,
         "record_count": 1,
     }
     assert any(command.startswith("BACKUP DATABASE milhouse") for command in _stub.commands)
@@ -615,7 +651,7 @@ def test_cli_storage_backup_then_dr_restore_into_empty_db(
     assert restore.exit_code == 0
     assert _json_payload(restore.output) == {
         "database": "milhouse",
-        "migration_version": 5,
+        "migration_version": 6,
         "reconciled": True,
         "record_count": 1,
         "source": "backup_one",
@@ -706,6 +742,8 @@ def test_cli_storage_backup_is_fenced_by_the_exclusive_commit_barrier(
     # during a REAL backup" proof is host-gated (E06); here we prove the mutual exclusion.
     config = _config(tmp_path)
     paths = _init_paths(config)
+    assert _run_migrate(config).exit_code == 0  # claim ownership so the backup passes require_owner
+    _stub.commands.clear()  # observe only the commands the fenced backup itself issues
     barrier = GlobalCommitBarrier(
         paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
     )
@@ -767,3 +805,153 @@ def test_cli_storage_restore_requires_an_initialized_control_plane(
     result = CliRunner().invoke(main, ["--config", str(config), "storage", "restore", "backup_one"])
     assert result.exit_code == 1
     assert _stub.commands == []
+
+
+# --- installation-ownership guard (one ClickHouse per installation, fail-closed) ---
+
+
+def test_cli_storage_migrate_claims_then_verifies_ownership(
+    tmp_path: Path, _stub: FakeClickHouseClient
+) -> None:
+    # A first migrate stamps THIS installation as the destination's owner; a re-run by the same
+    # installation verifies (a no-op re-stamp). The owner recorded is the local installation id.
+    config = _config(tmp_path)
+    paths = _init_paths(config)
+    installation_id = bootstrap.read_installation_id(paths)
+
+    first = CliRunner().invoke(main, ["--config", str(config), "storage", "migrate", "--json"])
+    assert first.exit_code == 0
+    assert _json_payload(first.output)["ownership"] == "claimed"
+    assert _stub.owners["milhouse"] == installation_id
+
+    second = CliRunner().invoke(main, ["--config", str(config), "storage", "migrate", "--json"])
+    assert second.exit_code == 0
+    assert _json_payload(second.output)["ownership"] == "verified"
+    assert _stub.owners["milhouse"] == installation_id  # unchanged
+
+
+def test_cli_storage_migrate_by_a_different_installation_is_fail_closed(
+    tmp_path: Path, _stub: FakeClickHouseClient
+) -> None:
+    # Installation A claims the shared (fake) ClickHouse. A SECOND installation B — its own state
+    # root, the same destination — is refused fail-closed, and only takes ownership with --reclaim.
+    config_a = _config(tmp_path)
+    _init_paths(config_a)
+    assert (
+        CliRunner().invoke(main, ["--config", str(config_a), "storage", "migrate"]).exit_code == 0
+    )
+    owner_a = _stub.owners["milhouse"]
+
+    config_b = _second_config(tmp_path)
+    paths_b = _init_paths(config_b)
+    id_b = bootstrap.read_installation_id(paths_b)
+    assert id_b != owner_a  # two distinct installations against one destination
+
+    refused = CliRunner().invoke(main, ["--config", str(config_b), "storage", "migrate"])
+    assert refused.exit_code == 1
+    assert "MH_STORAGE_OWNERSHIP" in refused.output
+    assert _stub.owners["milhouse"] == owner_a  # a refused claim never changed the owner
+
+    reclaimed = CliRunner().invoke(
+        main, ["--config", str(config_b), "storage", "migrate", "--reclaim", "--json"]
+    )
+    assert reclaimed.exit_code == 0
+    assert _json_payload(reclaimed.output)["ownership"] == "reclaimed"
+    assert _stub.owners["milhouse"] == id_b  # --reclaim superseded the prior owner
+
+
+def test_cli_storage_export_by_a_different_installation_is_fail_closed(
+    tmp_path: Path, _stub: FakeClickHouseClient
+) -> None:
+    # A second installation must not deliver to a destination another installation owns.
+    config_a = _config(tmp_path)
+    _init_paths(config_a)
+    assert (
+        CliRunner().invoke(main, ["--config", str(config_a), "storage", "migrate"]).exit_code == 0
+    )
+
+    config_b = _second_config(tmp_path)
+    _init_paths(config_b)
+    result = CliRunner().invoke(main, ["--config", str(config_b), "storage", "export"])
+    assert result.exit_code == 1
+    assert "MH_STORAGE_OWNERSHIP" in result.output
+    assert _stub.inserts == []  # B wrote nothing to A's ClickHouse
+
+
+def test_cli_storage_backup_by_a_different_installation_is_fail_closed(
+    tmp_path: Path, _stub: FakeClickHouseClient
+) -> None:
+    config_a = _config(tmp_path)
+    _init_paths(config_a)
+    assert (
+        CliRunner().invoke(main, ["--config", str(config_a), "storage", "migrate"]).exit_code == 0
+    )
+
+    config_b = _second_config(tmp_path)
+    _init_paths(config_b)
+    result = CliRunner().invoke(main, ["--config", str(config_b), "storage", "backup", "backup_b"])
+    assert result.exit_code == 1
+    assert "MH_STORAGE_OWNERSHIP" in result.output
+    assert not any(command.startswith("BACKUP DATABASE") for command in _stub.commands)
+
+
+def test_cli_storage_restore_of_a_foreign_backup_is_fail_closed(
+    tmp_path: Path, _stub: FakeClickHouseClient
+) -> None:
+    # Installation A migrates and backs up; the backup carries A's ``_installation`` owner row. B
+    # restores A's backup into an empty target — the restored owner is A ≠ B, so it fails closed
+    # with the restore-specific code and the MANUAL-DROP recovery, NOT the "--reclaim" guidance
+    # (which would make B adopt A's backup — the comingling this guard prevents).
+    config_a = _config(tmp_path)
+    _init_paths(config_a)
+    assert (
+        CliRunner().invoke(main, ["--config", str(config_a), "storage", "migrate"]).exit_code == 0
+    )
+    assert (
+        CliRunner()
+        .invoke(main, ["--config", str(config_a), "storage", "backup", "backup_a"])
+        .exit_code
+        == 0
+    )
+
+    config_b = _second_config(tmp_path)
+    _init_paths(config_b)
+    _stub.command("DROP DATABASE IF EXISTS milhouse")  # empty target so the native RESTORE proceeds
+    result = CliRunner().invoke(main, ["--config", str(config_b), "storage", "restore", "backup_a"])
+    assert result.exit_code == 1
+    assert (
+        "MH_STORAGE_RESTORE" in result.output
+    )  # restore-specific, not the ownership --reclaim path
+    assert "DROP this database" in result.output  # names the manual recovery for the wedged target
+    assert (
+        "--reclaim" not in result.output
+    )  # reclaiming would ADOPT the foreign backup (comingling)
+    # The restore materialized A's slice (incl. A's owner row) into B's empty target before failing
+    # closed; B did NOT adopt it, and the documented recovery is a manual DROP DATABASE (W16
+    # automates the rollback). The owner row still names A — exactly the populated state to drop.
+    assert _stub.owners["milhouse"] == bootstrap.read_installation_id(_paths(config_a))  # still A's
+
+
+def test_cli_storage_export_on_an_unclaimed_destination_fails_closed(
+    tmp_path: Path, _stub: FakeClickHouseClient
+) -> None:
+    # An initialized install pointed at a never-migrated (unclaimed) ClickHouse is refused with the
+    # "run migrate first" guidance, rather than writing an unowned destination.
+    config = _config(tmp_path)
+    _init_paths(config)  # control plane only; the fake ClickHouse is never migrated/claimed
+    result = CliRunner().invoke(main, ["--config", str(config), "storage", "export"])
+    assert result.exit_code == 1
+    assert "MH_STORAGE_OWNERSHIP" in result.output
+    assert "migrate" in result.output  # "the ClickHouse destination is unclaimed; run ... migrate"
+    assert _stub.inserts == []
+
+
+def test_cli_storage_backup_on_an_unclaimed_destination_fails_closed(
+    tmp_path: Path, _stub: FakeClickHouseClient
+) -> None:
+    config = _config(tmp_path)
+    _init_paths(config)
+    result = CliRunner().invoke(main, ["--config", str(config), "storage", "backup", "backup_one"])
+    assert result.exit_code == 1
+    assert "MH_STORAGE_OWNERSHIP" in result.output
+    assert not any(command.startswith("BACKUP DATABASE") for command in _stub.commands)

--- a/tests/unit/test_storage_backup.py
+++ b/tests/unit/test_storage_backup.py
@@ -63,7 +63,7 @@ from milhouse.storage import (
 
 _DB = "milhouse"
 _GENERATION = "a" * 64
-_FULL_SCHEMA = frozenset({1, 2, 3, 4, 5})
+_FULL_SCHEMA = frozenset({1, 2, 3, 4, 5, 6})
 
 
 # --- backup/restore round-trip over the fake (state-level fidelity) ---
@@ -76,7 +76,7 @@ def test_backup_restore_round_trip_matches_record_ids_and_migration_state() -> N
     export_records(fake, _DB, records)
 
     source = snapshot_state(fake, _DB)
-    assert source.migration_version == 5
+    assert source.migration_version == 6
     assert source.applied_versions == _FULL_SCHEMA
     assert source.record_ids == frozenset(record.record_id for record in records)
 
@@ -108,7 +108,7 @@ def test_snapshot_state_reads_raw_records_not_the_current_view() -> None:
 def test_verify_restored_returns_none_on_exact_match() -> None:
     snapshot = BackupSnapshot(
         database=_DB,
-        migration_version=5,
+        migration_version=6,
         applied_versions=_FULL_SCHEMA,
         record_ids=frozenset({"mh_r_a", "mh_r_b"}),
     )
@@ -116,8 +116,8 @@ def test_verify_restored_returns_none_on_exact_match() -> None:
 
 
 def test_verify_restored_fails_closed_on_a_record_id_mismatch() -> None:
-    source = BackupSnapshot(_DB, 5, _FULL_SCHEMA, frozenset({"mh_r_a", "mh_r_b"}))
-    restored = BackupSnapshot(_DB, 5, _FULL_SCHEMA, frozenset({"mh_r_a"}))  # lost mh_r_b
+    source = BackupSnapshot(_DB, 6, _FULL_SCHEMA, frozenset({"mh_r_a", "mh_r_b"}))
+    restored = BackupSnapshot(_DB, 6, _FULL_SCHEMA, frozenset({"mh_r_a"}))  # lost mh_r_b
     with pytest.raises(StorageError) as captured:
         verify_restored(source, restored)
     assert captured.value.code == "MH_STORAGE_RESTORE"
@@ -125,9 +125,9 @@ def test_verify_restored_fails_closed_on_a_record_id_mismatch() -> None:
 
 def test_verify_restored_fails_closed_on_a_migration_state_mismatch() -> None:
     ids = frozenset({"mh_r_a"})
-    source = BackupSnapshot(_DB, 5, _FULL_SCHEMA, ids)
+    source = BackupSnapshot(_DB, 6, _FULL_SCHEMA, ids)
     # Same record ids, but a lower/incomplete migration head must still fail closed.
-    behind = BackupSnapshot(_DB, 4, frozenset({1, 2, 3, 4}), ids)
+    behind = BackupSnapshot(_DB, 5, frozenset({1, 2, 3, 4, 5}), ids)
     with pytest.raises(StorageError) as captured:
         verify_restored(source, behind)
     assert captured.value.code == "MH_STORAGE_RESTORE"

--- a/tests/unit/test_storage_ownership.py
+++ b/tests/unit/test_storage_ownership.py
@@ -1,0 +1,118 @@
+"""Offline tests for the installation-ownership guard (fake client; no ClickHouse, no network)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from _storage_fakes import FakeClickHouseClient
+
+from milhouse.storage import StorageError, migrate
+from milhouse.storage.ownership import claim, read_owner, require_owner
+
+_NOW = datetime(2026, 8, 3, 12, 0, 0, tzinfo=UTC)
+_LATER = datetime(2026, 8, 4, 12, 0, 0, tzinfo=UTC)
+_DB = "milhouse"
+_A = "mh_in1_" + "a" * 32
+_B = "mh_in1_" + "b" * 32
+
+
+def _migrated() -> FakeClickHouseClient:
+    # Migration 0006 provisions the ``_installation`` table; a claim only ever happens post-migrate.
+    fake = FakeClickHouseClient()
+    migrate(fake, _DB, now=_NOW, milhouse_version="test")
+    return fake
+
+
+def test_read_owner_on_an_unmigrated_destination_is_none() -> None:
+    assert (
+        read_owner(FakeClickHouseClient(), _DB) is None
+    )  # no database, no _installation, no raise
+
+
+def test_read_owner_on_a_migrated_but_unclaimed_destination_is_none() -> None:
+    assert read_owner(_migrated(), _DB) is None  # table exists but holds no claim
+
+
+def test_claim_stamps_an_unclaimed_destination() -> None:
+    fake = _migrated()
+    claim(fake, _DB, installation_id=_A, now=_NOW, milhouse_version="test")
+    assert read_owner(fake, _DB) == _A
+
+
+def test_claim_by_the_same_installation_is_a_noop() -> None:
+    fake = _migrated()
+    claim(fake, _DB, installation_id=_A, now=_NOW, milhouse_version="test")
+    claim(fake, _DB, installation_id=_A, now=_LATER, milhouse_version="test")  # no raise
+    assert read_owner(fake, _DB) == _A
+
+
+def test_claim_by_a_different_installation_fails_closed() -> None:
+    fake = _migrated()
+    claim(fake, _DB, installation_id=_A, now=_NOW, milhouse_version="test")
+    with pytest.raises(StorageError) as captured:
+        claim(fake, _DB, installation_id=_B, now=_LATER, milhouse_version="test")
+    assert captured.value.code == "MH_STORAGE_OWNERSHIP"
+    assert read_owner(fake, _DB) == _A  # the refused claim did not change the owner
+
+
+def test_reclaim_supersedes_a_prior_owner() -> None:
+    fake = _migrated()
+    claim(fake, _DB, installation_id=_A, now=_NOW, milhouse_version="test")
+    claim(fake, _DB, installation_id=_B, now=_LATER, milhouse_version="test", reclaim=True)
+    assert read_owner(fake, _DB) == _B  # the newest claim supersedes
+
+
+def test_require_owner_passes_for_the_owner() -> None:
+    fake = _migrated()
+    claim(fake, _DB, installation_id=_A, now=_NOW, milhouse_version="test")
+    assert require_owner(fake, _DB, installation_id=_A) is None
+
+
+def test_require_owner_fails_closed_for_a_different_installation() -> None:
+    fake = _migrated()
+    claim(fake, _DB, installation_id=_A, now=_NOW, milhouse_version="test")
+    with pytest.raises(StorageError) as captured:
+        require_owner(fake, _DB, installation_id=_B)
+    assert captured.value.code == "MH_STORAGE_OWNERSHIP"
+
+
+def test_require_owner_on_an_unclaimed_destination_fails_closed() -> None:
+    with pytest.raises(StorageError) as captured:
+        require_owner(_migrated(), _DB, installation_id=_A)
+    assert captured.value.code == "MH_STORAGE_OWNERSHIP"
+    assert "migrate" in captured.value.message  # the "run `storage migrate` first" guidance
+
+
+def test_claim_rejects_a_bad_installation_id_before_writing() -> None:
+    fake = _migrated()
+    with pytest.raises(StorageError) as captured:
+        claim(fake, _DB, installation_id="bad; DROP", now=_NOW, milhouse_version="test")
+    assert captured.value.code == "MH_STORAGE_OWNERSHIP"
+    assert read_owner(fake, _DB) is None  # nothing was written
+
+
+def test_invalid_database_identifier_is_rejected() -> None:
+    with pytest.raises(StorageError) as captured:
+        read_owner(FakeClickHouseClient(), "bad name; DROP")
+    assert captured.value.code == "MH_STORAGE_OWNERSHIP"
+
+
+def test_ownership_is_per_destination() -> None:
+    # Two different fakes model two different ClickHouse destinations; each is claimable on its own
+    # by a different installation, the "installation id per client instance" the guard needs.
+    destination_1 = _migrated()
+    destination_2 = _migrated()
+    claim(destination_1, _DB, installation_id=_A, now=_NOW, milhouse_version="test")
+    claim(destination_2, _DB, installation_id=_B, now=_NOW, milhouse_version="test")
+    assert read_owner(destination_1, _DB) == _A
+    assert read_owner(destination_2, _DB) == _B
+
+
+def test_claim_rejects_a_naive_now() -> None:
+    fake = _migrated()
+    with pytest.raises(StorageError) as captured:
+        claim(
+            fake, _DB, installation_id=_A, now=datetime(2026, 8, 3, 12, 0, 0), milhouse_version="t"
+        )
+    assert captured.value.code == "MH_STORAGE_OWNERSHIP"

--- a/tests/unit/test_storage_runner.py
+++ b/tests/unit/test_storage_runner.py
@@ -23,7 +23,7 @@ def test_fresh_plan_lists_all_pending_and_does_not_mutate() -> None:
 
     report = plan(client, _DB)
 
-    assert [state.version for state in report.pending] == [1, 2, 3, 4, 5]
+    assert [state.version for state in report.pending] == [1, 2, 3, 4, 5, 6]
     assert report.applied == ()
     assert report.current_version == 0
     # Non-mutation: plan never created the database, the ledger, or any table.
@@ -35,7 +35,7 @@ def test_fresh_plan_lists_all_pending_and_does_not_mutate() -> None:
 def test_status_is_read_only_like_plan() -> None:
     client = FakeClickHouseClient()
     report = status(client, _DB)
-    assert len(report.pending) == 5
+    assert len(report.pending) == 6
     assert client.commands == []
 
 
@@ -44,13 +44,14 @@ def test_migrate_applies_all_in_order_with_ledger_rows() -> None:
 
     result = _migrate(client)
 
-    assert result.applied_now == (1, 2, 3, 4, 5)
+    assert result.applied_now == (1, 2, 3, 4, 5, 6)
     assert result.already_applied == ()
-    assert result.current_version == 5
+    assert result.current_version == 6
     assert (_DB, "records") in client.tables
     assert (_DB, "records_current") in client.tables
+    assert (_DB, "_installation") in client.tables
     ledger = client.ledger[_DB]
-    assert set(ledger) == {1, 2, 3, 4, 5}
+    assert set(ledger) == {1, 2, 3, 4, 5, 6}
     for migration in CLICKHOUSE_MIGRATIONS:
         assert ledger[migration.version] == (migration.name, migration.checksum)
 
@@ -62,8 +63,8 @@ def test_migrate_is_idempotent() -> None:
     result = _migrate(client)
 
     assert result.applied_now == ()
-    assert result.already_applied == (1, 2, 3, 4, 5)
-    assert plan(client, _DB).current_version == 5
+    assert result.already_applied == (1, 2, 3, 4, 5, 6)
+    assert plan(client, _DB).current_version == 6
 
 
 def test_migrate_refuses_a_tampered_applied_checksum() -> None:
@@ -104,7 +105,7 @@ def test_ledger_version_beyond_definitions_is_rejected() -> None:
     client = FakeClickHouseClient()
     for migration in CLICKHOUSE_MIGRATIONS:
         client.seed_ledger(_DB, migration.version, migration.name, migration.checksum)
-    client.seed_ledger(_DB, 6, "phantom", "0" * 64)  # a recorded version with no definition
+    client.seed_ledger(_DB, 7, "phantom", "0" * 64)  # a recorded version with no definition
 
     with pytest.raises(StorageError) as captured:
         plan(client, _DB)

--- a/tests/unit/test_storage_schema.py
+++ b/tests/unit/test_storage_schema.py
@@ -15,11 +15,15 @@ _GOLDEN: dict[int, tuple[str, str]] = {
         "feedback_transition_dedup",
         "158761bee4c675ac39eaec9cc6146423c6fb91aa5bd9794a41f946d581ff9e08",
     ),
+    6: (
+        "installation_ownership",
+        "959adb37cfe942aeda7547fb82da736eddde1c18fd4d108d358510bd2ed26b1b",
+    ),
 }
 
 
 def test_migrations_are_contiguous_named_and_nonempty() -> None:
-    assert tuple(m.version for m in CLICKHOUSE_MIGRATIONS) == (1, 2, 3, 4, 5)
+    assert tuple(m.version for m in CLICKHOUSE_MIGRATIONS) == (1, 2, 3, 4, 5, 6)
     for migration in CLICKHOUSE_MIGRATIONS:
         assert migration.name
         assert migration.sql.strip()
@@ -58,3 +62,16 @@ def test_records_current_view_enforces_retention_at_query_time() -> None:
     assert "records_current" in views.sql
     # Retention is enforced at query time independent of merge-time TTL deletion.
     assert "expires_at > now64" in views.sql
+
+
+def test_installation_ownership_migration_is_a_single_owner_replacing_table() -> None:
+    ownership = next(m for m in CLICKHOUSE_MIGRATIONS if m.name == "installation_ownership")
+    assert "_installation" in ownership.sql
+    # One logical owner row keyed on a fixed id; ReplacingMergeTree(claimed_at) keeps the newest
+    # claim so a --reclaim supersedes rather than forking a second owner.
+    assert "ReplacingMergeTree(claimed_at)" in ownership.sql
+    assert "ORDER BY id" in ownership.sql
+    # Idempotent DDL (retry-safe) and no destructive statement.
+    assert "CREATE TABLE IF NOT EXISTS" in ownership.sql
+    assert "DROP TABLE" not in ownership.sql.upper()
+    assert "DROP DATABASE" not in ownership.sql.upper()


### PR DESCRIPTION
## What & why
Enforce **one installation per ClickHouse destination**, fail-closed — resolving **#127**, the cross-installation coordination gap #126 flagged. The local commit barrier serializes exactly ONE installation's writers; it is a machine-local lock and cannot fence a **second** installation (different state root, clone, or host) pointed at the **same** ClickHouse. Two such installs would each hold the single-writer lock while silently comingling and corrupting each other's data. This makes "one ClickHouse per installation" an **enforced invariant** rather than an unwritten assumption. (Owner chose this over shared-destination coordination.)

## Changes
- **`migrations/0006_installation_ownership.sql`** — a single-owner control table `{database}._installation`: one logical row at `id = 1` under `ReplacingMergeTree(claimed_at)` (newest claim supersedes on merge; a `FINAL` read sees the current owner pre-merge). `CREATE TABLE IF NOT EXISTS` (retry-safe). 0001–0005 byte-unchanged; migration set repins **5 → 6** across `schema.py`, the packaged manifest, and every pin test.
- **`storage/ownership.py`** — `read_owner` (owner, or `None` on unmigrated/absent/empty — existence-guarded like the runner's ledger read, reads through `FINAL`), `claim` (unclaimed→stamp; same id→no-op; **different id → fail-closed `MH_STORAGE_OWNERSHIP` unless `--reclaim`**), `require_owner` (different **or** unclaimed → fail-closed). Installation id validated as the bounded non-secret `mh_in1_` token before interpolation (structural literal, not parameter-bindable) — same discipline as the database identifier.
- **`cli/root.py`** — `storage migrate --reclaim` claims after applying migrations under the exclusive barrier, reporting `ownership: claimed|verified|reclaimed` (text + `--json`). `storage export`/`backup` call `require_owner` **before** writing. `storage restore` checks the restored owner **after** the schema gate and refuses a cross-installation restore with a **restore-specific `MH_STORAGE_RESTORE`** naming the manual `DROP` recovery — deliberately **not** the `--reclaim` guidance, which would *adopt* the foreign backup (empty-target-only restore ⇒ the operator drops the DB back to empty).
- **Docs** — migrate `--help` + `ops/clickhouse/README.md` document the reclaim/upgrade semantics and the foreign/failed-restore recovery.
- **Tests** — `test_storage_ownership.py` (claim/verify/reclaim; unclaimed + foreign `require_owner` fail closed; bad-id rejection; `FINAL` newest-claim read) + `test_cli_storage.py` ownership cases (migrate reports claimed/verified/reclaimed; export/backup refuse a foreign destination; restore refuses a foreign backup with the manual-`DROP` message, not `--reclaim`) + a host-gated live smoke case. `FakeClickHouseClient` models `_installation` so the owner travels through BACKUP/RESTORE/DROP.

## Review trail
Built, then an **independent adversarial gate review** — verdict **`externally_pending`**, **no P0/P1**, no fail-open or bypass reproduced (raises on unclaimed/mismatch/read-error, reads via `FINAL`, every writer takes it, takeover gated behind `--reclaim`, ids validated, 0006 retry-safe + checksum-verified + 0001–0005 byte-unchanged). Its **one P2** (a foreign restore materialized data behind a misleading `--reclaim` error) and the actionable **P3s** are fixed here: restore-specific error + manual-`DROP` docs; upgrade-claim docs; a comment on the intentional export pre-barrier placement. Gates green: `test` **4870 passed / 6 skipped**, `quality` + `secret-scan` (tree + history) clean. **Recommend a `/code-review ultra` on this PR** as the final independent check before merge.

## Residual / deferred (host-gated, E06)
- Two installations racing the **very first** claim is a lock-free `INSERT`, not a compare-and-set: `ReplacingMergeTree(claimed_at)` converges to a single owner and the loser is refused fail-closed on its next `require_owner`, but the sub-merge window is real ClickHouse behaviour, not modelled offline. Same-host race is already fenced by the exclusive barrier.
- The one unvalidated interpolated field (`milhouse_version`) is a trusted build-time constant and mirrors the existing `runner.py` ledger insert; bounding it in **both** is a separate follow-up, out of this increment's scope.

## NOT claimed
No change to **G04b** status — the real BACKUP/RESTORE round-trip and the live ownership race stay owner/host-gated (E06, #108). **G04b remains In progress / not passed.**

## Base
Stacked on **#126** (`claude/w04-g04b-restore`); retargets to `main` once #126 merges.

Closes #127
Refs #93, #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
