### PR TITLE
feat(cli): W06 collect CLI increment 2 — full-mode ClickHouse export from collect run

### DIFF
--- a/src/milhouse/cli/root.py
+++ b/src/milhouse/cli/root.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -28,8 +29,15 @@ from milhouse.core.errors import MilhouseError
 from milhouse.privacy.keys import load_pseudonym_key
 from milhouse.privacy.pseudonym import PrivacyError
 from milhouse.privacy.redact import LayeredRedactor
-from milhouse.runtime import CollectorRegistry, PipelineError, PipelineRunSummary, RuntimePipeline
+from milhouse.runtime import (
+    CollectorRegistry,
+    PipelineError,
+    PipelineRunSummary,
+    RuntimeMode,
+    RuntimePipeline,
+)
 from milhouse.spooling import SpoolError, replay_segments
+from milhouse.spooling.exporter import Exporter
 from milhouse.spooling.ledger import list_segment_records
 from milhouse.state import (
     ControlDatabase,
@@ -304,9 +312,11 @@ def _build_collect_pipeline(
     installation_id: str,
     control: ControlDatabase,
     *,
+    mode: RuntimeMode,
+    exporters: Mapping[str, Exporter],
     registry: CollectorRegistry | None = None,
 ) -> RuntimePipeline:
-    """Assemble a spool-only :class:`RuntimePipeline` from validated config and control plane.
+    """Assemble a mode-aware :class:`RuntimePipeline` from validated config and control plane.
 
     Extracted as the testable seam the ``collect`` command builds through: production passes
     ``registry=None`` (the real registry, whose site_canary factory builds a live HTTP client) while
@@ -315,8 +325,11 @@ def _build_collect_pipeline(
     CLOSED with ``run milhouse init first`` when it is absent (a corrupt or foreign key surfaces its
     own fixed code instead). The redactor is built with no extra known secrets; the collectors are
     the primary redaction authority. ``config_generation`` is the deterministic 64-hex digest of
-    the fully validated config, which the pipeline re-checks. Exporters are empty (spool_only):
-    committed segments are NOT delivered to ClickHouse in this release.
+    the fully validated config, which the pipeline re-checks. The caller supplies ``mode`` and the
+    matching ``exporters`` map — empty for ``spool_only``, the ClickHouse exporter keyed by its
+    exporter id for ``full`` — and the pipeline ctor enforces that invariant (``full`` requires a
+    non-empty map, ``spool_only`` an empty one), so the full-mode obligation lives here rather than
+    in a separate reject guard.
     """
 
     if registry is None:
@@ -334,7 +347,7 @@ def _build_collect_pipeline(
         paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
     )
     return RuntimePipeline(
-        mode="spool_only",
+        mode=mode,
         config_generation=validated_config_digest(config),
         registry=registry,
         redactor=redactor,
@@ -344,7 +357,7 @@ def _build_collect_pipeline(
         installation_id=installation_id,
         clock=SystemClock(),
         retention=config.retention,
-        exporters={},
+        exporters=exporters,
         alert_rules=config.alert_rules,
         notifications=config.notifications,
     )
@@ -414,46 +427,33 @@ def collect_run_command(
     target_id: str | None,
     as_json: bool,
 ) -> None:
-    """Collect, redact, and spool every configured collector once (spool-only).
+    """Collect, redact, and spool every configured collector once; in full mode also export.
 
-    Builds the W05 runtime pipeline in spool_only mode and runs it a single time: each collector's
-    drafts are redacted, finalized, and committed to the local spool, and the configured canary
-    alert rules and notification-intent records are evaluated inside that run. Nothing is exported
-    to ClickHouse in this release — full-mode export from ``collect`` is a later increment, so a
-    config with ``runtime.mode = "full"`` is REJECTED (exit 2) rather than silently run spool-only.
-    Requires an initialized install (run ``milhouse init`` first): the pipeline's redactor needs the
-    keyed pseudonym key that ``init`` provisions.
+    Builds the W05 runtime pipeline in the configured ``runtime.mode`` and runs it a single time:
+    each collector's drafts are redacted, finalized, and committed to the local spool, and the
+    configured canary alert rules and notification-intent records are evaluated inside that run. In
+    ``spool_only`` mode nothing is exported. In ``full`` mode the committed segments are delivered
+    to ClickHouse through the same exactly-once delivery ledger ``storage export`` drives, so a
+    full-mode run additionally requires ClickHouse configured (``storage.clickhouse.enabled``) AND
+    the destination already migrated and claimed by THIS installation — run ``storage migrate``
+    first. Requires an initialized install (run ``milhouse init`` first): the pipeline's redactor
+    needs the keyed pseudonym key that ``init`` provisions.
 
     An optional ``COLLECTOR_ID`` runs only that configured collector; ``--target`` runs only the
     collectors bound to that declared target. An unknown collector or target id is a configuration
     error. The emitted summary carries ONLY privacy-safe counts, fixed codes, and config-declared
     ids — never a secret, PII, path, payload, URL, or target host.
 
-    Exit codes: 0 clean; 1 if any stage error code is set OR any records failed OR any collector
-    ended ``failed``/``error`` OR the run aborts with a coded spool/state/pipeline failure; 2 for an
-    invalid configuration — an unknown collector or target id, OR ``runtime.mode = "full"``
-    (full-mode ClickHouse export is unsupported this increment).
+    Exit codes: 0 clean; 1 if any stage error code is set OR any records failed (including a
+    contained ClickHouse delivery failure, which is non-fatal but reported) OR any collector ended
+    ``failed``/``error`` OR the run aborts with a coded spool/state/pipeline failure OR (full mode)
+    the ClickHouse destination is unclaimed/foreign-owned or ClickHouse is disabled/unbuildable; 2
+    for an invalid configuration — an unknown collector or target id, or (full mode) an unresolvable
+    ClickHouse secret/config (both surface the same exit-2 config error as ``storage export``).
     """
 
     state = context.ensure_object(CliState)
     config, paths = _resolve_config(state)
-
-    # Fail closed on full mode rather than silently downgrade: a spool_only run stamps
-    # ``required_exporters=()`` on every committed segment, so ``commit`` records no clickhouse
-    # delivery obligation and a later ``storage export`` can NEVER drain those segments (it reports
-    # them ``unhandled`` / "export incomplete" forever, with no way to attach an obligation after
-    # the fact). Running spool_only under a ``full`` config would therefore durably strand records
-    # the operator expects in ClickHouse. Wiring the export tail is the next increment; until then
-    # reject so nothing is stranded.
-    if config.runtime.mode == "full":
-        raise ConfigCommandError(
-            ConfigError(
-                "config.runtime.full_mode_unsupported",
-                "collect run does not support full-mode ClickHouse export yet; set "
-                "runtime.mode = spool_only in your config to collect now (full-mode export lands "
-                "in the next increment)",
-            )
-        )
 
     collectors = list(config.collectors)
     if collector_id is not None:
@@ -476,20 +476,53 @@ def collect_run_command(
         ]
 
     installation_id = _require_installation_id(paths)
+    # Full mode delivers committed segments to ClickHouse via the pipeline's delivery tail, so it
+    # needs an authenticated client and the ClickHouse exporter; spool_only needs neither. Open the
+    # client BEFORE the control handle so a storage-config failure (clickhouse disabled/unbuildable,
+    # or a bad secret env) surfaces its own coded exit without ever acquiring a control handle.
+    client: storage.ConnectedClickHouseClient | None = None
+    database: str | None = None
+    if config.runtime.mode == "full":
+        database, client = _storage_client(state)
     control = open_control_database(bootstrap.database_path(paths))
     try:
-        pipeline = _build_collect_pipeline(config, paths, installation_id, control)
+        exporters: dict[str, Exporter] = {}
+        if client is not None and database is not None:
+            # Refuse to deliver to a destination this installation does not own (fail closed) — the
+            # same read barrier ``storage export`` takes: an UNCLAIMED destination raises
+            # ``MH_STORAGE_OWNERSHIP`` with "run storage migrate first", a FOREIGN owner is refused.
+            # Placed BEFORE the pipeline commits/exports, so a full run over an unowned ClickHouse
+            # strands nothing.
+            storage.require_owner(client, database, installation_id=installation_id)
+            exporters = {
+                storage.CLICKHOUSE_EXPORTER_ID: storage.ClickHouseExporter(client, database)
+            }
+        pipeline = _build_collect_pipeline(
+            config,
+            paths,
+            installation_id,
+            control,
+            mode=config.runtime.mode,
+            exporters=exporters,
+        )
         # The full target set is passed for lookup; the collector filters above scope the run.
         summary = pipeline.run(tuple(collectors), tuple(config.targets))
-    except (SpoolError, StateError, PipelineError) as error:
-        # A spool-integrity, control-state, or pipeline-construction failure (e.g. DurableSpool
-        # reconciliation, a tampered barrier, a crashed-prior-writer orphan) must surface as the
-        # coded exit-1 contract every other command produces -- a clean ``error: MH_...`` rather
-        # than a raw traceback. Per-collector faults are already isolated INTO the summary; this
-        # catches only failures that abort the whole run. The key-missing / other PrivacyError
-        # mappings raised inside ``_build_collect_pipeline`` are ClickExceptions and propagate.
+    except (SpoolError, StateError, PipelineError, storage.StorageError) as error:
+        # A spool-integrity, control-state, pipeline-construction, or ClickHouse-ownership failure
+        # (e.g. DurableSpool reconciliation, a tampered barrier, a crashed-prior-writer orphan, an
+        # unclaimed/foreign destination) must surface as the coded exit-1 contract every other
+        # command produces -- a clean ``error: MH_...`` rather than a raw traceback. Per-collector
+        # faults AND a contained ClickHouse delivery failure are already isolated INTO the summary
+        # (records_failed / export_error_code → exit 1 below); this catches only failures that abort
+        # the whole run. The key-missing / other PrivacyError mappings raised inside
+        # ``_build_collect_pipeline`` are ClickExceptions and propagate.
         raise CollectCommandError(error) from None
     finally:
+        # Close the ClickHouse client and the control handle on EVERY path (ownership failure,
+        # pipeline error, or clean success), so a full run never leaks the client; spool_only opens
+        # none, so ``client is None`` and only the control handle is closed.
+        if client is not None:
+            client.close()
         control.close()
 
     if as_json:

--- a/tests/unit/test_collect_cli.py
+++ b/tests/unit/test_collect_cli.py
@@ -14,11 +14,13 @@ from pathlib import Path
 
 import pytest
 from _runtime_harness import KNOWN_SECRET, FakeCollector, fake_factory, registry_with
+from _storage_fakes import FakeClickHouseClient
 from click.testing import CliRunner
 
 from milhouse.cli import bootstrap, root
 from milhouse.cli.root import main
 from milhouse.config import RuntimePaths, load_config, resolve_runtime_paths
+from milhouse.config.secrets import SecretEnvironment
 from milhouse.domain.records import CollectorDescriptorV1
 from milhouse.spooling import SpoolError
 from milhouse.state import StateError
@@ -33,13 +35,20 @@ _SECOND_COLLECTOR = (
 )
 
 
-def _config_file(tmp_path: Path, *, extra: str = "", mode: str = "spool_only") -> Path:
-    # The example config ships ``runtime.mode = "full"``; collect run rejects full mode (exit 2), so
-    # the run-path tests default to a spool_only config. ``mode="full"`` is used to test the reject.
+def _config_file(
+    tmp_path: Path, *, extra: str = "", mode: str = "spool_only", clickhouse_enabled: bool = True
+) -> Path:
+    # The example config ships ``runtime.mode = "full"``; the spool-only run-path tests default to a
+    # spool_only config, while ``mode="full"`` exercises the ClickHouse export tail (against a fake
+    # client). ``clickhouse_enabled=False`` toggles the storage block off to test the disabled path.
     config_dir = tmp_path / "cfg"
     config_dir.mkdir()
     config_file = config_dir / "config.toml"
     body = _EXAMPLE_CONFIG.replace('mode = "full"', f'mode = "{mode}"')
+    if not clickhouse_enabled:
+        body = body.replace(
+            "[storage.clickhouse]\nenabled = true", "[storage.clickhouse]\nenabled = false"
+        )
     config_file.write_text(body + extra, encoding="utf-8")
     return config_file
 
@@ -299,26 +308,6 @@ def test_collect_run_filters_to_one_collector(
     assert ids == {"second-canary"}
 
 
-def test_collect_run_rejects_full_mode_and_commits_nothing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # A full-mode config must be REJECTED (exit 2) before any run: a spool_only run would stamp
-    # required_exporters=() and permanently strand the segments from storage export. Nothing spools.
-    config_file = _config_file(tmp_path, mode="full")
-    paths = _paths(config_file, tmp_path)
-    runner = CliRunner()
-    runner.invoke(main, ["--config", str(config_file), "init"])
-    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
-
-    result = runner.invoke(main, ["--config", str(config_file), "collect", "run"])
-
-    assert result.exit_code == 2
-    assert "full-mode" in result.output
-    assert "runtime.mode = spool_only" in result.output
-    # No segment was committed — the reject happens before the pipeline is built.
-    assert not list((paths.spool / "pending").rglob("*.jsonl"))
-
-
 @pytest.mark.parametrize(
     ("error", "code"),
     [
@@ -350,6 +339,179 @@ def test_collect_run_maps_a_run_abort_to_the_coded_exit_one_contract(
     assert code in result.output
     assert isinstance(result.exception, SystemExit)
     assert not isinstance(result.exception, (SpoolError, StateError))
+
+
+# --- Part C: collect run (full mode → ClickHouse export via the delivery ledger) ------------------
+#
+# Full mode wires the SAME exactly-once delivery tail ``storage export`` drives, so these tests
+# reuse the offline fake ClickHouse seam: monkeypatch ``build_client`` → a fake and
+# ``load_secret_environment`` → an empty env, and run ``storage migrate`` first so ``require_owner``
+# passes. The real ClickHouse round-trip is host-gated (live/E06).
+
+
+class _CloseSpyClient(FakeClickHouseClient):
+    """A fake CH client that counts ``close()`` calls, to prove close-on-every-path."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class _RaisingCloseSpyClient(_CloseSpyClient):
+    """A close-spy whose ``insert`` raises, so a delivery is contained as a retryable failure."""
+
+    def insert(self, *args: object, **kwargs: object) -> None:
+        raise RuntimeError("clickhouse insert unavailable")
+
+
+def _stub_clickhouse(monkeypatch: pytest.MonkeyPatch, client: FakeClickHouseClient) -> None:
+    """Point the storage client seam at ``client`` with an empty secret environment (no network)."""
+
+    monkeypatch.setattr(
+        root, "load_secret_environment", lambda config, paths: SecretEnvironment({}, {})
+    )
+    monkeypatch.setattr(root.storage, "build_client", lambda config, secrets: client)
+
+
+def _migrate(config_file: Path) -> None:
+    """Claim/verify ownership of the (fake) ClickHouse by applying migrations — the full-mode
+    precondition ``require_owner`` enforces."""
+
+    result = CliRunner().invoke(main, ["--config", str(config_file), "storage", "migrate"])
+    assert result.exit_code == 0, result.output
+
+
+def test_collect_run_full_mode_delivers_to_clickhouse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A migrated (claimed) full-mode destination: the committed segment is delivered through the
+    # ClickHouse exporter, so the summary reports a delivery and the fake client received a records
+    # insert. The client is closed on the clean-success path.
+    config_file = _config_file(tmp_path, mode="full")
+    client = _CloseSpyClient()
+    _stub_clickhouse(monkeypatch, client)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    _migrate(config_file)
+    client.close_calls = 0  # isolate collect run's own finally-close from migrate's client close
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["mode"] == "full"
+    assert payload["records_committed"] >= 1
+    assert payload["records_delivered"] >= 1
+    assert payload["records_failed"] == 0
+    assert payload["export_error_code"] is None
+    # The delivery tail actually wrote the event's record row to ClickHouse (not just migrate DDL).
+    assert "records" in [table for _db, table, *_ in client.inserts]
+    assert client.close_calls >= 1  # closed on the success path (no leak)
+
+
+def test_collect_run_full_mode_fails_closed_on_an_unclaimed_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Full mode WITHOUT ``storage migrate`` (the destination is unclaimed): require_owner refuses it
+    # with MH_STORAGE_OWNERSHIP and the "run storage migrate first" guidance, BEFORE any commit — so
+    # nothing spools and the client is still closed. Click handles it (no traceback).
+    config_file = _config_file(tmp_path, mode="full")
+    paths = _paths(config_file, tmp_path)
+    client = _CloseSpyClient()
+    _stub_clickhouse(monkeypatch, client)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run"])
+
+    assert result.exit_code == 1
+    assert "MH_STORAGE_OWNERSHIP" in result.output
+    assert "migrate" in result.output  # "...unclaimed; run storage migrate first"
+    assert isinstance(result.exception, SystemExit)  # a handled ClickException, not a raw traceback
+    # Nothing was committed (the ownership barrier precedes the pipeline) and the client was closed.
+    assert not list((paths.spool / "pending").rglob("*.jsonl"))
+    assert client.inserts == []
+    assert client.close_calls >= 1
+
+
+def test_collect_run_full_mode_with_clickhouse_disabled_is_a_config_error(
+    tmp_path: Path,
+) -> None:
+    # A full-mode config that disables ClickHouse cannot export: _storage_client raises
+    # MH_STORAGE_CONFIG (exit 1) BEFORE any control handle or client is opened.
+    config_file = _config_file(tmp_path, mode="full", clickhouse_enabled=False)
+    paths = _paths(config_file, tmp_path)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run"])
+
+    assert result.exit_code == 1
+    assert "MH_STORAGE_CONFIG" in result.output
+    assert isinstance(result.exception, SystemExit)
+    # It failed before the pipeline ran: nothing spooled.
+    assert not list((paths.spool / "pending").rglob("*.jsonl"))
+
+
+def test_collect_run_full_mode_delivery_failure_is_nonfatal_but_exits_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A ClickHouse insert that raises is CONTAINED by the delivery ledger as a retryable failure:
+    # the segment is durably committed, records_failed is set, and the run exits 1 (loud, not
+    # silent) — but the client is still closed. replay_segments does not raise, so export_error_code
+    # stays None.
+    config_file = _config_file(tmp_path, mode="full")
+    client = _RaisingCloseSpyClient()
+    _stub_clickhouse(monkeypatch, client)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    _migrate(config_file)  # migrate uses command(), not insert(), so it still claims ownership
+    client.close_calls = 0  # isolate collect run's own finally-close from migrate's client close
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["mode"] == "full"
+    assert payload["records_committed"] >= 1  # the commit is durable even though delivery failed
+    assert payload["records_delivered"] == 0
+    assert payload["records_failed"] >= 1  # the contained delivery failure forces exit 1
+    assert payload["export_error_code"] is None  # replay_segments did not itself raise
+    assert client.inserts == []  # the raising insert recorded nothing
+    assert client.close_calls >= 1  # closed on the delivery-failure path (no leak)
+
+
+def test_collect_run_spool_only_never_opens_a_clickhouse_client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # spool_only must never touch the storage client seam: point build_client / load_secret_
+    # environment at raising stubs and prove the run still succeeds without invoking either.
+    config_file = _config_file(tmp_path)  # spool_only
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+
+    def _boom_secret(config: object, paths: object) -> SecretEnvironment:
+        raise AssertionError("spool_only must not load the secret environment")
+
+    def _boom_client(config: object, secrets: object) -> FakeClickHouseClient:
+        raise AssertionError("spool_only must not build a ClickHouse client")
+
+    monkeypatch.setattr(root, "load_secret_environment", _boom_secret)
+    monkeypatch.setattr(root.storage, "build_client", _boom_client)
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["mode"] == "spool_only"
+    assert payload["records_delivered"] == 0
 
 
 # --- collect list ---------------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

W06 collect CLI **increment 2** — `collect run` now honors `runtime.mode = "full"` by wiring the ClickHouse export tail, so committed segments egress to the warehouse in one command. Increment 1 (#142) deliberately *rejected* full mode to avoid stranding records; this removes that reject and wires export properly, completing the `collect` vertical (offline). Refs #144, #141.

## How
- **`_build_collect_pipeline` is now mode-aware** — takes `mode` + `exporters` and threads them into `RuntimePipeline(...)` (the increment-1 hardcoded `spool_only`/`{}` are gone). The full-mode invariant now lives in the builder, which resolves the #143 "builder-guard altitude" P3.
- **`collect_run_command`** — for a `full` config it mirrors `storage export` exactly: `_storage_client(state)` → **`storage.require_owner(client, database, installation_id=…)`** (the one-ClickHouse-per-install ownership guard the pipeline's `_drive_export` documents as a command-layer duty) → `exporters = {CLICKHOUSE_EXPORTER_ID: ClickHouseExporter(client, database)}` → `RuntimePipeline(mode="full", …)`. The pipeline's `_drive_export` runs delivery; `collect` never calls `replay_segments` itself. `spool_only` is unchanged (no client, `exporters={}`).
- **Client lifecycle** — the CH client is opened only in full mode and closed in the `finally` alongside the control DB, on every in-run path (ownership failure, pipeline error, success).
- **Error/exit mapping** — `require_owner`'s `StorageError` (unclaimed → "run `storage migrate` first"; foreign-owner) is caught and mapped to a coded **exit 1** (`CollectCommandError`, widened to any `MilhouseError`); ClickHouse disabled/unbuildable → `_storage_client`'s `MH_STORAGE_CONFIG` exit 1; an unresolvable secret → exit 2 (same config error as `storage export`). A **delivery failure is non-fatal** — contained by the delivery ledger as `records_failed`, which the existing `_collect_run_failed` already turns into exit 1. So `_collect_run_payload`/`_collect_run_failed` needed no change.

**Precondition:** a full-mode run requires ClickHouse configured **and** the destination already migrated + claimed (`storage migrate` first) — an unclaimed/foreign destination fails closed before anything is collected.

## Review
Three independent adversarial angles (full-mode wiring + ownership, client lifecycle + error/exit mapping + no-regression, test-quality + scope) returned **`SAFE-TO-PR`, 0 blocking**. Two surfaced P3s were folded in:
- the docstring exit-code section now records that a full-mode secret/config error exits 2 (matching sibling storage commands);
- the client-close test-spy is reset after the `migrate` precondition so it genuinely guards `collect run`'s own `finally`-close (not `migrate`'s).

Deferred as confirmed-benign: a narrow `open_control_database`-raises window can't leak the client (the socket opens lazily on the first query, inside the `try`).

## Tests (offline, fake ClickHouse client)
Full-mode **delivers** (records insert + `records_delivered ≥ 1`, client closed); **ownership fail-closed** (`MH_STORAGE_OWNERSHIP`, nothing spooled, client closed); **ClickHouse-disabled** → `MH_STORAGE_CONFIG` exit 1; **delivery failure** non-fatal → `records_failed`, exit 1, client closed; **spool-only never opens a client**. `test` → 5094 passed / 6 skipped / 0 failed; `quality` clean. DCO + co-author trailers, no session locator.

## Scope / not here
The **real ClickHouse round-trip is live/E06 (#108)** — these tests prove the *wiring* (exporter constructed, `require_owner` enforced, delivery attempted, counts folded into the summary), not real egress fidelity. **G06/G05 remain *not passed*** until the owner's live pass. Out of scope: the `milhouse run [--once]` scheduler (W15) and the remaining #143 P3s.

Refs #144
Refs #141
