### PR TITLE
feat(domain,runtime): W05 increment 4 — durable notification-intent records (emit-only)

### DIFF
--- a/src/milhouse/domain/identity.py
+++ b/src/milhouse/domain/identity.py
@@ -50,6 +50,7 @@ RecordTypeV1 = Literal[
     "span",
     "run",
     "alert",
+    "notification_intent",
     "incident",
     "feedback_item",
     "feedback_transition",
@@ -65,6 +66,7 @@ _CONTENT_DOMAIN = b"milhouse-content-v1\0"
 _DEDUPE_DOMAIN = b"milhouse-dedupe-v1\0"
 _ALERT_KEY_DOMAIN = b"milhouse-alert-key-v1\0"
 _ALERT_TRANSITION_DOMAIN = b"milhouse-alert-transition-v1\0"
+_NOTIFICATION_INTENT_DOMAIN = b"milhouse-notification-intent-v1\0"
 
 
 def _contains_unsafe_identifier_characters(value: str) -> bool:
@@ -236,12 +238,24 @@ def derive_dedupe_key(dedupe: RecordDedupeV1) -> str:
     return f"mh_d1_{_base32_digest(_domain_digest(_DEDUPE_DOMAIN, projection))}"
 
 
-def _require_alert_text(value: object, subject: str) -> str:
+def _require_bounded_safe_text(value: object, *, code: str, subject: str) -> str:
     if type(value) is not str or not value or _contains_unsafe_identifier_characters(value):
-        raise IdentityError("MH_IDENTITY_ALERT_INPUT", f"an alert {subject} must be safe text")
+        raise IdentityError(code, f"{subject} must be safe text")
     if len(value.encode("utf-8")) > 256:
-        raise IdentityError("MH_IDENTITY_ALERT_INPUT", f"an alert {subject} exceeds its byte bound")
+        raise IdentityError(code, f"{subject} exceeds its byte bound")
     return value
+
+
+def _require_alert_text(value: object, subject: str) -> str:
+    return _require_bounded_safe_text(
+        value, code="MH_IDENTITY_ALERT_INPUT", subject=f"an alert {subject}"
+    )
+
+
+def _require_notification_text(value: object, subject: str) -> str:
+    return _require_bounded_safe_text(
+        value, code="MH_IDENTITY_NOTIFICATION_INPUT", subject=f"a notification intent {subject}"
+    )
 
 
 def _require_alert_version(value: object) -> int:
@@ -295,6 +309,26 @@ def derive_transition_id(
         "state": _require_alert_text(state, "state"),
     }
     return f"mh_atr1_{_base32_digest(_domain_digest(_ALERT_TRANSITION_DOMAIN, projection))}"
+
+
+def derive_notification_intent_id(*, transition_id: str, channel_id: str) -> str:
+    """Derive a deterministic notification-intent id from its alert transition and its channel.
+
+    A notification intent is one configured channel's durable INTENT to notify for one committed
+    alert transition (plan section 4.14); this id binds exactly the transition and the channel. Two
+    intents that share a transition and a channel re-derive the identical token, while a different
+    transition or a different channel yields a distinct one — so re-running the same transition for
+    the same channel stays idempotent. It is a domain-separated one-way digest, exactly like
+    :func:`derive_transition_id`, so it never renders or reverses its inputs and is safe to persist
+    or surface. The returned ``mh_nin1_`` token is a bounded, single-line, ``OpaqueIdV1``-valid
+    identifier.
+    """
+
+    projection = {
+        "channel_id": _require_notification_text(channel_id, "channel id"),
+        "transition_id": _require_notification_text(transition_id, "transition id"),
+    }
+    return f"mh_nin1_{_base32_digest(_domain_digest(_NOTIFICATION_INTENT_DOMAIN, projection))}"
 
 
 def _validate_digest_token(value: str, *, prefix: str, pattern: re.Pattern[str]) -> str:

--- a/src/milhouse/domain/records.py
+++ b/src/milhouse/domain/records.py
@@ -350,6 +350,29 @@ class AlertDataV1(_StrictRecordModel):
         return self
 
 
+class NotificationIntentDataV1(_StrictRecordModel):
+    """A durable record of one channel's INTENT to notify for one alert transition (plan 4.14).
+
+    It is emitted the moment an alert transition is committed, one per applicable configured
+    notification channel, and captures only the INTENT — no message is ever sent, and no delivery,
+    retry, rate-limit, or "sent" state lives here (all W14). It references the alert by id via
+    ``evidence_ids`` and names the channel by its non-secret configured ``channel_id`` and
+    ``channel_type`` ONLY: it never carries a bot token, chat id, provider, repository, URL, or
+    target. The ``summary`` is a fixed privacy-safe constant supplied by its producer, never
+    interpolated. ``severity`` couples to the envelope, mirroring :class:`AlertDataV1`.
+    """
+
+    type: Literal["notification_intent"] = "notification_intent"
+    intent_id: OpaqueIdV1
+    alert_key: OpaqueIdV1
+    transition_id: OpaqueIdV1
+    channel_id: MachineIdV1
+    channel_type: Literal["telegram", "github_issues"]
+    severity: SeverityV1
+    summary: FreeTextV1
+    evidence_ids: EvidenceIdsV1 = Field(min_length=1)
+
+
 class IncidentDataV1(_StrictRecordModel):
     type: Literal["incident"] = "incident"
     incident_key: OpaqueIdV1
@@ -552,6 +575,7 @@ RecordDataV1 = Annotated[
     | SpanDataV1
     | RunDataV1
     | AlertDataV1
+    | NotificationIntentDataV1
     | IncidentDataV1
     | FeedbackItemDataV1
     | FeedbackTransitionDataV1
@@ -606,7 +630,10 @@ class RecordDraftV1(_StrictRecordModel):
             raise ValueError("ingested_at must not precede observed_at")
         if self.expires_at <= self.ingested_at:
             raise ValueError("expires_at must be after ingested_at")
-        if isinstance(self.data, (AlertDataV1, IncidentDataV1, FeedbackItemDataV1)):
+        if isinstance(
+            self.data,
+            (AlertDataV1, NotificationIntentDataV1, IncidentDataV1, FeedbackItemDataV1),
+        ):
             if self.severity != self.data.severity:
                 raise ValueError("envelope severity must match payload severity")
         if isinstance(self.data, FeedbackItemDataV1):

--- a/src/milhouse/runtime/pipeline.py
+++ b/src/milhouse/runtime/pipeline.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from types import MappingProxyType
 from typing import Literal
@@ -44,15 +44,25 @@ from typing import Literal
 from milhouse.config._models import (
     CanaryStateAlertRule,
     CollectorConfig,
+    GithubIssuesNotification,
+    NotificationConfig,
     RetentionConfig,
     TargetConfig,
+    TelegramNotification,
 )
 from milhouse.core.clock import WallClock, format_timestamp
 from milhouse.core.errors import normalize_error
+from milhouse.domain.identity import (
+    ObservationCoordinateV1,
+    derive_notification_intent_id,
+)
 from milhouse.domain.records import (
+    AlertDataV1,
     EventDataV1,
+    NotificationIntentDataV1,
     RecordDraftV1,
     RecordEnvelopeV1,
+    SourceDescriptorV1,
     TargetDescriptorV1,
     finalize_record,
 )
@@ -107,6 +117,7 @@ _FREE_TEXT_FIELDS: Mapping[str, tuple[str, ...]] = MappingProxyType(
         "run": (),
         "span": (),
         "alert": ("summary",),
+        "notification_intent": ("summary",),
         "feedback_item": ("title", "summary", "recommendation"),
         "feedback_transition": ("rationale",),
     }
@@ -121,6 +132,9 @@ _RETENTION_FIELDS: Mapping[str, str] = MappingProxyType(
         "run": "runs_days",
         "span": "trace_events_days",
         "alert": "alerts_days",
+        # A notification intent shares its alert's retention window (it is derived from, and expires
+        # with, one alert transition). A dedicated retention field is a follow-up, not this slice.
+        "notification_intent": "alerts_days",
         "feedback_item": "feedback_days",
         "feedback_transition": "feedback_days",
     }
@@ -128,6 +142,21 @@ _RETENTION_FIELDS: Mapping[str, str] = MappingProxyType(
 
 _SHA256_HEX_LENGTH = 64
 _BATCH_SUFFIX_LENGTH = 24
+
+_NOTIFICATION_INTENT_SOURCE_TYPE = "alert.notification_intent"
+_NOTIFICATION_INTENT_RECORD_NAME = "alert.notification_intent"
+_NOTIFICATION_INTENT_OBSERVATION_KIND = "alert.notification_intent"
+#: A fixed v4-shaped namespace for system-derived notification-intent identity; stable so an intent
+#: re-derived for the same (transition, channel) stays idempotent.
+_NOTIFICATION_INTENT_NAMESPACE = "mh_ns1_b2f88c3d4e514a6b9c0d1e2f3a4b5c6d"
+#: Nominal record expiry; true retention is governed by the segment header and storage TTL.
+_NOTIFICATION_INTENT_EXPIRY = timedelta(days=365)
+#: A FIXED, privacy-safe summary. It is NEVER interpolated: it names no channel secret, chat id,
+#: provider, repository, URL, or target, so no such value can ever reach the durable intent record.
+_NOTIFICATION_INTENT_SUMMARY = (
+    "A configured notification channel recorded a durable intent to notify for this alert "
+    "transition. No message was sent; delivery is out of scope for this record."
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -156,6 +185,12 @@ class PipelineRunSummary:
     alerts_fired: int = 0
     alerts_resolved: int = 0
     alerts_error_code: str | None = None
+    #: Durable notification-intent records this run emitted (one per committed alert transition x
+    #: applicable configured channel). ``intents_error_code`` is the first fixed code an isolated
+    #: per-channel intent emission failed with, or ``None``. All privacy-safe — never a channel
+    #: secret, chat id, provider, repository, URL, or target.
+    intents_emitted: int = 0
+    intents_error_code: str | None = None
 
     @property
     def records_committed(self) -> int:
@@ -213,6 +248,7 @@ class RuntimePipeline:
         "_exporters",
         "_installation_id",
         "_mode",
+        "_notifications",
         "_redactor",
         "_registry",
         "_required_exporters",
@@ -235,6 +271,7 @@ class RuntimePipeline:
         retention: RetentionConfig,
         exporters: Mapping[str, Exporter] = MappingProxyType({}),
         alert_rules: Sequence[CanaryStateAlertRule] = (),
+        notifications: Sequence[NotificationConfig] = (),
     ) -> None:
         _require(
             mode in ("full", "spool_only"),
@@ -321,6 +358,15 @@ class RuntimePipeline:
             "MH_RUNTIME_PIPELINE_ALERT_RULES",
             "each alert rule must be a canary_state alert rule",
         )
+        notification_tuple = tuple(notifications)
+        _require(
+            all(
+                isinstance(channel, (TelegramNotification, GithubIssuesNotification))
+                for channel in notification_tuple
+            ),
+            "MH_RUNTIME_PIPELINE_NOTIFICATIONS",
+            "each notification must be a configured telegram or github_issues channel",
+        )
         self._mode = mode
         self._config_generation = config_generation
         self._registry = registry
@@ -334,6 +380,7 @@ class RuntimePipeline:
         self._exporters: Mapping[str, Exporter] = MappingProxyType(exporter_map)
         self._required_exporters = tuple(sorted(exporter_map))
         self._alert_rules: tuple[CanaryStateAlertRule, ...] = alert_rule_tuple
+        self._notifications: tuple[NotificationConfig, ...] = notification_tuple
 
     def run(
         self,
@@ -382,11 +429,24 @@ class RuntimePipeline:
         # Alert stage: AFTER the whole collector loop (so every availability record is committed and
         # citable as evidence) and BEFORE the export tail (so full mode drains any alert segment
         # this run emits). Each rule is isolated; a failure never aborts the run or the other rules.
-        alerts_fired, alerts_resolved, alerts_error_code = self._drive_alerts(
+        # It also threads out the committed alert records this run emitted, so the next stage can
+        # cite each one by id.
+        alerts_fired, alerts_resolved, alerts_error_code, committed_alerts = self._drive_alerts(
             collectors=collectors,
             spool=spool,
             target_by_id=target_by_id,
             availability=availability,
+            now=now,
+        )
+
+        # Notification-intent stage: AFTER alerts are committed (so each intent cites the alert
+        # record and shares its retention window) and BEFORE the export tail (so full mode drains
+        # any intent segment this run emits). This stage only RECORDS the intent to notify -- it
+        # never sends, previews, retries, rate-limits, or tracks delivery state (all W14). Each
+        # channel is isolated: one bad channel never aborts the others or the run.
+        intents_emitted, intents_error_code = self._drive_notification_intents(
+            committed_alerts=committed_alerts,
+            spool=spool,
             now=now,
         )
 
@@ -408,6 +468,8 @@ class RuntimePipeline:
             alerts_fired=alerts_fired,
             alerts_resolved=alerts_resolved,
             alerts_error_code=alerts_error_code,
+            intents_emitted=intents_emitted,
+            intents_error_code=intents_error_code,
         )
 
     def _run_collector(
@@ -472,23 +534,25 @@ class RuntimePipeline:
         target_by_id: Mapping[str, TargetConfig],
         availability: Mapping[str, _AvailabilitySample],
         now: datetime,
-    ) -> tuple[int, int, str | None]:
+    ) -> tuple[int, int, str | None, tuple[RecordEnvelopeV1, ...]]:
         """Evaluate every configured alert rule against this run's samples; return the alert counts.
 
         Each rule is isolated exactly like a collector: a single rule raising is captured as a fixed
         code and never aborts the run or the other rules. A rule whose collector did not run this
-        pass (no sample) is a silent no-op.
+        pass (no sample) is a silent no-op. Alongside the counts, this returns every alert record
+        actually committed this run, so the notification-intent stage can cite each one by id.
         """
 
         fired_total = 0
         resolved_total = 0
         error_code: str | None = None
+        committed_alerts: list[RecordEnvelopeV1] = []
         if not self._alert_rules:
-            return fired_total, resolved_total, error_code
+            return fired_total, resolved_total, error_code, ()
         collector_by_id = {str(config.id): config for config in collectors}
         for rule in self._alert_rules:
             try:
-                fired, resolved = self._evaluate_rule(
+                fired, resolved, committed = self._evaluate_rule(
                     rule,
                     collector_by_id=collector_by_id,
                     spool=spool,
@@ -498,10 +562,12 @@ class RuntimePipeline:
                 )
                 fired_total += fired
                 resolved_total += resolved
+                if committed is not None:
+                    committed_alerts.append(committed)
             except Exception as error:
                 if error_code is None:
                     error_code = normalize_error(error).code
-        return fired_total, resolved_total, error_code
+        return fired_total, resolved_total, error_code, tuple(committed_alerts)
 
     def _evaluate_rule(
         self,
@@ -512,14 +578,18 @@ class RuntimePipeline:
         target_by_id: Mapping[str, TargetConfig],
         availability: Mapping[str, _AvailabilitySample],
         now: datetime,
-    ) -> tuple[int, int]:
-        """Run one rule's engine, commit any transition, then CAS-advance the durable rule state."""
+    ) -> tuple[int, int, RecordEnvelopeV1 | None]:
+        """Run one rule's engine, commit any transition, then CAS-advance the durable rule state.
+
+        Returns the firing/resolution counts and the committed alert record (or ``None`` when this
+        sample produced no transition), so the caller can thread the record into the intent stage.
+        """
 
         sample = availability.get(str(rule.collector))
         collector_config = collector_by_id.get(str(rule.collector))
         if sample is None or collector_config is None:
             # The referenced collector produced no sample this run (idle, errored, or unconfigured).
-            return 0, 0
+            return 0, 0, None
         target = _target_descriptor(collector_config, target_by_id)
         _require(
             target is not None,
@@ -547,6 +617,7 @@ class RuntimePipeline:
         )
         fired = 0
         resolved = 0
+        committed: RecordEnvelopeV1 | None = None
         if evaluation.draft is not None:
             record = self._finalize(evaluation.draft)
             header, frames = self._build_segment(spec.rule_id, (record,), now=now)
@@ -561,6 +632,7 @@ class RuntimePipeline:
             # id and record id differ). That is the accepted "never miss a fire, may duplicate one"
             # tradeoff, not exactly-once. A commit failure is isolated per rule.
             spool.commit_segment(header, frames, committed_at=now)
+            committed = record
             if evaluation.transition == "firing":
                 fired = 1
             else:
@@ -579,7 +651,47 @@ class RuntimePipeline:
             now=now,
             expected_revision=update.expected_revision,
         )
-        return fired, resolved
+        return fired, resolved, committed
+
+    def _drive_notification_intents(
+        self,
+        *,
+        committed_alerts: Sequence[RecordEnvelopeV1],
+        spool: DurableSpool,
+        now: datetime,
+    ) -> tuple[int, str | None]:
+        """Emit one durable notification-intent record per committed alert x applicable channel.
+
+        A channel APPLIES when it is ``enabled`` AND its ``allowed_classifications`` admits the
+        alert record's ``privacy_class``. This stage records only the INTENT to notify — it never
+        sends, previews, retries, rate-limits, or tracks delivery/"sent" state (all W14). Each
+        (alert, channel) intent commits its own homogeneous ``notification_intent`` segment (never
+        mixed with the alert segment), isolated per channel: one channel raising is captured as the
+        first fixed code and never aborts the other channels or the run.
+        """
+
+        emitted = 0
+        error_code: str | None = None
+        if not self._notifications or not committed_alerts:
+            return emitted, error_code
+        for alert in committed_alerts:
+            for channel in self._notifications:
+                if not channel.enabled:
+                    continue
+                if alert.privacy_class not in channel.allowed_classifications:
+                    continue
+                try:
+                    draft = _notification_intent_draft(alert, channel, now=now)
+                    record = self._finalize(draft)
+                    source_id = f"{alert.source.id}-{channel.id}"
+                    header, frames = self._build_segment(source_id, (record,), now=now)
+                    spool.commit_segment(header, frames, committed_at=now)
+                    emitted += 1
+                except Exception as error:
+                    # Per-channel isolation: capture only the fixed code; never abort the others.
+                    if error_code is None:
+                        error_code = normalize_error(error).code
+        return emitted, error_code
 
     def _finalize(self, draft: RecordDraftV1) -> RecordEnvelopeV1:
         """Redact a draft's free text, then assign its deterministic canonical identity."""
@@ -705,6 +817,85 @@ def _availability_sample(records: tuple[RecordEnvelopeV1, ...]) -> _Availability
             if data.status == "degraded":
                 return ("failure", record.record_id)
     return None
+
+
+def _notification_source_generation_digest(rule_id: str, rule_version: int, channel_id: str) -> str:
+    """Derive a stable 64-hex source-generation digest for a channel's notification-intent source.
+
+    It binds the source type, the originating rule and its version, and the channel id -- all stable
+    across re-runs of the same (transition, channel) -- so a re-derived intent keeps one identity.
+    """
+
+    material = f"{_NOTIFICATION_INTENT_SOURCE_TYPE}\x00{rule_id}\x00{rule_version}\x00{channel_id}"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _notification_intent_draft(
+    alert: RecordEnvelopeV1,
+    channel: NotificationConfig,
+    *,
+    now: datetime,
+) -> RecordDraftV1:
+    """Build one system-produced notification-intent draft for one committed alert x one channel.
+
+    The intent references the alert ONLY by its record id (as evidence) and names the channel ONLY
+    by its non-secret configured ``id`` and ``type``: it carries no bot token, chat id, provider,
+    repository, URL, or target name/url anywhere. ``producer="system"`` with no collector provenance
+    mirrors the alert draft, and the (transition_id, channel_id) coordinate placed in
+    ``source.observation`` makes :func:`~milhouse.domain.records.finalize_record` derive a record
+    identity that is idempotent for one transition/channel pair and distinct across pairs. The
+    summary is a fixed privacy-safe constant, never interpolated; the severity couples to the
+    envelope, matching the alert.
+    """
+
+    payload = alert.data
+    assert isinstance(payload, AlertDataV1)  # the caller only threads committed alert records
+    target = alert.target
+    assert target is not None  # an alert transition is always target-scoped
+    channel_id = channel.id
+    transition_id = payload.transition_id
+    observation = ObservationCoordinateV1(
+        kind=_NOTIFICATION_INTENT_OBSERVATION_KIND,
+        parts={"transition": transition_id, "channel": channel_id},
+    )
+    source = SourceDescriptorV1(
+        id=payload.rule_id,
+        type=_NOTIFICATION_INTENT_SOURCE_TYPE,
+        producer="system",
+        observation_namespace_id=_NOTIFICATION_INTENT_NAMESPACE,
+        source_generation_digest=_notification_source_generation_digest(
+            payload.rule_id, payload.rule_version, channel_id
+        ),
+        observation=observation,
+    )
+    data = NotificationIntentDataV1(
+        intent_id=derive_notification_intent_id(transition_id=transition_id, channel_id=channel_id),
+        alert_key=payload.alert_key,
+        transition_id=transition_id,
+        channel_id=channel_id,
+        channel_type=channel.type,
+        severity=alert.severity,
+        summary=_NOTIFICATION_INTENT_SUMMARY,
+        evidence_ids=[alert.record_id],
+    )
+    stamp = format_timestamp(now)
+    return RecordDraftV1(
+        record_type="notification_intent",
+        name=_NOTIFICATION_INTENT_RECORD_NAME,
+        occurred_at=now,
+        observed_at=now,
+        ingested_at=now,
+        expires_at=now + _NOTIFICATION_INTENT_EXPIRY,
+        operation_id=f"{payload.rule_id}:{channel_id}:{stamp}",
+        scope="target",
+        source=source,
+        target=target,
+        severity=alert.severity,
+        trust_level="system",
+        privacy_class="internal",
+        redaction_version="r1-e1",
+        data=data,
+    )
 
 
 def _target_descriptor(

--- a/tests/security/test_domain_validation_boundary.py
+++ b/tests/security/test_domain_validation_boundary.py
@@ -1125,7 +1125,7 @@ def test_every_public_domain_model_inherits_the_value_safe_guard() -> None:
     record_models = _public_models(record_module)
 
     assert len(identity_models) == 5
-    assert len(record_models) == 23
+    assert len(record_models) == 24  # + NotificationIntentDataV1 (W05 increment 4)
     assert all(issubclass(model, ValueSafeIdentityModel) for model in identity_models)
     assert all(issubclass(model, ValueSafeRecordModel) for model in record_models)
 

--- a/tests/unit/_runtime_harness.py
+++ b/tests/unit/_runtime_harness.py
@@ -261,6 +261,7 @@ def make_pipeline(
     clock: Any,
     exporters: Any = None,
     alert_rules: Any = (),
+    notifications: Any = (),
 ) -> RuntimePipeline:
     return RuntimePipeline(
         mode=mode,  # type: ignore[arg-type]
@@ -275,6 +276,7 @@ def make_pipeline(
         retention=retention_config(),
         exporters={} if exporters is None else exporters,
         alert_rules=alert_rules,
+        notifications=notifications,
     )
 
 

--- a/tests/unit/test_alert_identity.py
+++ b/tests/unit/test_alert_identity.py
@@ -13,6 +13,7 @@ from milhouse.domain.identity import (
     IdentityError,
     ObservationCoordinateV1,
     derive_alert_key,
+    derive_notification_intent_id,
     derive_transition_id,
 )
 
@@ -124,3 +125,33 @@ def test_a_malformed_transition_input_fails_closed() -> None:
             state="firing",
             triggering_observation=_observation(),
         )
+
+
+def test_the_notification_intent_id_is_deterministic_and_a_valid_opaque_id() -> None:
+    first = derive_notification_intent_id(transition_id="mh_atr1_example", channel_id="telegram1")
+    second = derive_notification_intent_id(transition_id="mh_atr1_example", channel_id="telegram1")
+    assert first == second
+    assert first.startswith("mh_nin1_")
+    assert _is_opaque_id(first)
+
+
+def test_the_notification_intent_id_is_distinct_per_transition_and_channel() -> None:
+    base = derive_notification_intent_id(transition_id="mh_atr1_example", channel_id="telegram1")
+    # A different channel for the same transition derives a distinct intent id ...
+    assert base != derive_notification_intent_id(
+        transition_id="mh_atr1_example", channel_id="github1"
+    )
+    # ... and the same channel for a different transition also derives a distinct one.
+    assert base != derive_notification_intent_id(
+        transition_id="mh_atr1_other", channel_id="telegram1"
+    )
+
+
+@pytest.mark.parametrize("bad", ["", "with\nnewline", "a" * 257])
+def test_a_malformed_notification_intent_input_fails_closed(bad: str) -> None:
+    with pytest.raises(IdentityError) as captured:
+        derive_notification_intent_id(transition_id=bad, channel_id="telegram1")
+    assert captured.value.code == "MH_IDENTITY_NOTIFICATION_INPUT"
+    with pytest.raises(IdentityError) as channel_captured:
+        derive_notification_intent_id(transition_id="mh_atr1_example", channel_id=bad)
+    assert channel_captured.value.code == "MH_IDENTITY_NOTIFICATION_INPUT"

--- a/tests/unit/test_notification_intents_pipeline.py
+++ b/tests/unit/test_notification_intents_pipeline.py
@@ -1,0 +1,447 @@
+"""Integration: committed alert transitions drive durable notification-intent records (W05 inc 4).
+
+Drives the real ``site_canary`` collector through the :class:`RuntimePipeline` with one
+``canary_state`` alert rule and configured notification channels, and asserts that when an alert
+transition commits, the runtime ALSO emits one durable notification-intent record per applicable
+channel -- WITHOUT sending anything (delivery/transports/retry/rate-limit/"sent" state are all W14).
+
+It proves channel applicability (``enabled`` AND an ``allowed_classifications`` that admits the
+alert's privacy class), that a steady poll with no transition emits none, that each intent cites the
+alert record id, that a homogeneous ``notification_intent`` segment is drained by the full-mode
+export tail, that NO channel secret/chat-id/provider/repository/url/target-url string leaks into the
+intent bytes/summary/run summary, and that a failing channel is isolated from the others.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from _http_fakes import fixed_resolver, responding_transport, stream_response
+from _record_factories import INSTALLATION_ID, NOW
+from _runtime_harness import (
+    build_control,
+    canary_config,
+    clickhouse_exporters,
+    make_pipeline,
+    target_config,
+)
+from _storage_fakes import FakeClickHouseClient
+
+from milhouse.collectors.site_canary import SITE_CANARY_TYPE, build_collector
+from milhouse.config._models import (
+    CanaryStateAlertRule,
+    GithubIssuesNotification,
+    SiteCanaryCollector,
+    TargetConfig,
+    TelegramNotification,
+)
+from milhouse.core.clock import FixedClock
+from milhouse.http import BoundedHttpClient
+from milhouse.runtime.errors import PipelineError
+from milhouse.runtime.pipeline import (
+    _FREE_TEXT_FIELDS,
+    _NOTIFICATION_INTENT_SUMMARY,
+    _RETENTION_FIELDS,
+)
+from milhouse.runtime.registry import CollectorRegistry
+from milhouse.spooling import read_trusted_segment
+
+_PUBLIC = "93.184.216.34"
+
+
+def _rule() -> CanaryStateAlertRule:
+    return CanaryStateAlertRule(
+        id="rule1",
+        type="canary_state",
+        collector="canary1",
+        consecutive_failures=1,
+        consecutive_successes=1,
+        cooldown_seconds=0,
+    )
+
+
+def _telegram(
+    channel_id: str,
+    *,
+    enabled: bool = True,
+    classifications: list[str] | None = None,
+    bot_token_env: str = "PLACEHOLDER_BOT_TOKEN_ENV",
+    chat_id_env: str = "PLACEHOLDER_CHAT_ID_ENV",
+) -> TelegramNotification:
+    return TelegramNotification(
+        id=channel_id,
+        type="telegram",
+        enabled=enabled,
+        bot_token_env=bot_token_env,
+        chat_id_env=chat_id_env,
+        allowed_classifications=classifications or ["internal"],  # type: ignore[arg-type]
+    )
+
+
+def _github(
+    channel_id: str,
+    *,
+    enabled: bool = True,
+    provider: str = "placeholder-provider",
+    repository: str = "placeholder-owner/placeholder-repo",
+    label: str = "placeholder-label",
+) -> GithubIssuesNotification:
+    return GithubIssuesNotification(
+        id=channel_id,
+        type="github_issues",
+        enabled=enabled,
+        provider=provider,
+        repository=repository,
+        label_allowlist=[label],
+        enabled_priorities=["P1"],
+        enabled_actionabilities=["observe"],
+        allowed_classifications=["internal"],
+    )
+
+
+def _registry(status: int) -> CollectorRegistry:
+    transport, _ = responding_transport(lambda request: stream_response(status))
+
+    def factory(config: object) -> object:
+        client = BoundedHttpClient(resolver=fixed_resolver(_PUBLIC), transport=transport)
+        return build_collector(config, client=client)  # type: ignore[arg-type]
+
+    registry = CollectorRegistry()
+    registry.register(SITE_CANARY_TYPE, factory)
+    return registry
+
+
+def _run(
+    database,
+    barrier,
+    spool_root,
+    *,
+    status: int,
+    notifications,
+    mode: str = "spool_only",
+    exporters=None,
+    canary=None,
+    target=None,
+):
+    pipeline = make_pipeline(
+        mode=mode,
+        registry=_registry(status),
+        control=database,
+        barrier=barrier,
+        spool_root=spool_root,
+        clock=FixedClock(NOW),
+        alert_rules=[_rule()],
+        notifications=notifications,
+        exporters=exporters,
+    )
+    return pipeline.run(
+        [canary or canary_config("canary1")],
+        [target or target_config("t1")],
+    )
+
+
+def _records(spool_root: Path, record_type: str) -> list:
+    records = []
+    for path in sorted((spool_root / "pending").glob("*/*.jsonl")):
+        parsed = read_trusted_segment(path, installation_id=INSTALLATION_ID)
+        for frame in parsed.frames:
+            if frame.record.record_type == record_type:
+                records.append(frame.record)
+    return records
+
+
+def _intent_segment_bytes(spool_root: Path) -> bytes:
+    """The concatenated raw durable bytes of every homogeneous notification_intent segment."""
+
+    blob = b""
+    for path in sorted((spool_root / "pending").glob("*/*.jsonl")):
+        parsed = read_trusted_segment(path, installation_id=INSTALLATION_ID)
+        if all(frame.record.record_type == "notification_intent" for frame in parsed.frames):
+            blob += path.read_bytes()
+    return blob
+
+
+# --- applicability: one intent per applicable channel, citing the alert -------------------------
+
+
+def test_a_firing_alert_emits_one_intent_per_applicable_channel_citing_the_alert(
+    tmp_path: Path,
+) -> None:
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        summary = _run(
+            database,
+            barrier,
+            spool_root,
+            status=503,
+            notifications=[_telegram("telegram1"), _github("github1")],
+        )
+        assert (summary.alerts_fired, summary.alerts_resolved) == (1, 0)
+        assert summary.intents_emitted == 2
+        assert summary.intents_error_code is None
+
+        alerts = _records(spool_root, "alert")
+        assert len(alerts) == 1
+        alert = alerts[0]
+
+        intents = _records(spool_root, "notification_intent")
+        assert len(intents) == 2
+        by_channel = {intent.data.channel_id: intent for intent in intents}
+        assert set(by_channel) == {"telegram1", "github1"}
+        assert by_channel["telegram1"].data.channel_type == "telegram"
+        assert by_channel["github1"].data.channel_type == "github_issues"
+        for intent in intents:
+            # Every intent references exactly the committed alert record as its evidence ...
+            assert list(intent.data.evidence_ids) == [alert.record_id]
+            # ... shares the alert's transition identity and coupled severity ...
+            assert intent.data.alert_key == alert.data.alert_key
+            assert intent.data.transition_id == alert.data.transition_id
+            assert intent.severity == intent.data.severity == alert.severity == "error"
+            # ... is system-produced, target-scoped, internal, with the FIXED summary ...
+            assert intent.source.producer == "system"
+            assert intent.collector is None
+            assert intent.scope == "target"
+            assert intent.privacy_class == "internal"
+            assert intent.data.summary == _NOTIFICATION_INTENT_SUMMARY
+    finally:
+        database.close()
+
+
+def test_re_deriving_the_same_transition_and_channel_yields_the_identical_intent_identity(
+    tmp_path: Path,
+) -> None:
+    # Idempotency: the (transition_id, channel_id) coordinate makes the intent record id stable, so
+    # a second identical build of the same alert x channel derives the same record and intent ids.
+    from milhouse.domain.records import finalize_record
+    from milhouse.runtime.pipeline import _notification_intent_draft
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        _run(
+            database,
+            barrier,
+            spool_root,
+            status=503,
+            notifications=[_telegram("telegram1")],
+        )
+        alert = _records(spool_root, "alert")[0]
+        channel = _telegram("telegram1")
+        first = finalize_record(
+            _notification_intent_draft(alert, channel, now=NOW), installation_id=INSTALLATION_ID
+        )
+        second = finalize_record(
+            _notification_intent_draft(alert, channel, now=NOW), installation_id=INSTALLATION_ID
+        )
+        assert first.record_id == second.record_id
+        assert first.data.intent_id == second.data.intent_id
+        # A different channel for the same transition derives a distinct record identity.
+        other = finalize_record(
+            _notification_intent_draft(alert, _telegram("telegram2"), now=NOW),
+            installation_id=INSTALLATION_ID,
+        )
+        assert other.record_id != first.record_id
+        assert other.data.intent_id != first.data.intent_id
+    finally:
+        database.close()
+
+
+def test_a_disabled_or_classification_excluded_channel_emits_no_intent(tmp_path: Path) -> None:
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        summary = _run(
+            database,
+            barrier,
+            spool_root,
+            status=503,
+            notifications=[
+                _telegram("disabled1", enabled=False),  # enabled=False -> never applies
+                _telegram("publiconly1", classifications=["public"]),  # excludes "internal"
+            ],
+        )
+        assert summary.alerts_fired == 1
+        assert summary.intents_emitted == 0
+        assert summary.intents_error_code is None
+        assert _records(spool_root, "notification_intent") == []
+    finally:
+        database.close()
+
+
+def test_a_steady_poll_with_no_transition_emits_no_intent(tmp_path: Path) -> None:
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        # A healthy probe with an inactive rule produces no transition, so no alert, so no intent --
+        # even with an applicable channel configured.
+        summary = _run(
+            database,
+            barrier,
+            spool_root,
+            status=200,
+            notifications=[_telegram("telegram1")],
+        )
+        assert (summary.alerts_fired, summary.alerts_resolved) == (0, 0)
+        assert summary.intents_emitted == 0
+        assert _records(spool_root, "alert") == []
+        assert _records(spool_root, "notification_intent") == []
+    finally:
+        database.close()
+
+
+# --- the intent segment is drained by the existing export tail ----------------------------------
+
+
+def test_a_homogeneous_intent_segment_is_drained_by_the_full_mode_export(tmp_path: Path) -> None:
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        client = FakeClickHouseClient()
+        summary = _run(
+            database,
+            barrier,
+            spool_root,
+            status=503,
+            notifications=[_telegram("telegram1")],
+            mode="full",
+            exporters=clickhouse_exporters(client),
+        )
+        assert summary.intents_emitted == 1
+        assert summary.export_error_code is None
+        # The reused G03/G04b export tail drained the intent segment into the records table.
+        inserted_types = set()
+        for _db, table, rows, columns in client.inserts:
+            if table != "records" or "record_type" not in columns:
+                continue
+            index = list(columns).index("record_type")
+            inserted_types.update(str(row[index]) for row in rows)
+        assert "notification_intent" in inserted_types
+    finally:
+        database.close()
+
+
+# --- privacy: no channel secret / url / target-url leaks into the intent ------------------------
+
+
+def test_no_channel_secret_or_url_or_target_leaks_into_the_intent(tmp_path: Path) -> None:
+    leak_markers = [
+        "LEAKBOTTOKEN",
+        "LEAKCHATID",
+        "leakprovider",
+        "leakowner/leakrepo",
+        "leaklabel",
+        "leakcanaryurl.example",
+        "leaktargeturl.example",
+    ]
+    canary = SiteCanaryCollector(
+        id="canary1",
+        target="t1",
+        type="site_canary",
+        url="https://leakcanaryurl.example/probe",
+        expected_statuses=[200],
+    )
+    target = TargetConfig(
+        id="t1",
+        name="Example Target",
+        kind="web_service",
+        environment="test",
+        base_url="https://leaktargeturl.example",
+    )
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        summary = _run(
+            database,
+            barrier,
+            spool_root,
+            status=503,
+            notifications=[
+                _telegram("telegram1", bot_token_env="LEAKBOTTOKEN", chat_id_env="LEAKCHATID"),
+                _github(
+                    "github1",
+                    provider="leakprovider",
+                    repository="leakowner/leakrepo",
+                    label="leaklabel",
+                ),
+            ],
+            canary=canary,
+            target=target,
+        )
+        assert summary.intents_emitted == 2
+
+        intent_bytes = _intent_segment_bytes(spool_root)
+        assert intent_bytes  # the intent segments exist and were read
+        summary_repr = repr(summary)
+        for marker in leak_markers:
+            # No channel secret ref, provider, repository, label, canary url, or target url reaches
+            # the durable intent bytes, its fixed summary, or the privacy-safe run summary.
+            assert marker.encode("utf-8") not in intent_bytes
+            assert marker not in _NOTIFICATION_INTENT_SUMMARY
+            assert marker not in summary_repr
+        for intent in _records(spool_root, "notification_intent"):
+            for marker in leak_markers:
+                assert marker not in intent.data.summary
+    finally:
+        database.close()
+
+
+# --- per-channel isolation ----------------------------------------------------------------------
+
+
+def test_a_failing_channel_is_isolated_and_never_aborts_the_others(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import milhouse.runtime.pipeline as pipeline_module
+
+    original = pipeline_module._notification_intent_draft
+
+    def flaky(alert, channel, *, now):
+        if channel.id == "boom":
+            raise RuntimeError("channel boom with a secret PLACEHOLDER_BOT_TOKEN_ENV")
+        return original(alert, channel, now=now)
+
+    monkeypatch.setattr(pipeline_module, "_notification_intent_draft", flaky)
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        summary = _run(
+            database,
+            barrier,
+            spool_root,
+            status=503,
+            notifications=[_telegram("boom"), _telegram("good1")],
+        )
+        # The failing channel is isolated with a fixed code; the healthy channel still emitted, and
+        # the alert itself still committed -- the run was never aborted.
+        assert summary.alerts_fired == 1
+        assert summary.intents_emitted == 1
+        assert summary.intents_error_code == "MH_INTERNAL_UNEXPECTED"
+        intents = _records(spool_root, "notification_intent")
+        assert [intent.data.channel_id for intent in intents] == ["good1"]
+        assert "PLACEHOLDER_BOT_TOKEN_ENV" not in repr(summary)
+    finally:
+        database.close()
+
+
+# --- construction guard and static wiring -------------------------------------------------------
+
+
+def test_a_non_channel_notification_fails_closed_at_construction(tmp_path: Path) -> None:
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        with pytest.raises(PipelineError) as caught:
+            make_pipeline(
+                mode="spool_only",
+                registry=_registry(200),
+                control=database,
+                barrier=barrier,
+                spool_root=spool_root,
+                clock=FixedClock(NOW),
+                notifications=["not a channel"],
+            )
+        assert caught.value.code == "MH_RUNTIME_PIPELINE_NOTIFICATIONS"
+    finally:
+        database.close()
+
+
+def test_notification_intent_is_wired_into_the_redaction_and_retention_maps() -> None:
+    # A record type absent from either map fails closed (see _redact_draft / _retention_days), so a
+    # new type MUST be in both to redact its segment and earn a retention window.
+    assert _FREE_TEXT_FIELDS["notification_intent"] == ("summary",)
+    assert _RETENTION_FIELDS["notification_intent"] == "alerts_days"

--- a/tests/unit/test_records.py
+++ b/tests/unit/test_records.py
@@ -16,6 +16,7 @@ from milhouse.domain.records import (
     FeedbackTransitionDataV1,
     IncidentDataV1,
     MetricDataV1,
+    NotificationIntentDataV1,
     RatioAtLeastPredicateV1,
     RecordDraftV1,
     RecordEnvelopeV1,
@@ -488,6 +489,57 @@ def test_alert_and_incident_transitions_are_append_only_and_consistent() -> None
         )
     with pytest.raises(ValidationError, match=RECORD_VALIDATION_MESSAGE):
         _draft(alert, record_type="alert", severity="warning")
+
+
+def test_notification_intent_record_round_trips_and_couples_severity() -> None:
+    intent = NotificationIntentDataV1(
+        intent_id="mh_nin1_example",
+        alert_key="mh_ak1_example",
+        transition_id="mh_atr1_example",
+        channel_id="telegram1",
+        channel_type="telegram",
+        severity="error",
+        summary="A configured channel recorded a durable intent to notify.",
+        evidence_ids=[EVIDENCE_ID],
+    )
+    # A notification intent is system-produced, so it carries NO collector provenance.
+    record = finalize_record(
+        _draft(
+            intent,
+            record_type="notification_intent",
+            name="alert.notification_intent",
+            severity="error",
+            source=_source(producer="system"),
+            collector=None,
+            collector_run_id=None,
+        ),
+        installation_id=INSTALLATION_ID,
+    )
+    assert record.data.type == "notification_intent"
+    assert record.record_type == "notification_intent"
+    assert record.severity == record.data.severity == "error"  # type: ignore[union-attr]
+    verify_record_identity(record, installation_id=INSTALLATION_ID)
+
+    # The envelope severity must couple to the payload severity, exactly like an alert.
+    with pytest.raises(ValidationError, match=RECORD_VALIDATION_MESSAGE):
+        _draft(
+            intent,
+            record_type="notification_intent",
+            name="alert.notification_intent",
+            severity="warning",
+            source=_source(producer="system"),
+            collector=None,
+            collector_run_id=None,
+        )
+    # A system-produced record forbids collector provenance.
+    with pytest.raises(ValidationError, match=RECORD_VALIDATION_MESSAGE):
+        _draft(
+            intent,
+            record_type="notification_intent",
+            name="alert.notification_intent",
+            severity="error",
+            source=_source(producer="system"),
+        )
 
 
 def test_feedback_item_and_transition_contracts_enforce_authority_and_evidence() -> None:


### PR DESCRIPTION
## What & why
Fourth offline slice of **W05** (epic #94, issue **#139**): when the alert engine commits an `AlertDataV1` firing/resolved transition, the runtime emits durable `NotificationIntentDataV1` records — one per applicable configured notification channel — **without sending anything**. Delivery (transports, dry-run, retry, rate-limit, idempotent "sent" state) is **W14**. G05/G04 stay In progress / NOT passed (live = E06/#108).

## Changes
- **`domain/records.py` `NotificationIntentDataV1`** — privacy-safe **by construction**: references the alert (`alert_key`/`transition_id`/`evidence_ids`) and names the channel by its **non-secret `channel_id` + `channel_type` only**, with a **fixed** `summary` and coupled `severity`. It has **no field** that could hold a bot token / chat id / provider / repository / url / target. Added to the `RecordDataV1` union, `RecordTypeV1`, and the severity-coupling contract; the security count-pin moves 23→24.
- **`domain/identity.py` `derive_notification_intent_id(transition_id, channel_id)`** — a domain-separated one-way digest, so one `(transition × channel)` re-derives an identical id (idempotent) and is distinct across channels/transitions.
- **`runtime/pipeline.py` `_drive_notification_intents`** — a stage after the alert stage, before the export tail: for each committed alert transition × each channel that is **`enabled` AND whose `allowed_classifications` admits the alert's privacy class**, build one intent draft, redact+finalize, and commit its **own homogeneous `notification_intent` segment** (never mixed with the alert segment), isolated per channel. Wired into `_FREE_TEXT_FIELDS` (`summary`) + `_RETENTION_FIELDS` (`alerts_days`) — an unwired type fails closed. `PipelineRunSummary` gains `intents_emitted`/`intents_error_code`. No new ClickHouse migration (the generic `records` table takes any type).

## Review
The build agent stalled on its final full-suite run; I completed the verification (the security count-pin 23→24 it missed, a `ruff format` reflow, two lint nits). An independent **adversarial review** then confirmed the **privacy boundary holds under a field-by-field trace** (no secret reaches the intent record, its durable bytes, the fixed summary, the source coordinate, the run summary, or any error), and every functional requirement (applicability, idempotency, fail-closed wiring, homogeneous segment, per-channel isolation, no alert-stage regression) is met + test-backed — **verdict SAFE-TO-MERGE**.

## Deferred → #132
**P2 (non-blocking):** notification intents are **at-most-once** relative to a transition — the alert state advances before the intent stage commits, so a transient intent-commit failure is surfaced in the run summary but not retried. A transactional emit-before-advance or a reconciliation pass is tracked. Also deferred: actual sending/transports (W14), a precise alert-rule→channel routing config field, latency/freshness rules.

## Gates
`test` **5073 passed / 6 skipped** · `quality` (ruff, mypy strict, docs-check, zizmor, skill-check) · `secret-scan` (tree + history) — all clean.

Refs #94, #93, #108, #132
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)