### PR TITLE
feat(cli): W06 collect CLI increment 1 — collect (spool-only) + init pseudonym-key provisioning

### DIFF
--- a/src/milhouse/cli/bootstrap.py
+++ b/src/milhouse/cli/bootstrap.py
@@ -7,9 +7,12 @@ non-secret installation identity; ``health`` reports whether an initialized inst
 are local, spool-only, and credential-free — no network, no secret resolution, no provider calls.
 
 The installation identity here is the record-identity ``mh_in1_`` UUID used in canonical record
-derivation (plan section 4.2), persisted as an owner-only file in the control directory. It is
-distinct from the keyed pseudonym-key lifecycle of plan section 4.7, which amendment A09 keeps
-deferred; this slice never creates or reads that key.
+derivation (plan section 4.2), persisted as an owner-only file in the control directory. When the
+validated config is supplied (the ``init`` command passes it), ``initialize`` ALSO provisions the
+keyed pseudonym key of plan section 4.7 that the runtime redactor requires — created once,
+owner-only (0600), and never rotated on a re-run — by reusing the ``privacy.keys`` primitives
+exactly. Callers that do not need the key (the spool-only demo) omit the config and never touch it.
+Key material is never logged, echoed, or returned: only whether a key was provisioned.
 """
 
 from __future__ import annotations
@@ -22,11 +25,18 @@ from datetime import datetime
 from pathlib import Path
 
 from milhouse.config import RuntimePaths
+from milhouse.config._models import MilhouseConfig
 from milhouse.config.filesystem import (
     SecureFileError,
     create_regular_file_no_follow,
     open_regular_file_no_follow,
 )
+from milhouse.privacy.keys import (
+    PseudonymKeyCommitUncertain,
+    create_pseudonym_key,
+    recover_pseudonym_key_creation,
+)
+from milhouse.privacy.pseudonym import PrivacyError
 from milhouse.state import (
     GlobalCommitBarrier,
     initialize_control_state,
@@ -66,12 +76,19 @@ class InitReport:
     created_directories: tuple[str, ...]
     schema_version: int
     installation_id_created: bool
+    #: Whether this pass created the keyed pseudonym key. Always ``False`` when ``initialize`` was
+    #: called without a config (the credential-free callers that never touch the key).
+    pseudonym_key_created: bool = False
 
     @property
     def already_initialized(self) -> bool:
         """Whether the pass changed nothing durable (fully idempotent re-run)."""
 
-        return not self.created_directories and not self.installation_id_created
+        return (
+            not self.created_directories
+            and not self.installation_id_created
+            and not self.pseudonym_key_created
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -187,12 +204,54 @@ def _ensure_installation_id(paths: RuntimePaths) -> bool:
     return True
 
 
-def initialize(paths: RuntimePaths, *, now: datetime) -> InitReport:
+def _ensure_pseudonym_key(config: MilhouseConfig, paths: RuntimePaths) -> bool:
+    """Provision the keyed pseudonym key iff absent; recover a commit-uncertain publish. Idempotent.
+
+    Reuses the ``privacy.keys`` primitives EXACTLY: ``create_pseudonym_key`` writes a fresh
+    owner-only (0600) key and refuses to overwrite an existing path, so a present key is left
+    untouched (never rotated) and reported as ``False``. A commit-uncertain publication is durably
+    adopted through ``recover_pseudonym_key_creation`` using the non-secret key id it carries; a
+    still-uncertain or otherwise failed provision fails closed with a fixed code. The returned
+    :class:`Pseudonymizer` is deliberately discarded — this function NEVER logs, echoes, or returns
+    key material, only whether a key was created.
+    """
+
+    try:
+        create_pseudonym_key(config, paths)
+    except PseudonymKeyCommitUncertain as uncertain:
+        # The key bytes reached disk but their durability was uncertain: verify by non-secret key id
+        # (``mh_pk1_...`` -- not key material) and fsync the parent. A still-uncertain outcome fails
+        # closed rather than leaving a possibly-unrecoverable key silently in place.
+        try:
+            recover_pseudonym_key_creation(config, paths, expected_key_id=uncertain.key_id)
+        except PrivacyError as error:
+            raise BootstrapError(
+                "MH_INIT_PSEUDONYM_KEY",
+                "the pseudonym key could not be durably provisioned",
+            ) from error
+        return True
+    except PrivacyError as error:
+        if error.code == "MH_PRIVACY_KEY_EXISTS":
+            # Idempotent: a present key is never rotated or overwritten on a re-run.
+            return False
+        raise BootstrapError(
+            "MH_INIT_PSEUDONYM_KEY",
+            "the pseudonym key could not be provisioned",
+        ) from error
+    return True
+
+
+def initialize(
+    paths: RuntimePaths, *, now: datetime, config: MilhouseConfig | None = None
+) -> InitReport:
     """Idempotently create the state-root layout, apply the schema, and establish identity.
 
     Creates ``state_root`` and its ``control``/``spool``/``reports``/``logs``/``backups`` children
     (0700), opens the control database and applies every unapplied migration under the commit
-    barrier, and generates the installation id if absent. Re-running changes nothing durable.
+    barrier, and generates the installation id if absent. When ``config`` is supplied (the ``init``
+    command passes the validated config), it ALSO provisions the keyed pseudonym key the runtime
+    redactor requires, once and owner-only, reusing the ``privacy.keys`` primitives. Re-running
+    changes nothing durable — the key is never rotated once present.
     """
 
     created: list[str] = []
@@ -208,10 +267,15 @@ def initialize(paths: RuntimePaths, *, now: datetime) -> InitReport:
         database.close()
 
     installation_created = _ensure_installation_id(paths)
+    # The pseudonym key is provisioned only when the validated config is available: its secure
+    # creation is bound to that config's resolved runtime generation, and credential-free callers
+    # (the spool-only demo) never need it. The control dir it lives under was created above (0700).
+    pseudonym_key_created = _ensure_pseudonym_key(config, paths) if config is not None else False
     return InitReport(
         created_directories=tuple(created),
         schema_version=version,
         installation_id_created=installation_created,
+        pseudonym_key_created=pseudonym_key_created,
     )
 
 
@@ -231,6 +295,25 @@ def _database_check(paths: RuntimePaths) -> HealthCheck:
     ok = version == EXPECTED_SCHEMA_VERSION
     detail = f"schema {version}" if ok else f"schema {version}, expected {EXPECTED_SCHEMA_VERSION}"
     return HealthCheck("control_database", ok, detail)
+
+
+def _pseudonym_key_present(paths: RuntimePaths) -> bool:
+    """Whether the pseudonym key file is present, checked privacy-safely (its bytes are never read).
+
+    Mirrors :func:`read_installation_id`'s no-follow presence probe: a regular non-symlink file that
+    opens is present; any :class:`SecureFileError` (missing, not regular, symlink, unsafe) means it
+    is absent. This is a PRESENCE check only — it never reads, loads, logs, or returns key material.
+    """
+
+    try:
+        opened = open_regular_file_no_follow(paths.pseudonym_key)
+    except SecureFileError:
+        return False
+    try:
+        os.close(opened.descriptor)
+    except OSError:  # pragma: no cover - defensive: close of our own fd
+        pass
+    return True
 
 
 def health(paths: RuntimePaths, *, now: datetime) -> HealthReport:
@@ -255,6 +338,19 @@ def health(paths: RuntimePaths, *, now: datetime) -> HealthReport:
             "installation_identity",
             identity_present,
             "established" if identity_present else "missing (run milhouse init)",
+        )
+    )
+
+    # The runtime redactor -- and therefore ``collect run`` -- hard-requires the pseudonym key, so
+    # an install without it is NOT usable even though its directories, schema, and identity are
+    # sound. Report its presence (a privacy-safe presence probe only) so ``health``/``doctor`` no
+    # longer call a keyless install healthy while ``collect run`` fails "run milhouse init first".
+    key_present = _pseudonym_key_present(paths)
+    checks.append(
+        HealthCheck(
+            "pseudonym_key",
+            key_present,
+            "present" if key_present else "missing (run milhouse init)",
         )
     )
     return HealthReport(checks=tuple(checks))

--- a/src/milhouse/cli/root.py
+++ b/src/milhouse/cli/root.py
@@ -12,6 +12,7 @@ from platformdirs import user_config_path, user_data_path
 
 from milhouse import __version__, storage
 from milhouse.cli import bootstrap, demo, views
+from milhouse.collectors.site_canary import register_site_canary
 from milhouse.config import (
     ConfigError,
     RuntimePaths,
@@ -21,10 +22,21 @@ from milhouse.config import (
     resolve_runtime_paths,
 )
 from milhouse.config._models import MilhouseConfig
+from milhouse.config.loader import validated_config_digest
 from milhouse.core.clock import SystemClock
+from milhouse.core.errors import MilhouseError
+from milhouse.privacy.keys import load_pseudonym_key
+from milhouse.privacy.pseudonym import PrivacyError
+from milhouse.privacy.redact import LayeredRedactor
+from milhouse.runtime import CollectorRegistry, PipelineError, PipelineRunSummary, RuntimePipeline
 from milhouse.spooling import SpoolError, replay_segments
 from milhouse.spooling.ledger import list_segment_records
-from milhouse.state import GlobalCommitBarrier, open_control_database
+from milhouse.state import (
+    ControlDatabase,
+    GlobalCommitBarrier,
+    StateError,
+    open_control_database,
+)
 
 
 @dataclass(frozen=True, slots=True, repr=False)
@@ -147,11 +159,16 @@ class BootstrapCommandError(click.ClickException):
 @click.option("--json", "as_json", is_flag=True, help="Emit the result as stable JSON.")
 @click.pass_obj
 def init_command(state: CliState, as_json: bool) -> None:
-    """Initialize the state root, control database, and installation identity (idempotent)."""
+    """Initialize the state root, control database, installation identity, and pseudonym key.
 
-    paths = _resolve_paths(state)
+    Fully idempotent: a re-run creates only what is missing and NEVER rotates the pseudonym key the
+    runtime redactor requires. Reports only whether each artifact was created — never any key
+    material. Exit 0 on success, 1 on a bootstrap failure, 2 on an invalid configuration.
+    """
+
+    config, paths = _resolve_config(state)
     try:
-        report = bootstrap.initialize(paths, now=SystemClock().now())
+        report = bootstrap.initialize(paths, now=SystemClock().now(), config=config)
     except bootstrap.BootstrapError as error:
         raise BootstrapCommandError(error) from None
     if as_json:
@@ -161,6 +178,7 @@ def init_command(state: CliState, as_json: bool) -> None:
                     "created_directories": list(report.created_directories),
                     "schema_version": report.schema_version,
                     "installation_id_created": report.installation_id_created,
+                    "pseudonym_key_created": report.pseudonym_key_created,
                     "already_initialized": report.already_initialized,
                 },
                 sort_keys=True,
@@ -172,9 +190,10 @@ def init_command(state: CliState, as_json: bool) -> None:
         return
     created = ", ".join(report.created_directories) or "none"
     identity = "created" if report.installation_id_created else "present"
+    key = "created" if report.pseudonym_key_created else "present"
     click.echo(
         f"initialized: directories={created}; schema {report.schema_version}; "
-        f"installation id {identity}"
+        f"installation id {identity}; pseudonym key {key}"
     )
 
 
@@ -249,6 +268,276 @@ def _require_installation_id(paths: RuntimePaths) -> str:
             bootstrap.BootstrapError("MH_NOT_INITIALIZED", "run milhouse init first")
         )
     return installation_id
+
+
+class CollectCommandError(click.ClickException):
+    """A stable ``collect`` failure using the CLI contract's exit code 1.
+
+    Carries the fixed machine code of an underlying coded failure — a privacy, spool, state, or
+    pipeline error (all :class:`~milhouse.core.errors.MilhouseError` subclasses with a ``.code``).
+    Those errors expose only bounded, fixed strings — never key material, a secret, a path, a URL,
+    or a payload — so rendering the code and message here leaks nothing.
+    """
+
+    exit_code = 1
+
+    def __init__(self, error: MilhouseError) -> None:
+        self.code = error.code
+        super().__init__(str(error))
+
+
+def _new_collect_registry() -> CollectorRegistry:
+    """Build the production first-party collector registry (real HTTP-backed site_canary).
+
+    A module-level seam so a network-free test can substitute a registry holding a fake collector;
+    production ``collect`` always calls it with the real registry.
+    """
+
+    registry = CollectorRegistry()
+    register_site_canary(registry)
+    return registry
+
+
+def _build_collect_pipeline(
+    config: MilhouseConfig,
+    paths: RuntimePaths,
+    installation_id: str,
+    control: ControlDatabase,
+    *,
+    registry: CollectorRegistry | None = None,
+) -> RuntimePipeline:
+    """Assemble a spool-only :class:`RuntimePipeline` from validated config and control plane.
+
+    Extracted as the testable seam the ``collect`` command builds through: production passes
+    ``registry=None`` (the real registry, whose site_canary factory builds a live HTTP client) while
+    a test injects a registry holding a network-free fake collector. The pipeline hard-requires a
+    :class:`LayeredRedactor`, so this loads the keyed pseudonym key ``init`` provisions and FAILS
+    CLOSED with ``run milhouse init first`` when it is absent (a corrupt or foreign key surfaces its
+    own fixed code instead). The redactor is built with no extra known secrets; the collectors are
+    the primary redaction authority. ``config_generation`` is the deterministic 64-hex digest of
+    the fully validated config, which the pipeline re-checks. Exporters are empty (spool_only):
+    committed segments are NOT delivered to ClickHouse in this release.
+    """
+
+    if registry is None:
+        registry = _new_collect_registry()
+    try:
+        pseudonymizer = load_pseudonym_key(config, paths)
+    except PrivacyError as error:
+        if error.code == "MH_PRIVACY_KEY_NOT_FOUND":
+            raise BootstrapCommandError(
+                bootstrap.BootstrapError("MH_NOT_INITIALIZED", "run milhouse init first")
+            ) from None
+        raise CollectCommandError(error) from None
+    redactor = LayeredRedactor(pseudonymizer, known_secrets=())
+    barrier = GlobalCommitBarrier(
+        paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
+    )
+    return RuntimePipeline(
+        mode="spool_only",
+        config_generation=validated_config_digest(config),
+        registry=registry,
+        redactor=redactor,
+        control=control,
+        barrier=barrier,
+        spool_root=paths.spool,
+        installation_id=installation_id,
+        clock=SystemClock(),
+        retention=config.retention,
+        exporters={},
+        alert_rules=config.alert_rules,
+        notifications=config.notifications,
+    )
+
+
+def _collect_run_payload(summary: PipelineRunSummary) -> dict[str, object]:
+    """Project a run summary into the privacy-safe JSON payload (counts, codes, config ids)."""
+
+    return {
+        "mode": summary.mode,
+        "alerts_fired": summary.alerts_fired,
+        "alerts_resolved": summary.alerts_resolved,
+        "alerts_error_code": summary.alerts_error_code,
+        "intents_emitted": summary.intents_emitted,
+        "intents_error_code": summary.intents_error_code,
+        "export_error_code": summary.export_error_code,
+        "records_committed": summary.records_committed,
+        "records_delivered": summary.records_delivered,
+        "records_failed": summary.records_failed,
+        "collectors": [
+            {
+                "collector_id": collector.collector_id,
+                "status": collector.status,
+                "error_code": collector.error_code,
+                "drafts_produced": collector.drafts_produced,
+                "records_committed": collector.records_committed,
+                "records_delivered": collector.records_delivered,
+                "records_failed": collector.records_failed,
+                "batch_id": collector.batch_id,
+            }
+            for collector in summary.collectors
+        ],
+    }
+
+
+def _collect_run_failed(summary: PipelineRunSummary) -> bool:
+    """The exit-1 predicate: any stage error code, a failed record, or a failed/error collector."""
+
+    return (
+        summary.export_error_code is not None
+        or summary.alerts_error_code is not None
+        or summary.intents_error_code is not None
+        or summary.records_failed > 0
+        or any(collector.status in ("failed", "error") for collector in summary.collectors)
+    )
+
+
+@main.group(name="collect")
+def collect_group() -> None:
+    """Run configured collectors once into the local spool (spool-only), or list them."""
+
+
+@collect_group.command(name="run")
+@click.argument("collector_id", required=False)
+@click.option(
+    "--target",
+    "target_id",
+    default=None,
+    metavar="TARGET_ID",
+    help="Run only the collectors bound to this declared target id.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the run summary as stable JSON.")
+@click.pass_context
+def collect_run_command(
+    context: click.Context,
+    collector_id: str | None,
+    target_id: str | None,
+    as_json: bool,
+) -> None:
+    """Collect, redact, and spool every configured collector once (spool-only).
+
+    Builds the W05 runtime pipeline in spool_only mode and runs it a single time: each collector's
+    drafts are redacted, finalized, and committed to the local spool, and the configured canary
+    alert rules and notification-intent records are evaluated inside that run. Nothing is exported
+    to ClickHouse in this release — full-mode export from ``collect`` is a later increment, so a
+    config with ``runtime.mode = "full"`` is REJECTED (exit 2) rather than silently run spool-only.
+    Requires an initialized install (run ``milhouse init`` first): the pipeline's redactor needs the
+    keyed pseudonym key that ``init`` provisions.
+
+    An optional ``COLLECTOR_ID`` runs only that configured collector; ``--target`` runs only the
+    collectors bound to that declared target. An unknown collector or target id is a configuration
+    error. The emitted summary carries ONLY privacy-safe counts, fixed codes, and config-declared
+    ids — never a secret, PII, path, payload, URL, or target host.
+
+    Exit codes: 0 clean; 1 if any stage error code is set OR any records failed OR any collector
+    ended ``failed``/``error`` OR the run aborts with a coded spool/state/pipeline failure; 2 for an
+    invalid configuration — an unknown collector or target id, OR ``runtime.mode = "full"``
+    (full-mode ClickHouse export is unsupported this increment).
+    """
+
+    state = context.ensure_object(CliState)
+    config, paths = _resolve_config(state)
+
+    # Fail closed on full mode rather than silently downgrade: a spool_only run stamps
+    # ``required_exporters=()`` on every committed segment, so ``commit`` records no clickhouse
+    # delivery obligation and a later ``storage export`` can NEVER drain those segments (it reports
+    # them ``unhandled`` / "export incomplete" forever, with no way to attach an obligation after
+    # the fact). Running spool_only under a ``full`` config would therefore durably strand records
+    # the operator expects in ClickHouse. Wiring the export tail is the next increment; until then
+    # reject so nothing is stranded.
+    if config.runtime.mode == "full":
+        raise ConfigCommandError(
+            ConfigError(
+                "config.runtime.full_mode_unsupported",
+                "collect run does not support full-mode ClickHouse export yet; set "
+                "runtime.mode = spool_only in your config to collect now (full-mode export lands "
+                "in the next increment)",
+            )
+        )
+
+    collectors = list(config.collectors)
+    if collector_id is not None:
+        collectors = [collector for collector in collectors if collector.id == collector_id]
+        if not collectors:
+            raise ConfigCommandError(
+                ConfigError(
+                    "config.collector.unknown", "no collector with the requested id is configured"
+                )
+            )
+    if target_id is not None:
+        if target_id not in {target.id for target in config.targets}:
+            raise ConfigCommandError(
+                ConfigError(
+                    "config.target.unknown", "no target with the requested id is configured"
+                )
+            )
+        collectors = [
+            collector for collector in collectors if getattr(collector, "target", None) == target_id
+        ]
+
+    installation_id = _require_installation_id(paths)
+    control = open_control_database(bootstrap.database_path(paths))
+    try:
+        pipeline = _build_collect_pipeline(config, paths, installation_id, control)
+        # The full target set is passed for lookup; the collector filters above scope the run.
+        summary = pipeline.run(tuple(collectors), tuple(config.targets))
+    except (SpoolError, StateError, PipelineError) as error:
+        # A spool-integrity, control-state, or pipeline-construction failure (e.g. DurableSpool
+        # reconciliation, a tampered barrier, a crashed-prior-writer orphan) must surface as the
+        # coded exit-1 contract every other command produces -- a clean ``error: MH_...`` rather
+        # than a raw traceback. Per-collector faults are already isolated INTO the summary; this
+        # catches only failures that abort the whole run. The key-missing / other PrivacyError
+        # mappings raised inside ``_build_collect_pipeline`` are ClickExceptions and propagate.
+        raise CollectCommandError(error) from None
+    finally:
+        control.close()
+
+    if as_json:
+        click.echo(json.dumps(_collect_run_payload(summary), sort_keys=True))
+    else:
+        click.echo(
+            f"collect: mode={summary.mode} committed={summary.records_committed} "
+            f"delivered={summary.records_delivered} failed={summary.records_failed} "
+            f"alerts_fired={summary.alerts_fired} alerts_resolved={summary.alerts_resolved} "
+            f"intents_emitted={summary.intents_emitted}"
+        )
+        for collector in summary.collectors:
+            code = collector.error_code or "none"
+            batch = collector.batch_id or "none"
+            click.echo(
+                f"  {collector.collector_id}: status={collector.status} error={code} "
+                f"drafts={collector.drafts_produced} committed={collector.records_committed} "
+                f"delivered={collector.records_delivered} failed={collector.records_failed} "
+                f"batch={batch}"
+            )
+    stage_error_codes: tuple[tuple[str, str | None], ...] = (
+        ("export", summary.export_error_code),
+        ("alerts", summary.alerts_error_code),
+        ("intents", summary.intents_error_code),
+    )
+    for label, stage_code in stage_error_codes:
+        if stage_code is not None:
+            click.echo(f"WARNING: the {label} stage reported {stage_code}", err=True)
+    if _collect_run_failed(summary):
+        context.exit(1)
+
+
+@collect_group.command(name="list")
+@click.option("--json", "as_json", is_flag=True, help="Emit the listing as stable JSON.")
+@click.pass_obj
+def collect_list_command(state: CliState, as_json: bool) -> None:
+    """List the configured collectors' ids and kinds (privacy-safe; config-declared, not secret)."""
+
+    config, _paths = _resolve_config(state)
+    rows = [{"id": collector.id, "type": collector.type} for collector in config.collectors]
+    if as_json:
+        click.echo(json.dumps({"collectors": rows}, sort_keys=True))
+        return
+    if not rows:
+        click.echo("no configured collectors")
+        return
+    for row in rows:
+        click.echo(f"{row['id']}  type={row['type']}")
 
 
 @main.group(name="spool")

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -38,6 +38,18 @@ def _paths(tmp_path: Path) -> RuntimePaths:
     )
 
 
+def _init_with_key(tmp_path: Path) -> RuntimePaths:
+    """Initialize an install WITH the pseudonym key (a full config-aware init)."""
+
+    config_file = _config_file(tmp_path)
+    config, config_path = load_config(config_file, platform_default=config_file)
+    paths = resolve_runtime_paths(
+        config, config_path=config_path, platform_data_root=tmp_path / "platform"
+    )
+    bootstrap.initialize(paths, now=_NOW, config=config)
+    return paths
+
+
 def test_initialize_creates_the_full_layout_schema_and_identity(tmp_path: Path) -> None:
     paths = _paths(tmp_path)
     report = bootstrap.initialize(paths, now=_NOW)
@@ -125,8 +137,8 @@ def test_initialize_fails_closed_when_a_directory_cannot_be_created(tmp_path: Pa
 
 
 def test_health_is_healthy_after_init(tmp_path: Path) -> None:
-    paths = _paths(tmp_path)
-    bootstrap.initialize(paths, now=_NOW)
+    # A full config-aware init provisions the pseudonym key, so the install is fully healthy.
+    paths = _init_with_key(tmp_path)
 
     report = bootstrap.health(paths, now=_NOW)
 
@@ -136,7 +148,30 @@ def test_health_is_healthy_after_init(tmp_path: Path) -> None:
         "control_database",
         "installation_identity",
         "directory:spool",
+        "pseudonym_key",
     }
+
+
+def test_health_flags_a_missing_pseudonym_key(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    config, config_path = load_config(config_file, platform_default=config_file)
+    paths = resolve_runtime_paths(
+        config, config_path=config_path, platform_data_root=tmp_path / "platform"
+    )
+    # Keyless init: directories + schema + identity, but NO pseudonym key (collect run needs it).
+    bootstrap.initialize(paths, now=_NOW)
+
+    report = bootstrap.health(paths, now=_NOW)
+
+    key_check = next(check for check in report.checks if check.name == "pseudonym_key")
+    assert key_check.ok is False
+    assert report.healthy is False  # a keyless install is not usable
+
+    # A full init (with config) provisions the key; the install becomes healthy again.
+    bootstrap.initialize(paths, now=_NOW, config=config)
+    healed = bootstrap.health(paths, now=_NOW)
+    assert next(check for check in healed.checks if check.name == "pseudonym_key").ok is True
+    assert healed.healthy is True
 
 
 def test_health_is_unhealthy_before_init(tmp_path: Path) -> None:

--- a/tests/unit/test_cli_views.py
+++ b/tests/unit/test_cli_views.py
@@ -32,6 +32,18 @@ def _paths(tmp_path: Path) -> RuntimePaths:
     )
 
 
+def _init_with_key(tmp_path: Path) -> RuntimePaths:
+    """Initialize an install WITH the pseudonym key so ``health``/``doctor`` report it healthy."""
+
+    config_file = _config_file(tmp_path)
+    config, config_path = load_config(config_file, platform_default=config_file)
+    paths = resolve_runtime_paths(
+        config, config_path=config_path, platform_data_root=tmp_path / "platform"
+    )
+    bootstrap.initialize(paths, now=_NOW, config=config)
+    return paths
+
+
 def test_list_segments_reports_spooled_segments(tmp_path: Path) -> None:
     paths = _paths(tmp_path)
     first = demo.run_demo(paths, now=_NOW)
@@ -114,7 +126,8 @@ def test_show_segment_reports_an_unreadable_file(tmp_path: Path) -> None:
 
 
 def test_doctor_reports_health_and_spool_totals(tmp_path: Path) -> None:
-    paths = _paths(tmp_path)
+    # Provision the pseudonym key so the install is fully healthy; demo alone does not create it.
+    paths = _init_with_key(tmp_path)
     demo.run_demo(paths, now=_NOW)
     demo.run_demo(paths, now=_NOW)
 
@@ -139,6 +152,8 @@ def test_doctor_is_unhealthy_before_init(tmp_path: Path) -> None:
 def test_cli_spool_list_and_events_and_doctor(tmp_path: Path) -> None:
     config_file = _config_file(tmp_path)
     runner = CliRunner()
+    # A full config-aware init provisions the pseudonym key so ``doctor`` reports the install ok.
+    runner.invoke(main, ["--config", str(config_file), "init"])
     runner.invoke(main, ["--config", str(config_file), "demo"])
 
     listing = runner.invoke(main, ["--config", str(config_file), "spool", "list"])

--- a/tests/unit/test_collect_cli.py
+++ b/tests/unit/test_collect_cli.py
@@ -1,0 +1,363 @@
+"""Tests for the W06 ``collect`` CLI and ``init`` pseudonym-key provisioning (increment 1).
+
+Network-free: the real ``site_canary`` collector performs a live HTTP GET through a registry factory
+with no injection seam, so these tests substitute the module-level collect registry
+(:func:`milhouse.cli.root._new_collect_registry`) with one holding a fake, spool-only collector.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from _runtime_harness import KNOWN_SECRET, FakeCollector, fake_factory, registry_with
+from click.testing import CliRunner
+
+from milhouse.cli import bootstrap, root
+from milhouse.cli.root import main
+from milhouse.config import RuntimePaths, load_config, resolve_runtime_paths
+from milhouse.domain.records import CollectorDescriptorV1
+from milhouse.spooling import SpoolError
+from milhouse.state import StateError
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLE_CONFIG = (_REPO_ROOT / "config" / "example.toml").read_text(encoding="utf-8")
+# A second site_canary collector on the already-declared target, so a per-collector isolation run
+# has one collector that fails and one that succeeds. Appended text appends to the collectors array.
+_SECOND_COLLECTOR = (
+    '\n[[collectors]]\nid = "second-canary"\ntype = "site_canary"\n'
+    'target = "example-app"\nurl = "https://example.com/health2"\nexpected_statuses = [200]\n'
+)
+
+
+def _config_file(tmp_path: Path, *, extra: str = "", mode: str = "spool_only") -> Path:
+    # The example config ships ``runtime.mode = "full"``; collect run rejects full mode (exit 2), so
+    # the run-path tests default to a spool_only config. ``mode="full"`` is used to test the reject.
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    config_file = config_dir / "config.toml"
+    body = _EXAMPLE_CONFIG.replace('mode = "full"', f'mode = "{mode}"')
+    config_file.write_text(body + extra, encoding="utf-8")
+    return config_file
+
+
+def _paths(config_file: Path, tmp_path: Path) -> RuntimePaths:
+    config, config_path = load_config(config_file, platform_default=config_file)
+    return resolve_runtime_paths(
+        config, config_path=config_path, platform_data_root=tmp_path / "platform"
+    )
+
+
+def _use_fake_registry(monkeypatch: pytest.MonkeyPatch, factory: object) -> None:
+    """Swap the production collect registry for one resolving ``site_canary`` to ``factory``."""
+
+    registry = registry_with("site_canary", factory)
+    monkeypatch.setattr(root, "_new_collect_registry", lambda: registry)
+
+
+def _isolation_factory(fail_id: str) -> object:
+    """A factory whose collector raises for ``fail_id`` and otherwise succeeds with one event."""
+
+    def factory(config: object) -> FakeCollector:
+        descriptor = CollectorDescriptorV1(
+            id=config.id,  # type: ignore[attr-defined]
+            type="site.canary",
+            implementation_version="1.0.0",
+        )
+        return FakeCollector(
+            descriptor=descriptor,
+            messages=("probe ok",),
+            raises=(config.id == fail_id),  # type: ignore[attr-defined]
+        )
+
+    return factory
+
+
+_PRIVACY_SAFE_TOP_KEYS = {
+    "mode",
+    "alerts_fired",
+    "alerts_resolved",
+    "alerts_error_code",
+    "intents_emitted",
+    "intents_error_code",
+    "export_error_code",
+    "records_committed",
+    "records_delivered",
+    "records_failed",
+    "collectors",
+}
+_PRIVACY_SAFE_COLLECTOR_KEYS = {
+    "collector_id",
+    "status",
+    "error_code",
+    "drafts_produced",
+    "records_committed",
+    "records_delivered",
+    "records_failed",
+    "batch_id",
+}
+
+
+# --- Part A: init provisions the pseudonym key, idempotently --------------------------------------
+
+
+def test_init_provisions_the_pseudonym_key_owner_only(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    paths = _paths(config_file, tmp_path)
+
+    result = CliRunner().invoke(main, ["--config", str(config_file), "init"])
+
+    assert result.exit_code == 0
+    key_file = paths.pseudonym_key
+    assert key_file.is_file()
+    assert stat.S_IMODE(os.stat(key_file).st_mode) == 0o600
+    assert "pseudonym key created" in result.output
+
+
+def test_init_is_idempotent_and_never_rotates_the_key(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    paths = _paths(config_file, tmp_path)
+    runner = CliRunner()
+
+    first = runner.invoke(main, ["--config", str(config_file), "init", "--json"])
+    assert first.exit_code == 0
+    key_bytes = paths.pseudonym_key.read_bytes()
+
+    second = runner.invoke(main, ["--config", str(config_file), "init", "--json"])
+
+    assert second.exit_code == 0
+    assert json.loads(first.output)["pseudonym_key_created"] is True
+    assert json.loads(second.output)["pseudonym_key_created"] is False
+    assert json.loads(second.output)["already_initialized"] is True
+    # The key bytes are unchanged across the re-run (never rotated/overwritten).
+    assert paths.pseudonym_key.read_bytes() == key_bytes
+
+
+def test_init_never_echoes_key_material(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    paths = _paths(config_file, tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+    key_bytes = paths.pseudonym_key.read_bytes()
+
+    text = runner.invoke(main, ["--config", str(config_file), "init"]).output
+    as_json = runner.invoke(main, ["--config", str(config_file), "init", "--json"]).output
+
+    # Neither the raw bytes nor their hex ever appear in any rendering.
+    assert key_bytes.hex() not in text
+    assert key_bytes.hex() not in as_json
+    for rendering in (text, as_json):
+        assert not any(chunk in rendering for chunk in (key_bytes[:8].hex(), key_bytes[-8:].hex()))
+
+
+# --- Part B: collect run (spool-only) -------------------------------------------------------------
+
+
+def test_collect_run_commits_a_segment_and_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = _config_file(tmp_path)
+    paths = _paths(config_file, tmp_path)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["mode"] == "spool_only"
+    assert payload["records_committed"] >= 1
+    assert payload["records_delivered"] == 0
+    # A durable segment reached the spool.
+    assert list((paths.spool / "pending").rglob("*.jsonl"))
+
+
+def test_collect_run_json_is_stable_and_privacy_safe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run", "--json"])
+
+    assert result.exit_code == 0
+    json_line = result.output.strip().splitlines()[-1]
+    payload = json.loads(json_line)
+    # Stable: the emitted line is exactly the sorted-keys serialization of what was parsed.
+    assert json_line == json.dumps(payload, sort_keys=True)
+    assert set(payload) == _PRIVACY_SAFE_TOP_KEYS
+    for collector in payload["collectors"]:
+        assert set(collector) == _PRIVACY_SAFE_COLLECTOR_KEYS
+    # No target url or host leaks into the summary.
+    assert "example.com" not in result.output
+    assert "health2" not in result.output
+
+
+def test_collect_run_exits_one_when_a_collector_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+    _use_fake_registry(monkeypatch, fake_factory(("boom",), raises=True))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["collectors"][0]["status"] == "error"
+    assert payload["collectors"][0]["error_code"] is not None
+    # The fake's raised exception embeds KNOWN_SECRET; per-collector isolation must reduce it to a
+    # fixed code, so the secret in the exception message never surfaces in any rendered output.
+    assert KNOWN_SECRET not in result.output
+
+
+def test_collect_run_isolates_a_failing_collector_from_a_healthy_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = _config_file(tmp_path, extra=_SECOND_COLLECTOR)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+    # "second-canary" raises; "example-canary" succeeds — one failure must not abort the other.
+    _use_fake_registry(monkeypatch, _isolation_factory("second-canary"))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run", "--json"])
+
+    assert result.exit_code == 1  # a failed collector forces exit 1
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    by_id = {c["collector_id"]: c for c in payload["collectors"]}
+    assert by_id["example-canary"]["status"] == "ok"
+    assert by_id["example-canary"]["records_committed"] >= 1
+    assert by_id["second-canary"]["status"] == "error"
+    assert by_id["second-canary"]["error_code"] is not None
+
+
+def test_collect_run_fails_closed_without_init(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    result = CliRunner().invoke(main, ["--config", str(config_file), "collect", "run"])
+    assert result.exit_code == 1
+    assert "run milhouse init first" in result.output
+
+
+def test_collect_run_fails_closed_when_the_pseudonym_key_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = _config_file(tmp_path)
+    paths = _paths(config_file, tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+    # Simulate an install predating key provisioning: identity present, key gone.
+    paths.pseudonym_key.unlink()
+    assert bootstrap.read_installation_id(paths) is not None
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run"])
+
+    assert result.exit_code == 1
+    assert "run milhouse init first" in result.output
+    # It never reached a collect run.
+    assert not list((paths.spool / "pending").rglob("*.jsonl"))
+
+
+def test_collect_run_unknown_collector_id_is_config_error(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    CliRunner().invoke(main, ["--config", str(config_file), "init"])
+    result = CliRunner().invoke(main, ["--config", str(config_file), "collect", "run", "nope"])
+    assert result.exit_code == 2
+
+
+def test_collect_run_unknown_target_is_config_error(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    CliRunner().invoke(main, ["--config", str(config_file), "init"])
+    result = CliRunner().invoke(
+        main, ["--config", str(config_file), "collect", "run", "--target", "nope"]
+    )
+    assert result.exit_code == 2
+
+
+def test_collect_run_filters_to_one_collector(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = _config_file(tmp_path, extra=_SECOND_COLLECTOR)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(
+        main, ["--config", str(config_file), "collect", "run", "second-canary", "--json"]
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    ids = {c["collector_id"] for c in payload["collectors"]}
+    assert ids == {"second-canary"}
+
+
+def test_collect_run_rejects_full_mode_and_commits_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A full-mode config must be REJECTED (exit 2) before any run: a spool_only run would stamp
+    # required_exporters=() and permanently strand the segments from storage export. Nothing spools.
+    config_file = _config_file(tmp_path, mode="full")
+    paths = _paths(config_file, tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run"])
+
+    assert result.exit_code == 2
+    assert "full-mode" in result.output
+    assert "runtime.mode = spool_only" in result.output
+    # No segment was committed — the reject happens before the pipeline is built.
+    assert not list((paths.spool / "pending").rglob("*.jsonl"))
+
+
+@pytest.mark.parametrize(
+    ("error", "code"),
+    [
+        (SpoolError("MH_SPOOL_TEST", "spool integrity check failed"), "MH_SPOOL_TEST"),
+        (StateError("MH_STATE_TEST", "control state check failed"), "MH_STATE_TEST"),
+    ],
+)
+def test_collect_run_maps_a_run_abort_to_the_coded_exit_one_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error: Exception, code: str
+) -> None:
+    # A whole-run abort (spool integrity, control state, pipeline ctor) must surface as the coded
+    # exit-1 ClickException every other command produces -- never a raw traceback.
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+
+    class _AbortingPipeline:
+        def run(self, collectors: object, targets: object) -> object:
+            raise error
+
+    monkeypatch.setattr(root, "_build_collect_pipeline", lambda *a, **k: _AbortingPipeline())
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run"])
+
+    assert result.exit_code == 1
+    # The coded message is rendered by the ClickException handler (an escaped raw error would not
+    # reach the captured output), and the recorded exception is the clean SystemExit Click raises
+    # for a handled ClickException -- NOT the raw SpoolError/StateError with a traceback.
+    assert code in result.output
+    assert isinstance(result.exception, SystemExit)
+    assert not isinstance(result.exception, (SpoolError, StateError))
+
+
+# --- collect list ---------------------------------------------------------------------------------
+
+
+def test_collect_list_reports_configured_collectors(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    result = CliRunner().invoke(main, ["--config", str(config_file), "collect", "list", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert {"id": "example-canary", "type": "site_canary"} in payload["collectors"]


### PR DESCRIPTION
## What & why

W06 collect CLI, **increment 1** — the first slice that wires the already-merged W05 runtime vertical (collectors → validate → redact → spool → alert → notification-intents) into an operator command. Until now `RuntimePipeline` + `register_site_canary` + the alert/intent stages were all on `main` but had **no CLI entry point**.

Two parts:

### 1. `milhouse init` provisions the keyed pseudonym key (idempotent)
The `RuntimePipeline` requires a `LayeredRedactor`, which needs a keyed pseudonym key — but nothing in `src/` created one yet. `init` now provisions it, reusing the existing `privacy/keys.py` primitives exactly (`create_pseudonym_key` / `recover_pseudonym_key_creation`): a fresh install writes a 0600 key; a second `init` is a no-op (never rotates); a commit-uncertain outcome runs recovery and otherwise fails closed with a fixed code. No key material is ever logged, echoed, returned, or placed in any output/error — only a boolean. Credential-free callers (`demo`, tests) omit the new optional `config` arg and never touch the key.

### 2. `collect` command (spool-only)
`milhouse collect run [COLLECTOR_ID] [--target TARGET_ID] [--json]` builds a `RuntimePipeline` from config + paths (registry + `register_site_canary`, redactor from the provisioned key, control + shared `GlobalCommitBarrier`, `config_generation` via `validated_config_digest`, `exporters={}`), runs it once, and prints a privacy-safe `PipelineRunSummary`. Plus `collect list`. Alerting + notification-intents run **inside** `pipeline.run()`, so a `collect` run drives them as a side effect — there is intentionally no separate `alert` command.

**Exit codes** (documented in `--help`): `0` clean; `1` if any export/alert/intent `error_code` is set, or `records_failed > 0`, or any collector status is failed/error; `2` for invalid config (unknown collector/target id, **or `runtime.mode = "full"`** — see below).

## Full-mode is rejected this increment (fail-closed)
A spool-only run stamps `required_exporters=()` on every committed segment, so a later `storage export` can **never** attach a ClickHouse delivery obligation to them — they would be durably spooled but permanently unqueryable in ClickHouse, and `storage export` would flag them "unhandled"/exit 1 forever. Rather than silently strand records under the shipped default `mode="full"` config, `collect run` **rejects** a full-mode config (exit 2) with an actionable message pointing to `runtime.mode = spool_only`. Proper full-mode ClickHouse export is the next increment.

## Review
Four independent adversarial reviewers (pseudonym-key security, full-mode durability, command-output privacy, wiring/exit-codes/regression):

- **Key security — safe.** No key-material escape path; idempotent + never-rotating (`O_CREAT|O_EXCL`); correct `PseudonymKeyCommitUncertain`-before-`PrivacyError` catch order with non-secret key-id recovery; 0600 + atomic delegated to reused primitives; no fresh-install circularity.
- **Output privacy — safe.** Every emitted byte (both commands, human + `--json`, all errors, NOTE/WARNING, `init`) is a config-declared identifier, fixed literal, integer count, sha256-derived batch id, or bounded machine code. `error_code = normalize_error(error).code` captures only the code, so a canary HTTP exception carrying a target URL can't leak.
- **Wiring / exit-codes / regression — safe.** Pipeline construction, the exit-code contract, `--target` handling, and backward-compat all correct; strong tests; scope clean (3 files, no pipeline/records/alerting internals touched).
- **Durability — one P1, now fixed:** the full-mode stranding above, remediated by the fail-closed reject (with a test asserting exit 2 **and** zero segments spooled).

Deferred as follow-ups (non-blocking): the redactor's `known_secrets=()` defense-in-depth layer (no live leak reachable in this emit-only path), and a pre-existing benign orphan-temp property of the secure-file primitive.

## Gates
- `make test` → 5087 passed, 6 skipped, 0 failed.
- `make quality` → clean (ruff format+lint, mypy strict, docs/config/link/workflow/zizmor/skill checks).

## Scope / not in this PR
Full-mode ClickHouse export (increment 2), the real ClickHouse round-trip (live/E06, #108), the `milhouse run [--once]` scheduler (W15), `--fixture` / `--dry-run`.

W06 is formally gated on **G05** (not yet passed — live evidence host-gated, #108); this offline CLI is built ahead per the product-first pivot. **G06 is not claimed passed.**

Refs #141
Refs #94
