### PR TITLE
fix(cli): W06 collect CLI — resolve deferred P3s (#143)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,10 +1,15 @@
 # Quickstart (pre-alpha)
 
-> **Pre-alpha.** Milhouse is not released and not ready for production use. This quickstart exercises
-> the local, spool-only foundation only: it configures a state root, initializes the control
-> database and installation identity, and reports health. No network, no credentials, no provider
-> calls, and no ClickHouse are involved. Capabilities gated by later work packages
-> (see [implementation-status.md](implementation-status.md)) are not available yet.
+> **Pre-alpha.** Milhouse is not released and not ready for production use. This quickstart focuses
+> on the local path: it configures a state root, initializes the control database, installation
+> identity, and pseudonym key, reports health, and runs the configured collectors into the local
+> spool. Collection runs in one of two modes set by the required `runtime.mode` field: `spool_only`
+> (local only — no network egress, no credentials, no ClickHouse) or `full` (additionally delivers to
+> ClickHouse). The `demo` command is always spool-only. The checked-in `config/example.toml` ships
+> `runtime.mode = "full"`; set it to `spool_only` for the local-only path below. Full-mode collection
+> and the `storage` commands (which reach ClickHouse when configured) remain gated by later work
+> packages (see [implementation-status.md](implementation-status.md)); their live evidence is still
+> pending.
 
 ## 1. Provide a configuration
 
@@ -77,7 +82,51 @@ The spooled segment is a self-describing JSONL file under `<state root>/spool/pe
 header (frame/schema versions, batch id, config-generation digest, privacy/retention class, required
 exporters, record count, and the ordered-frame SHA-256) followed by the redacted record frame.
 
-## 5. Inspect what you spooled
+## 5. Run configured collectors
+
+`collect run` runs every configured collector once through the runtime pipeline: each collector's
+drafts are redacted, finalized, and committed to the local spool, and the configured canary alert
+rules and notification-intent records are evaluated in the same run. It requires an initialized
+install — the pipeline's redactor needs the keyed pseudonym key `init` provisions — so a run before
+`init`, or one whose key is missing, fails closed with `run milhouse init first` (a corrupt key
+surfaces a specific `MH_PRIVACY_KEY_*` error instead, and `init` will not rotate an existing key).
+
+The required `runtime.mode` in your config selects what a run does:
+
+- **`spool_only`**: collect, redact, and spool locally — no network egress and no ClickHouse.
+- **`full`**: additionally deliver the committed segments to ClickHouse through the same
+  exactly-once delivery ledger `storage export` drives. Full mode requires ClickHouse configured
+  (`storage.clickhouse.enabled`) **and** the destination already migrated and claimed by this
+  installation, so run `storage migrate` first. This is the one path that reaches ClickHouse.
+
+With `runtime.mode = "spool_only"` in your config, a local run needs no migrate step:
+
+```console
+$ milhouse --config ./config.toml init            # once; also provisions the pseudonym key
+$ milhouse --config ./config.toml collect run
+collect: mode=spool_only committed=1 delivered=0 failed=0 alerts_fired=0 alerts_resolved=0 intents_emitted=0
+  example-canary: status=ok error=none drafts=1 committed=1 delivered=0 failed=0 batch=2026-08-16/...
+
+$ milhouse --config ./config.toml collect list    # the configured collectors' ids and kinds
+example-canary  type=site_canary
+```
+
+An optional `COLLECTOR_ID` runs only that collector, and `--target TARGET_ID` runs only the
+collectors bound to that declared target. An unknown collector or target id — or a named collector
+that is not bound to the named target — is a configuration error (exit 2). For a **full**-mode flow,
+migrate and claim the ClickHouse destination first, then run:
+
+```console
+$ milhouse --config ./config.toml storage migrate   # apply schema + claim the destination (full mode)
+$ milhouse --config ./config.toml collect run        # runtime.mode = "full": also delivers to ClickHouse
+```
+
+The `--json` summary carries only privacy-safe counts, fixed codes, and config-declared ids — never
+a secret, payload, path, URL, or target host. `collect run` exits 0 when clean; 1 when any stage
+error is set, any records failed (including a contained ClickHouse delivery failure), or any
+collector ended `failed`/`error`; and 2 for an invalid configuration.
+
+## 6. Inspect what you spooled
 
 These commands are read-only and report privacy-safe **metadata only** — never the raw record
 payload — consistent with the local-query egress policy.
@@ -99,13 +148,14 @@ Add `--json` to any of them for a stable machine-readable form.
 
 | Code | Meaning |
 |---:|---|
-| `0` | Success; `health`/`doctor` report **healthy**; `demo` spooled and read back its record. |
-| `1` | `health`/`doctor` report a problem; `init`/`demo` could not establish or exercise the state root; or an inspect command was run before `init`. |
-| `2` | The configuration is missing or invalid. |
+| `0` | Success; `health`/`doctor` report **healthy**; `demo` spooled and read back its record; `collect run` completed with no failures. |
+| `1` | `health`/`doctor` report a problem; `init`/`demo` could not establish or exercise the state root; a `collect run` stage errored, a record failed, or a collector ended `failed`/`error`; or an inspect command was run before `init`. |
+| `2` | The configuration is missing or invalid (including an unknown or unbound collector/target id). |
 
 ## What this is (and is not)
 
-This is a preparatory product vertical built on the accepted W02 (configuration, identity, privacy)
-and W03 (SQLite control state and durable spool) foundations. It is tracked as a roadmap feature and
-does **not** claim the W05 runtime or W06 initialization gates. The full CLI surface, real collectors,
-and ClickHouse-backed query follow in later work packages.
+This is a product vertical built on the accepted W02 (configuration, identity, privacy) and W03
+(SQLite control state and durable spool) foundations, now extended with the W04 ClickHouse store and
+the W05/W06 runtime and `collect` surface. The offline behaviour is exercised here, but the runtime
+and storage gates' **live** evidence is still pending, so treat full-mode ClickHouse delivery as
+gated. Additional collectors and richer ClickHouse-backed query follow in later work packages.

--- a/src/milhouse/cli/bootstrap.py
+++ b/src/milhouse/cli/bootstrap.py
@@ -28,11 +28,13 @@ from milhouse.config import RuntimePaths
 from milhouse.config._models import MilhouseConfig
 from milhouse.config.filesystem import (
     SecureFileError,
+    SecureFileErrorKind,
     create_regular_file_no_follow,
     open_regular_file_no_follow,
 )
 from milhouse.privacy.keys import (
     PseudonymKeyCommitUncertain,
+    _validate_key_metadata,
     create_pseudonym_key,
     recover_pseudonym_key_creation,
 )
@@ -123,6 +125,17 @@ def database_path(paths: RuntimePaths) -> Path:
     return _control_dir(paths) / DATABASE_NAME
 
 
+def barrier_path(paths: RuntimePaths) -> Path:
+    """Return the single global commit-lock path (the control dir's ``commit.lock``).
+
+    The sole constructor of the :class:`GlobalCommitBarrier` path across the CLI, so every writer
+    (``collect``, ``storage`` export/migrate/backup/restore, ``demo``, ``init``) acquires the SAME
+    lock file. A divergent join at any one site would silently break the single-writer exclusion.
+    """
+
+    return _control_dir(paths) / BARRIER_NAME
+
+
 def _installation_id_path(paths: RuntimePaths) -> Path:
     return _control_dir(paths) / INSTALLATION_ID_NAME
 
@@ -148,6 +161,27 @@ def _ensure_private_directory(path: Path) -> bool:
     except OSError as error:
         raise BootstrapError("MH_INIT_DIR", "a state directory could not be created") from error
     return created
+
+
+def _ensure_private_key_parent(paths: RuntimePaths) -> None:
+    """Ensure every directory from STATE_ROOT down to the pseudonym key's parent is owner-only.
+
+    A non-default nested ``identity.pseudonym_key_path`` may put the key beneath directories the
+    managed set does not cover. Each intermediate level is created individually (0700) rather than
+    with ``mkdir(parents=True)`` in one call, because that would create the intermediates with the
+    umask default and tighten only the leaf. ``resolve_runtime_paths`` guarantees the key stays a
+    strict descendant of STATE_ROOT, so the upward walk terminates at STATE_ROOT.
+    """
+
+    pending: list[Path] = []
+    current = paths.pseudonym_key.parent
+    while True:
+        pending.append(current)
+        if current == paths.state_root or current == current.parent:
+            break
+        current = current.parent
+    for directory in reversed(pending):  # shallowest first: each level's parent already exists
+        _ensure_private_directory(directory)
 
 
 def _generate_installation_id() -> str:
@@ -261,7 +295,7 @@ def initialize(
 
     database = open_control_database(database_path(paths))
     try:
-        barrier = GlobalCommitBarrier(_control_dir(paths) / BARRIER_NAME)
+        barrier = GlobalCommitBarrier(barrier_path(paths))
         version = initialize_control_state(database, barrier=barrier, applied_at=now)
     finally:
         database.close()
@@ -269,8 +303,13 @@ def initialize(
     installation_created = _ensure_installation_id(paths)
     # The pseudonym key is provisioned only when the validated config is available: its secure
     # creation is bound to that config's resolved runtime generation, and credential-free callers
-    # (the spool-only demo) never need it. The control dir it lives under was created above (0700).
-    pseudonym_key_created = _ensure_pseudonym_key(config, paths) if config is not None else False
+    # (the spool-only demo) never need it.
+    pseudonym_key_created = False
+    if config is not None:
+        # Ensure the key's owner-only (0700) parent chain exists first, or the secure key creation
+        # would fail with an opaque parent-missing error for a non-default nested key path.
+        _ensure_private_key_parent(paths)
+        pseudonym_key_created = _ensure_pseudonym_key(config, paths)
     return InitReport(
         created_directories=tuple(created),
         schema_version=version,
@@ -297,23 +336,39 @@ def _database_check(paths: RuntimePaths) -> HealthCheck:
     return HealthCheck("control_database", ok, detail)
 
 
-def _pseudonym_key_present(paths: RuntimePaths) -> bool:
-    """Whether the pseudonym key file is present, checked privacy-safely (its bytes are never read).
+def _pseudonym_key_check(paths: RuntimePaths) -> HealthCheck:
+    """Report the pseudonym key's health, VALIDATED the way ``collect``'s key load validates it.
 
-    Mirrors :func:`read_installation_id`'s no-follow presence probe: a regular non-symlink file that
-    opens is present; any :class:`SecureFileError` (missing, not regular, symlink, unsafe) means it
-    is absent. This is a PRESENCE check only — it never reads, loads, logs, or returns key material.
+    A mere presence probe would call an install whose key is present-but-corrupt (wrong
+    mode/size/owner/nlink, an unsafe parent, or a non-regular file) "healthy" while ``collect run``
+    rejects it with a precise ``MH_PRIVACY_KEY_*`` code, so this opens the key no-follow beneath an
+    owner-only parent (as :func:`~milhouse.privacy.keys.load_pseudonym_key` does) and runs the
+    shared :func:`~milhouse.privacy.keys._validate_key_metadata` over the ``os.fstat`` METADATA
+    only. It is privacy-safe: it inspects fstat metadata ONLY and NEVER reads, loads, logs, or
+    returns key material. Absent → ``missing``; present but failing validation → ``present but
+    invalid``.
     """
 
     try:
-        opened = open_regular_file_no_follow(paths.pseudonym_key)
-    except SecureFileError:
-        return False
+        opened = open_regular_file_no_follow(paths.pseudonym_key, require_private_parent=True)
+    except SecureFileError as error:
+        detail = (
+            "missing (run milhouse init)"
+            if error.kind is SecureFileErrorKind.NOT_FOUND
+            else "present but invalid (run milhouse init)"
+        )
+        return HealthCheck("pseudonym_key", False, detail)
+    descriptor = opened.descriptor
     try:
-        os.close(opened.descriptor)
-    except OSError:  # pragma: no cover - defensive: close of our own fd
-        pass
-    return True
+        _validate_key_metadata(os.fstat(descriptor))
+    except (PrivacyError, OSError):
+        return HealthCheck("pseudonym_key", False, "present but invalid (run milhouse init)")
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError:  # pragma: no cover - defensive: close of our own fd
+            pass
+    return HealthCheck("pseudonym_key", True, "present")
 
 
 def health(paths: RuntimePaths, *, now: datetime) -> HealthReport:
@@ -341,16 +396,9 @@ def health(paths: RuntimePaths, *, now: datetime) -> HealthReport:
         )
     )
 
-    # The runtime redactor -- and therefore ``collect run`` -- hard-requires the pseudonym key, so
-    # an install without it is NOT usable even though its directories, schema, and identity are
-    # sound. Report its presence (a privacy-safe presence probe only) so ``health``/``doctor`` no
-    # longer call a keyless install healthy while ``collect run`` fails "run milhouse init first".
-    key_present = _pseudonym_key_present(paths)
-    checks.append(
-        HealthCheck(
-            "pseudonym_key",
-            key_present,
-            "present" if key_present else "missing (run milhouse init)",
-        )
-    )
+    # The runtime redactor -- and therefore ``collect run`` -- hard-requires a VALID pseudonym key,
+    # so an install whose key is missing or corrupt is NOT usable even though its directories,
+    # schema, and identity are sound. Validate it (metadata only) so ``health``/``doctor`` no longer
+    # call such an install healthy while ``collect run`` fails "run milhouse init first".
+    checks.append(_pseudonym_key_check(paths))
     return HealthReport(checks=tuple(checks))

--- a/src/milhouse/cli/demo.py
+++ b/src/milhouse/cli/demo.py
@@ -125,10 +125,9 @@ def run_demo(paths: RuntimePaths, *, now: datetime) -> DemoReport:
     frames = [SpoolFrameV1(batch_id=batch_id, sequence=1, record=record)]
     header = _demo_header(batch_id, frames)
 
-    control = paths.state_root / bootstrap.CONTROL_DIRNAME
     database = open_control_database(bootstrap.database_path(paths))
     try:
-        barrier = GlobalCommitBarrier(control / bootstrap.BARRIER_NAME)
+        barrier = GlobalCommitBarrier(bootstrap.barrier_path(paths))
         store = DurableSpool(
             database=database,
             barrier=barrier,

--- a/src/milhouse/cli/root.py
+++ b/src/milhouse/cli/root.py
@@ -7,6 +7,7 @@ from collections import Counter
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Protocol
 
 import click
 from platformdirs import user_config_path, user_data_path
@@ -23,9 +24,7 @@ from milhouse.config import (
     resolve_runtime_paths,
 )
 from milhouse.config._models import MilhouseConfig
-from milhouse.config.loader import validated_config_digest
 from milhouse.core.clock import SystemClock
-from milhouse.core.errors import MilhouseError
 from milhouse.privacy.keys import load_pseudonym_key
 from milhouse.privacy.pseudonym import PrivacyError
 from milhouse.privacy.redact import LayeredRedactor
@@ -62,6 +61,29 @@ class CliState:
         )
 
     __str__ = __repr__
+
+
+class _CodedError(Protocol):
+    """Structural type for an underlying failure that carries a fixed machine ``.code``."""
+
+    @property
+    def code(self) -> str: ...
+
+
+class _CodedCommandError(click.ClickException):
+    """Base for CLI failures that surface an underlying coded error's fixed machine code.
+
+    Carries the common body every exit-1 command error shares: it records the fixed ``.code`` of an
+    underlying coded failure (a bootstrap, spool, state, pipeline, privacy, or storage error) and
+    renders that error's bounded, value-safe string. Those errors expose only fixed strings — never
+    key material, a secret, a path, a URL, or a payload — so rendering the code and message here
+    leaks nothing. Subclasses set only their ``exit_code``; behaviour (exit code and rendering) is
+    identical to the per-class bodies this base replaces.
+    """
+
+    def __init__(self, error: _CodedError) -> None:
+        self.code = error.code
+        super().__init__(str(error))
 
 
 class ConfigCommandError(click.ClickException):
@@ -153,14 +175,10 @@ def config_schema_command() -> None:
     output.flush()
 
 
-class BootstrapCommandError(click.ClickException):
+class BootstrapCommandError(_CodedCommandError):
     """A stable bootstrap failure using the CLI contract's exit code 1."""
 
     exit_code = 1
-
-    def __init__(self, error: bootstrap.BootstrapError) -> None:
-        self.code = error.code
-        super().__init__(str(error))
 
 
 @main.command(name="init")
@@ -278,7 +296,7 @@ def _require_installation_id(paths: RuntimePaths) -> str:
     return installation_id
 
 
-class CollectCommandError(click.ClickException):
+class CollectCommandError(_CodedCommandError):
     """A stable ``collect`` failure using the CLI contract's exit code 1.
 
     Carries the fixed machine code of an underlying coded failure — a privacy, spool, state, or
@@ -288,10 +306,6 @@ class CollectCommandError(click.ClickException):
     """
 
     exit_code = 1
-
-    def __init__(self, error: MilhouseError) -> None:
-        self.code = error.code
-        super().__init__(str(error))
 
 
 def _new_collect_registry() -> CollectorRegistry:
@@ -314,41 +328,33 @@ def _build_collect_pipeline(
     *,
     mode: RuntimeMode,
     exporters: Mapping[str, Exporter],
-    registry: CollectorRegistry | None = None,
+    redactor: LayeredRedactor,
 ) -> RuntimePipeline:
     """Assemble a mode-aware :class:`RuntimePipeline` from validated config and control plane.
 
-    Extracted as the testable seam the ``collect`` command builds through: production passes
-    ``registry=None`` (the real registry, whose site_canary factory builds a live HTTP client) while
-    a test injects a registry holding a network-free fake collector. The pipeline hard-requires a
-    :class:`LayeredRedactor`, so this loads the keyed pseudonym key ``init`` provisions and FAILS
-    CLOSED with ``run milhouse init first`` when it is absent (a corrupt or foreign key surfaces its
-    own fixed code instead). The redactor is built with no extra known secrets; the collectors are
-    the primary redaction authority. ``config_generation`` is the deterministic 64-hex digest of
-    the fully validated config, which the pipeline re-checks. The caller supplies ``mode`` and the
-    matching ``exporters`` map — empty for ``spool_only``, the ClickHouse exporter keyed by its
-    exporter id for ``full`` — and the pipeline ctor enforces that invariant (``full`` requires a
-    non-empty map, ``spool_only`` an empty one), so the full-mode obligation lives here rather than
-    in a separate reject guard.
+    The testable seam the ``collect`` command builds through. It always uses the production
+    first-party registry (:func:`_new_collect_registry`, whose site_canary factory builds a live
+    HTTP client); a network-free test substitutes it by monkeypatching that module-level factory.
+    The caller supplies the already-built :class:`LayeredRedactor` the pipeline hard-requires,
+    loaded from the keyed pseudonym key ``init`` provisions BEFORE any client or control handle is
+    opened — so a missing/corrupt key fails closed "run milhouse init first" without leaving a
+    ClickHouse client or an empty control DB behind. ``config_generation`` is the deterministic
+    64-hex digest of the fully validated config, which the pipeline re-checks. The caller supplies
+    ``mode`` and the matching ``exporters`` map — empty for ``spool_only``, the ClickHouse exporter
+    keyed by its exporter id for ``full`` — and the pipeline ctor enforces that invariant (``full``
+    requires a non-empty map, ``spool_only`` an empty one), so the full-mode obligation lives here
+    rather than in a separate reject guard.
     """
 
-    if registry is None:
-        registry = _new_collect_registry()
-    try:
-        pseudonymizer = load_pseudonym_key(config, paths)
-    except PrivacyError as error:
-        if error.code == "MH_PRIVACY_KEY_NOT_FOUND":
-            raise BootstrapCommandError(
-                bootstrap.BootstrapError("MH_NOT_INITIALIZED", "run milhouse init first")
-            ) from None
-        raise CollectCommandError(error) from None
-    redactor = LayeredRedactor(pseudonymizer, known_secrets=())
-    barrier = GlobalCommitBarrier(
-        paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
-    )
+    registry = _new_collect_registry()
+    barrier = GlobalCommitBarrier(bootstrap.barrier_path(paths))
     return RuntimePipeline(
         mode=mode,
-        config_generation=validated_config_digest(config),
+        # Reuse the digest ``_resolve_config`` already computed and bound into the runtime paths:
+        # the loader sets ``config_selection.config_digest = validated_config_digest(config)`` for
+        # this exact config, and ``verify_config_generation`` enforces their equality as a runtime
+        # invariant, so it is byte-identical to recomputing it here (a unit test locks this).
+        config_generation=paths.config_selection.config_digest,
         registry=registry,
         redactor=redactor,
         control=control,
@@ -474,8 +480,32 @@ def collect_run_command(
         collectors = [
             collector for collector in collectors if getattr(collector, "target", None) == target_id
         ]
+        # A named collector that is not bound to the named target is an operator mistake, not an
+        # empty run: fail closed (exit 2) rather than silently doing nothing. (``--target`` alone
+        # with no bound collectors stays a legitimate empty run — exit 0 — and is not caught here.)
+        if collector_id is not None and not collectors:
+            raise ConfigCommandError(
+                ConfigError(
+                    "config.collector.unbound",
+                    f"collector {collector_id} is not bound to target {target_id}",
+                )
+            )
 
     installation_id = _require_installation_id(paths)
+    # Load the pseudonym key and build the redactor the pipeline hard-requires BEFORE opening any
+    # ClickHouse client or control handle, so a missing/corrupt key fails closed "run milhouse init
+    # first" without wasting a client/DB open — which could otherwise leave an empty control DB
+    # behind. The collectors are the primary redaction authority, so no extra known secrets here.
+    try:
+        pseudonymizer = load_pseudonym_key(config, paths)
+    except PrivacyError as error:
+        if error.code == "MH_PRIVACY_KEY_NOT_FOUND":
+            raise BootstrapCommandError(
+                bootstrap.BootstrapError("MH_NOT_INITIALIZED", "run milhouse init first")
+            ) from None
+        raise CollectCommandError(error) from None
+    redactor = LayeredRedactor(pseudonymizer, known_secrets=())
+
     # Full mode delivers committed segments to ClickHouse via the pipeline's delivery tail, so it
     # needs an authenticated client and the ClickHouse exporter; spool_only needs neither. Open the
     # client BEFORE the control handle so a storage-config failure (clickhouse disabled/unbuildable,
@@ -504,6 +534,7 @@ def collect_run_command(
             control,
             mode=config.runtime.mode,
             exporters=exporters,
+            redactor=redactor,
         )
         # The full target set is passed for lookup; the collector filters above scope the run.
         summary = pipeline.run(tuple(collectors), tuple(config.targets))
@@ -514,8 +545,8 @@ def collect_run_command(
         # command produces -- a clean ``error: MH_...`` rather than a raw traceback. Per-collector
         # faults AND a contained ClickHouse delivery failure are already isolated INTO the summary
         # (records_failed / export_error_code → exit 1 below); this catches only failures that abort
-        # the whole run. The key-missing / other PrivacyError mappings raised inside
-        # ``_build_collect_pipeline`` are ClickExceptions and propagate.
+        # the whole run. The key-missing / other PrivacyError mapping ran earlier (before any handle
+        # opened), so it never reaches here.
         raise CollectCommandError(error) from None
     finally:
         # Close the ClickHouse client and the control handle on EVERY path (ownership failure,
@@ -551,6 +582,16 @@ def collect_run_command(
     for label, stage_code in stage_error_codes:
         if stage_code is not None:
             click.echo(f"WARNING: the {label} stage reported {stage_code}", err=True)
+    # A failed/error collector forces exit 1; emit a uniform per-collector stderr WARNING (the same
+    # operator signal the stage errors give), privacy-safe: only the config-declared collector id
+    # and its fixed error code -- never a payload, path, URL, or secret.
+    for collector in summary.collectors:
+        if collector.status in ("failed", "error"):
+            click.echo(
+                f"WARNING: collector {collector.collector_id} ended {collector.status} "
+                f"({collector.error_code or 'none'})",
+                err=True,
+            )
     if _collect_run_failed(summary):
         context.exit(1)
 
@@ -701,17 +742,13 @@ def doctor_command(context: click.Context, as_json: bool) -> None:
         context.exit(1)
 
 
-class StorageCommandError(click.ClickException):
+class StorageCommandError(_CodedCommandError):
     """A stable ClickHouse-storage failure using the CLI contract's exit code 1."""
 
     exit_code = 1
 
-    def __init__(self, error: storage.StorageError) -> None:
-        self.code = error.code
-        super().__init__(str(error))
 
-
-class StorageExportError(click.ClickException):
+class StorageExportError(_CodedCommandError):
     """A stable ``storage export`` drain failure using the CLI contract's exit code 1.
 
     The ledger-gated export spans two fail-closed layers — the spool's replay/delivery machine
@@ -721,12 +758,8 @@ class StorageExportError(click.ClickException):
 
     exit_code = 1
 
-    def __init__(self, error: SpoolError | storage.StorageError) -> None:
-        self.code = error.code
-        super().__init__(str(error))
 
-
-class StorageRestoreError(click.ClickException):
+class StorageRestoreError(_CodedCommandError):
     """A stable ``storage restore`` failure using the CLI contract's exit code 1.
 
     Restore spans two fail-closed layers — the native ClickHouse round-trip/verification
@@ -737,10 +770,6 @@ class StorageRestoreError(click.ClickException):
     """
 
     exit_code = 1
-
-    def __init__(self, error: SpoolError | storage.StorageError) -> None:
-        self.code = error.code
-        super().__init__(str(error))
 
 
 def _storage_client(state: CliState) -> tuple[str, storage.ConnectedClickHouseClient]:
@@ -863,9 +892,7 @@ def storage_migrate_command(state: CliState, reclaim: bool, as_json: bool) -> No
     paths = _resolve_paths(state)
     installation_id = _require_installation_id(paths)  # the commit lock lives under a control dir
     database, client = _storage_client(state)
-    barrier = GlobalCommitBarrier(
-        paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
-    )
+    barrier = GlobalCommitBarrier(bootstrap.barrier_path(paths))
     try:
         with barrier.exclusive():
             result = storage.migrate(
@@ -936,9 +963,7 @@ def storage_backup_command(state: CliState, destination: str, as_json: bool) -> 
     paths = _resolve_paths(state)
     installation_id = _require_installation_id(paths)  # the commit lock lives under a control dir
     database, client = _storage_client(state)
-    barrier = GlobalCommitBarrier(
-        paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
-    )
+    barrier = GlobalCommitBarrier(bootstrap.barrier_path(paths))
     try:
         with barrier.exclusive():
             # Refuse to back up a destination this installation does not own (fail closed): the
@@ -1012,9 +1037,7 @@ def storage_restore_command(context: click.Context, source: str, as_json: bool) 
     try:
         database, client = _storage_client(state)
         try:
-            barrier = GlobalCommitBarrier(
-                paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
-            )
+            barrier = GlobalCommitBarrier(bootstrap.barrier_path(paths))
             with barrier.exclusive():
                 # A native RESTORE DATABASE rejects a non-empty target, and this command never drops
                 # or overwrites live data (that is W16). A present schema (any applied migration)
@@ -1130,9 +1153,7 @@ def storage_export_command(context: click.Context, as_json: bool) -> None:
             # — unlike backup/restore, which check inside their exclusive scope because they hold it
             # the whole operation — the placement here is a correctness no-op vs the barrier.
             storage.require_owner(client, database, installation_id=installation_id)
-            barrier = GlobalCommitBarrier(
-                paths.state_root / bootstrap.CONTROL_DIRNAME / bootstrap.BARRIER_NAME
-            )
+            barrier = GlobalCommitBarrier(bootstrap.barrier_path(paths))
             report = replay_segments(
                 control,
                 barrier,

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -198,6 +198,66 @@ def test_health_flags_a_wrong_schema_version(
     assert "expected 999" in database_check.detail
 
 
+def test_health_flags_a_corrupt_pseudonym_key(tmp_path: Path) -> None:
+    # A present-but-invalid key (here: mode loosened from owner-only 0600 to 0644) must read NOT-ok
+    # and unhealthy -- matching how ``collect``'s load_pseudonym_key rejects it -- rather than being
+    # called "healthy" by a bare presence probe.
+    paths = _init_with_key(tmp_path)
+    os.chmod(paths.pseudonym_key, 0o644)
+
+    report = bootstrap.health(paths, now=_NOW)
+
+    key_check = next(check for check in report.checks if check.name == "pseudonym_key")
+    assert key_check.ok is False
+    assert key_check.detail == "present but invalid (run milhouse init)"
+    assert report.healthy is False
+
+
+def test_initialize_without_config_never_provisions_the_pseudonym_key(tmp_path: Path) -> None:
+    # Credential-free callers (the spool-only demo) init WITHOUT a config: the pseudonym key file
+    # must stay ABSENT and ``pseudonym_key_created`` False -- the privacy invariant that a keyless
+    # init never provisions key material.
+    config_file = _config_file(tmp_path)
+    config, config_path = load_config(config_file, platform_default=config_file)
+    paths = resolve_runtime_paths(
+        config, config_path=config_path, platform_data_root=tmp_path / "platform"
+    )
+
+    report = bootstrap.initialize(paths, now=_NOW)  # no config
+
+    assert report.pseudonym_key_created is False
+    assert not paths.pseudonym_key.exists()
+
+
+def test_initialize_creates_a_nested_pseudonym_key_parent(tmp_path: Path) -> None:
+    # A non-default nested ``identity.pseudonym_key_path`` must have its owner-only parent chain
+    # created, or key provisioning would fail with an opaque parent-missing error.
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    config_file = config_dir / "config.toml"
+    body = _EXAMPLE_CONFIG.replace(
+        'pseudonym_key_path = "control/pseudonym.key"',
+        'pseudonym_key_path = "control/keys/nested/pseudonym.key"',
+    )
+    config_file.write_text(body, encoding="utf-8")
+    config, config_path = load_config(config_file, platform_default=config_file)
+    paths = resolve_runtime_paths(
+        config, config_path=config_path, platform_data_root=tmp_path / "platform"
+    )
+    assert not paths.pseudonym_key.parent.exists()
+
+    report = bootstrap.initialize(paths, now=_NOW, config=config)
+
+    assert report.pseudonym_key_created is True
+    assert paths.pseudonym_key.is_file()
+    assert stat.S_IMODE(os.stat(paths.pseudonym_key).st_mode) == 0o600
+    # Every ancestor directory created down to the key's parent is owner-only (0700), including the
+    # intermediate levels ``mkdir(parents=True)`` would otherwise leave at the umask default.
+    parent = paths.pseudonym_key.parent
+    for level in (parent, parent.parent):  # control/keys/nested, control/keys
+        assert stat.S_IMODE(os.stat(level).st_mode) == 0o700
+
+
 # --- CLI surface (exit codes + stable JSON) -------------------------------------------------------
 
 

--- a/tests/unit/test_collect_cli.py
+++ b/tests/unit/test_collect_cli.py
@@ -20,18 +20,30 @@ from click.testing import CliRunner
 from milhouse.cli import bootstrap, root
 from milhouse.cli.root import main
 from milhouse.config import RuntimePaths, load_config, resolve_runtime_paths
+from milhouse.config.loader import validated_config_digest
 from milhouse.config.secrets import SecretEnvironment
 from milhouse.domain.records import CollectorDescriptorV1
+from milhouse.runtime import PipelineError
 from milhouse.spooling import SpoolError
 from milhouse.state import StateError
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _EXAMPLE_CONFIG = (_REPO_ROOT / "config" / "example.toml").read_text(encoding="utf-8")
+# A minimal config whose single collector is its LAST block with no job/rule referencing it, so
+# truncating at ``[[collectors]]`` yields a valid ZERO-collector config for the empty-list branch.
+_LOCAL_ONLY_CONFIG = (_REPO_ROOT / "config" / "examples" / "local-only.toml").read_text(
+    encoding="utf-8"
+)
 # A second site_canary collector on the already-declared target, so a per-collector isolation run
 # has one collector that fails and one that succeeds. Appended text appends to the collectors array.
 _SECOND_COLLECTOR = (
     '\n[[collectors]]\nid = "second-canary"\ntype = "site_canary"\n'
     'target = "example-app"\nurl = "https://example.com/health2"\nexpected_statuses = [200]\n'
+)
+# A second declared target that no example collector is bound to.
+_SECOND_TARGET = (
+    '\n[[targets]]\nid = "other-app"\nname = "Other App"\nkind = "web_service"\n'
+    'environment = "production"\n'
 )
 
 
@@ -108,6 +120,25 @@ _PRIVACY_SAFE_COLLECTOR_KEYS = {
     "records_failed",
     "batch_id",
 }
+
+# The example config's example-canary target URL/host; a fake collector emits it inside a draft's
+# free-text field so a privacy assertion that it never reaches the summary is meaningful.
+_TARGET_URL = "https://example.com/health"
+_TARGET_HOST = "example.com"
+_URL_BEARING_MESSAGE = f"probe of {_TARGET_URL} failed for host {_TARGET_HOST}"
+
+
+def _json_payload(output: str) -> dict[str, object]:
+    """Parse the ``--json`` summary object from mixed stdout/stderr CLI output.
+
+    ``collect run`` may trail its JSON summary with privacy-safe stderr WARNING/NOTE lines (a failed
+    collector, a stage error), which CliRunner mixes into ``output``; the summary is therefore the
+    last line that starts with ``{``, not simply the last line.
+    """
+
+    json_lines = [line for line in output.splitlines() if line.startswith("{")]
+    assert json_lines, output
+    return json.loads(json_lines[-1])
 
 
 # --- Part A: init provisions the pseudonym key, idempotently --------------------------------------
@@ -191,7 +222,10 @@ def test_collect_run_json_is_stable_and_privacy_safe(
     config_file = _config_file(tmp_path)
     runner = CliRunner()
     runner.invoke(main, ["--config", str(config_file), "init"])
-    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+    # The fake collector emits a draft whose free-text message ACTUALLY carries the target URL/host,
+    # so the no-leak assertions below prove the summary is privacy-safe (it never renders draft
+    # payloads) rather than being vacuously true against a URL-free draft.
+    _use_fake_registry(monkeypatch, fake_factory((_URL_BEARING_MESSAGE,)))
 
     result = runner.invoke(main, ["--config", str(config_file), "collect", "run", "--json"])
 
@@ -203,9 +237,9 @@ def test_collect_run_json_is_stable_and_privacy_safe(
     assert set(payload) == _PRIVACY_SAFE_TOP_KEYS
     for collector in payload["collectors"]:
         assert set(collector) == _PRIVACY_SAFE_COLLECTOR_KEYS
-    # No target url or host leaks into the summary.
-    assert "example.com" not in result.output
-    assert "health2" not in result.output
+    # The draft carried the target URL/host in a free-text field; neither leaks into the summary.
+    assert _TARGET_URL not in result.output
+    assert _TARGET_HOST not in result.output
 
 
 def test_collect_run_exits_one_when_a_collector_fails(
@@ -219,12 +253,16 @@ def test_collect_run_exits_one_when_a_collector_fails(
     result = runner.invoke(main, ["--config", str(config_file), "collect", "run", "--json"])
 
     assert result.exit_code == 1
-    payload = json.loads(result.output.strip().splitlines()[-1])
+    payload = _json_payload(result.output)
     assert payload["collectors"][0]["status"] == "error"
     assert payload["collectors"][0]["error_code"] is not None
     # The fake's raised exception embeds KNOWN_SECRET; per-collector isolation must reduce it to a
     # fixed code, so the secret in the exception message never surfaces in any rendered output.
     assert KNOWN_SECRET not in result.output
+    # A failed/error collector emits a uniform stderr WARNING carrying ONLY the config-declared
+    # collector id and its fixed error code (never the secret-bearing exception message).
+    assert "WARNING: collector example-canary ended error" in result.output
+    assert payload["collectors"][0]["error_code"] in result.output
 
 
 def test_collect_run_isolates_a_failing_collector_from_a_healthy_one(
@@ -239,12 +277,15 @@ def test_collect_run_isolates_a_failing_collector_from_a_healthy_one(
     result = runner.invoke(main, ["--config", str(config_file), "collect", "run", "--json"])
 
     assert result.exit_code == 1  # a failed collector forces exit 1
-    payload = json.loads(result.output.strip().splitlines()[-1])
+    payload = _json_payload(result.output)
     by_id = {c["collector_id"]: c for c in payload["collectors"]}
     assert by_id["example-canary"]["status"] == "ok"
     assert by_id["example-canary"]["records_committed"] >= 1
     assert by_id["second-canary"]["status"] == "error"
     assert by_id["second-canary"]["error_code"] is not None
+    # The uniform per-collector WARNING names only the failing collector, not the healthy one.
+    assert "WARNING: collector second-canary ended error" in result.output
+    assert "WARNING: collector example-canary" not in result.output
 
 
 def test_collect_run_fails_closed_without_init(tmp_path: Path) -> None:
@@ -274,6 +315,30 @@ def test_collect_run_fails_closed_when_the_pseudonym_key_is_absent(
     assert not list((paths.spool / "pending").rglob("*.jsonl"))
 
 
+def test_collect_run_missing_key_opens_no_control_database(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A2: the pseudonym-key fail-closed guard runs BEFORE any control-DB (or ClickHouse client)
+    # handle is opened, so a run whose key is absent leaves no (empty) control DB behind. Simulate a
+    # partial state -- identity present, but BOTH the key and the control DB gone -- and prove the
+    # DB is not recreated.
+    config_file = _config_file(tmp_path)
+    paths = _paths(config_file, tmp_path)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    paths.pseudonym_key.unlink()
+    database = bootstrap.database_path(paths)
+    database.unlink()
+    assert bootstrap.read_installation_id(paths) is not None  # identity persists (separate file)
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run"])
+
+    assert result.exit_code == 1
+    assert "run milhouse init first" in result.output
+    assert not database.exists()  # the key guard preceded open_control_database
+
+
 def test_collect_run_unknown_collector_id_is_config_error(tmp_path: Path) -> None:
     config_file = _config_file(tmp_path)
     CliRunner().invoke(main, ["--config", str(config_file), "init"])
@@ -288,6 +353,36 @@ def test_collect_run_unknown_target_is_config_error(tmp_path: Path) -> None:
         main, ["--config", str(config_file), "collect", "run", "--target", "nope"]
     )
     assert result.exit_code == 2
+
+
+def test_collect_run_collector_not_bound_to_target_is_config_error(tmp_path: Path) -> None:
+    # example-canary is bound to example-app, not other-app. Naming BOTH a collector and a target it
+    # is not bound to is an operator mistake -- a config error (exit 2), not a silent empty run.
+    config_file = _config_file(tmp_path, extra=_SECOND_TARGET)
+    result = CliRunner().invoke(
+        main,
+        ["--config", str(config_file), "collect", "run", "example-canary", "--target", "other-app"],
+    )
+    assert result.exit_code == 2
+
+
+def test_collect_run_target_only_with_no_bound_collectors_is_an_empty_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # ``--target`` alone (no collector id) over a target that has no bound collectors stays a
+    # legitimate empty run (exit 0), NOT a config error -- only the both-given case is an error.
+    config_file = _config_file(tmp_path, extra=_SECOND_TARGET)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(
+        main, ["--config", str(config_file), "collect", "run", "--target", "other-app", "--json"]
+    )
+
+    assert result.exit_code == 0
+    payload = _json_payload(result.output)
+    assert payload["collectors"] == []
 
 
 def test_collect_run_filters_to_one_collector(
@@ -313,13 +408,14 @@ def test_collect_run_filters_to_one_collector(
     [
         (SpoolError("MH_SPOOL_TEST", "spool integrity check failed"), "MH_SPOOL_TEST"),
         (StateError("MH_STATE_TEST", "control state check failed"), "MH_STATE_TEST"),
+        (PipelineError("MH_PIPELINE_TEST", "pipeline construction failed"), "MH_PIPELINE_TEST"),
     ],
 )
 def test_collect_run_maps_a_run_abort_to_the_coded_exit_one_contract(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error: Exception, code: str
 ) -> None:
-    # A whole-run abort (spool integrity, control state, pipeline ctor) must surface as the coded
-    # exit-1 ClickException every other command produces -- never a raw traceback.
+    # A whole-run abort (spool integrity, control state, or a pipeline ctor PipelineError) must
+    # surface as the coded exit-1 ClickException every other command produces -- never a traceback.
     config_file = _config_file(tmp_path)
     runner = CliRunner()
     runner.invoke(main, ["--config", str(config_file), "init"])
@@ -335,10 +431,11 @@ def test_collect_run_maps_a_run_abort_to_the_coded_exit_one_contract(
     assert result.exit_code == 1
     # The coded message is rendered by the ClickException handler (an escaped raw error would not
     # reach the captured output), and the recorded exception is the clean SystemExit Click raises
-    # for a handled ClickException -- NOT the raw SpoolError/StateError with a traceback.
+    # for a handled ClickException -- NOT the raw SpoolError/StateError/PipelineError with a
+    # traceback.
     assert code in result.output
     assert isinstance(result.exception, SystemExit)
-    assert not isinstance(result.exception, (SpoolError, StateError))
+    assert not isinstance(result.exception, (SpoolError, StateError, PipelineError))
 
 
 # --- Part C: collect run (full mode → ClickHouse export via the delivery ledger) ------------------
@@ -523,3 +620,62 @@ def test_collect_list_reports_configured_collectors(tmp_path: Path) -> None:
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert {"id": "example-canary", "type": "site_canary"} in payload["collectors"]
+
+
+# --- human-mode (non --json) render paths ---------------------------------------------------------
+
+
+def test_collect_run_human_mode_renders_summary_and_per_collector_lines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = _config_file(tmp_path)  # spool_only
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run"])  # no --json
+
+    assert result.exit_code == 0
+    # The human-mode summary line and the per-collector line for the configured, healthy collector.
+    assert "collect: mode=spool_only committed=" in result.output
+    assert "delivered=0" in result.output
+    assert "example-canary: status=ok" in result.output
+    # Human mode emits no JSON object.
+    assert "{" not in result.output
+
+
+def test_collect_list_human_mode_renders_configured_collectors(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    result = CliRunner().invoke(
+        main, ["--config", str(config_file), "collect", "list"]
+    )  # no --json
+    assert result.exit_code == 0
+    assert "example-canary  type=site_canary" in result.output
+
+
+def test_collect_list_human_mode_reports_no_configured_collectors(tmp_path: Path) -> None:
+    body = _LOCAL_ONLY_CONFIG[: _LOCAL_ONLY_CONFIG.index("[[collectors]]")]
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    config_file = config_dir / "config.toml"
+    config_file.write_text(body, encoding="utf-8")
+
+    result = CliRunner().invoke(main, ["--config", str(config_file), "collect", "list"])
+
+    assert result.exit_code == 0
+    assert "no configured collectors" in result.output
+
+
+# --- config_generation digest reuse (locks B4 byte-identity) --------------------------------------
+
+
+def test_config_selection_digest_is_the_validated_config_digest(tmp_path: Path) -> None:
+    # ``_build_collect_pipeline`` reuses ``paths.config_selection.config_digest`` as the pipeline's
+    # ``config_generation`` INSTEAD of recomputing ``validated_config_digest(config)``; the loader
+    # binds them equal and ``verify_config_generation`` enforces it, so lock byte-identity here.
+    config_file = _config_file(tmp_path)
+    config, config_path = load_config(config_file, platform_default=config_file)
+    paths = resolve_runtime_paths(
+        config, config_path=config_path, platform_data_root=tmp_path / "platform"
+    )
+    assert paths.config_selection.config_digest == validated_config_digest(config)


### PR DESCRIPTION
## What & why

Knocks out the deferred **P3** findings from the `/code-review max 142` review, tracked in **#143** (the builder-guard P3 was already resolved by #145). All P3s were non-blocking; this is the cleanup/hardening pass. **Closes #143.** Refs #141.

## Group A — robustness / behavior (`collect run`, `init`, `health`)
- **health checks key *validity*, not just presence** — `health`/`doctor` now validate the pseudonym key's mode/size/owner/nlink (via `os.fstat` **metadata only** — never reads key bytes), matching what `collect run` requires. A corrupt (e.g. `0644`) key now reports `unhealthy` instead of falsely "healthy".
- **key guard before any handle opens** — `collect run` loads the pseudonym key + builds the redactor *before* `_storage_client` (full mode) and `open_control_database`, so a missing/corrupt key fails closed with "run milhouse init first" without opening a ClickHouse client or leaving an empty control DB behind. The increment-2 full-mode wiring is unchanged.
- **failed-collector stderr WARNING** — a `failed`/`error` collector now emits a stderr WARNING (privacy-safe: `collector_id` + `error_code`), consistent with stage-error WARNINGs.
- **`--target` empty intersection** — a named collector not bound to the named `--target` is now a config error (exit 2, "collector X is not bound to target Y") instead of a silent exit-0 no-op.
- **`init` creates the key's parent dir** — a non-default nested `pseudonym_key` path now works (each ancestor created owner-only `0700`).

## Group B — cleanup / refactor (behavior-identical, verified)
- **`bootstrap.barrier_path()`** replaces ~8 inline commit-lock path joins (collect / storage export·migrate·backup·restore / demo / init) — byte-identical to the old path at every site (verified against the spool-layer barrier validator).
- removed the **dead `registry` param** on `_build_collect_pipeline` (tests inject via the `_new_collect_registry` monkeypatch seam).
- extracted a **`_CodedCommandError` base** for the coded `ClickException` classes (same exit codes, same rendering).
- **config-digest reuse** — the builder now reuses `config_selection.config_digest` (proven byte-identical to `validated_config_digest(config)` and locked by a test) instead of recomputing it.

## Group C — tests / docs
- the privacy test now has a fake collector emit a draft whose free-text **actually contains the target URL/host**, and asserts it never leaks into the summary (the old assertion was vacuous).
- added tests: credential-free `initialize(config=None)` leaves the key absent; human-mode (non-`--json`) render of `collect run` + `collect list` (incl. the empty branch); `PipelineError` run-abort; corrupt-key-unhealthy; missing-key-opens-no-DB; unbound-collector exit-2; nested-key-parent `0700`.
- **`docs/quickstart.md`** gains a "Run configured collectors" section (init → migrate → collect run; spool_only vs full) with an accurate exit-code table.

## Review
A 4-angle adversarial workflow verified the **code** clean across all three code angles — robustness, **barrier lock-path byte-identity**, and the error-class/digest **refactor behavior-identity** all `safe`, 0 issues. It flagged two **docs-only** inaccuracies in the new quickstart section (falsely calling `spool_only` "the default" when `example.toml` ships `full` and `mode` is required; and over-claiming that a *corrupt* key gives "run milhouse init first"). **Both are fixed in this PR** — the quickstart now states `mode` is required, that `example.toml` ships `full`, and how a missing vs corrupt key differ.

## Gates
`test` → 5105 passed / 6 skipped / 0 failed; `quality` clean (ruff, mypy, config/link/workflow/zizmor/skills). DCO + co-author trailers, no session locator.

## Scope
Cleanup/hardening only — no functional change to the collect vertical beyond the exit-2 and WARNING refinements above; the real ClickHouse round-trip remains live/E06 (#108). **G06/G05 stay *not passed*.**

Closes #143
Refs #141
