### PR TITLE
feat(cli): add the milhouse canary shorthand (#147)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -111,6 +111,18 @@ $ milhouse --config ./config.toml collect list    # the configured collectors' i
 example-canary  type=site_canary
 ```
 
+`milhouse canary` is a shorthand that runs only the configured `site_canary` collectors (the network
+probes) through the same pipeline, with the same modes, summary, and exit codes as `collect run`.
+`--target TARGET_ID` scopes it to the canaries bound to one target. If no `site_canary` collector is
+configured — or none is bound to the given target — it reports that and exits 0 without running
+anything.
+
+```console
+$ milhouse --config ./config.toml canary          # runs the site_canary collectors once
+collect: mode=spool_only committed=1 delivered=0 failed=0 alerts_fired=0 alerts_resolved=0 intents_emitted=0
+  example-canary: status=ok error=none drafts=1 committed=1 delivered=0 failed=0 batch=2026-08-16/...
+```
+
 An optional `COLLECTOR_ID` runs only that collector, and `--target TARGET_ID` runs only the
 collectors bound to that declared target. An unknown collector or target id — or a named collector
 that is not bound to the named target — is a configuration error (exit 2). For a **full**-mode flow,

--- a/src/milhouse/cli/root.py
+++ b/src/milhouse/cli/root.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections import Counter
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Protocol
@@ -14,7 +14,7 @@ from platformdirs import user_config_path, user_data_path
 
 from milhouse import __version__, storage
 from milhouse.cli import bootstrap, demo, views
-from milhouse.collectors.site_canary import register_site_canary
+from milhouse.collectors.site_canary import SITE_CANARY_TYPE, register_site_canary
 from milhouse.config import (
     ConfigError,
     RuntimePaths,
@@ -23,7 +23,7 @@ from milhouse.config import (
     load_secret_environment,
     resolve_runtime_paths,
 )
-from milhouse.config._models import MilhouseConfig
+from milhouse.config._models import CollectorConfig, MilhouseConfig, TargetConfig
 from milhouse.core.clock import SystemClock
 from milhouse.privacy.keys import load_pseudonym_key
 from milhouse.privacy.pseudonym import PrivacyError
@@ -411,6 +411,134 @@ def _collect_run_failed(summary: PipelineRunSummary) -> bool:
     )
 
 
+def _run_collect(
+    context: click.Context,
+    state: CliState,
+    config: MilhouseConfig,
+    paths: RuntimePaths,
+    collectors: Sequence[CollectorConfig],
+    targets: Sequence[TargetConfig],
+    *,
+    as_json: bool,
+) -> None:
+    """Run the already-filtered ``collectors`` once through the runtime pipeline, then exit.
+
+    The shared body ``collect run`` and the ``canary`` shorthand both call after doing their own
+    collector selection. It takes the ALREADY-FILTERED ``collectors`` plus the full ``targets`` set
+    (passed to the pipeline for lookup) and performs everything from the pseudonym-key/redactor load
+    through the exit: the fail-closed key guard BEFORE any handle opens, the mode-aware full-mode
+    ClickHouse client lifecycle (client closed in ``finally`` on every path), the coded exit-1
+    mapping for a whole-run abort, the privacy-safe ``--json``/human summary, the per-stage and
+    per-collector stderr WARNINGs, and the exit-code contract (``context.exit(1)`` on failure). The
+    behaviour is identical for either caller — the only thing that differs is which collectors were
+    selected upstream.
+    """
+
+    installation_id = _require_installation_id(paths)
+    # Load the pseudonym key and build the redactor the pipeline hard-requires BEFORE opening any
+    # ClickHouse client or control handle, so a missing/corrupt key fails closed "run milhouse init
+    # first" without wasting a client/DB open — which could otherwise leave an empty control DB
+    # behind. The collectors are the primary redaction authority, so no extra known secrets here.
+    try:
+        pseudonymizer = load_pseudonym_key(config, paths)
+    except PrivacyError as error:
+        if error.code == "MH_PRIVACY_KEY_NOT_FOUND":
+            raise BootstrapCommandError(
+                bootstrap.BootstrapError("MH_NOT_INITIALIZED", "run milhouse init first")
+            ) from None
+        raise CollectCommandError(error) from None
+    redactor = LayeredRedactor(pseudonymizer, known_secrets=())
+
+    # Full mode delivers committed segments to ClickHouse via the pipeline's delivery tail, so it
+    # needs an authenticated client and the ClickHouse exporter; spool_only needs neither. Open the
+    # client BEFORE the control handle so a storage-config failure (clickhouse disabled/unbuildable,
+    # or a bad secret env) surfaces its own coded exit without ever acquiring a control handle.
+    client: storage.ConnectedClickHouseClient | None = None
+    database: str | None = None
+    if config.runtime.mode == "full":
+        database, client = _storage_client(state)
+    control = open_control_database(bootstrap.database_path(paths))
+    try:
+        exporters: dict[str, Exporter] = {}
+        if client is not None and database is not None:
+            # Refuse to deliver to a destination this installation does not own (fail closed) — the
+            # same read barrier ``storage export`` takes: an UNCLAIMED destination raises
+            # ``MH_STORAGE_OWNERSHIP`` with "run storage migrate first", a FOREIGN owner is refused.
+            # Placed BEFORE the pipeline commits/exports, so a full run over an unowned ClickHouse
+            # strands nothing.
+            storage.require_owner(client, database, installation_id=installation_id)
+            exporters = {
+                storage.CLICKHOUSE_EXPORTER_ID: storage.ClickHouseExporter(client, database)
+            }
+        pipeline = _build_collect_pipeline(
+            config,
+            paths,
+            installation_id,
+            control,
+            mode=config.runtime.mode,
+            exporters=exporters,
+            redactor=redactor,
+        )
+        # The full target set is passed for lookup; the collector filters above scope the run.
+        summary = pipeline.run(tuple(collectors), tuple(targets))
+    except (SpoolError, StateError, PipelineError, storage.StorageError) as error:
+        # A spool-integrity, control-state, pipeline-construction, or ClickHouse-ownership failure
+        # (e.g. DurableSpool reconciliation, a tampered barrier, a crashed-prior-writer orphan, an
+        # unclaimed/foreign destination) must surface as the coded exit-1 contract every other
+        # command produces -- a clean ``error: MH_...`` rather than a raw traceback. Per-collector
+        # faults AND a contained ClickHouse delivery failure are already isolated INTO the summary
+        # (records_failed / export_error_code → exit 1 below); this catches only failures that abort
+        # the whole run. The key-missing / other PrivacyError mapping ran earlier (before any handle
+        # opened), so it never reaches here.
+        raise CollectCommandError(error) from None
+    finally:
+        # Close the ClickHouse client and the control handle on EVERY path (ownership failure,
+        # pipeline error, or clean success), so a full run never leaks the client; spool_only opens
+        # none, so ``client is None`` and only the control handle is closed.
+        if client is not None:
+            client.close()
+        control.close()
+
+    if as_json:
+        click.echo(json.dumps(_collect_run_payload(summary), sort_keys=True))
+    else:
+        click.echo(
+            f"collect: mode={summary.mode} committed={summary.records_committed} "
+            f"delivered={summary.records_delivered} failed={summary.records_failed} "
+            f"alerts_fired={summary.alerts_fired} alerts_resolved={summary.alerts_resolved} "
+            f"intents_emitted={summary.intents_emitted}"
+        )
+        for collector in summary.collectors:
+            code = collector.error_code or "none"
+            batch = collector.batch_id or "none"
+            click.echo(
+                f"  {collector.collector_id}: status={collector.status} error={code} "
+                f"drafts={collector.drafts_produced} committed={collector.records_committed} "
+                f"delivered={collector.records_delivered} failed={collector.records_failed} "
+                f"batch={batch}"
+            )
+    stage_error_codes: tuple[tuple[str, str | None], ...] = (
+        ("export", summary.export_error_code),
+        ("alerts", summary.alerts_error_code),
+        ("intents", summary.intents_error_code),
+    )
+    for label, stage_code in stage_error_codes:
+        if stage_code is not None:
+            click.echo(f"WARNING: the {label} stage reported {stage_code}", err=True)
+    # A failed/error collector forces exit 1; emit a uniform per-collector stderr WARNING (the same
+    # operator signal the stage errors give), privacy-safe: only the config-declared collector id
+    # and its fixed error code -- never a payload, path, URL, or secret.
+    for collector in summary.collectors:
+        if collector.status in ("failed", "error"):
+            click.echo(
+                f"WARNING: collector {collector.collector_id} ended {collector.status} "
+                f"({collector.error_code or 'none'})",
+                err=True,
+            )
+    if _collect_run_failed(summary):
+        context.exit(1)
+
+
 @main.group(name="collect")
 def collect_group() -> None:
     """Run configured collectors once into the local spool (spool-only), or list them."""
@@ -491,109 +619,9 @@ def collect_run_command(
                 )
             )
 
-    installation_id = _require_installation_id(paths)
-    # Load the pseudonym key and build the redactor the pipeline hard-requires BEFORE opening any
-    # ClickHouse client or control handle, so a missing/corrupt key fails closed "run milhouse init
-    # first" without wasting a client/DB open — which could otherwise leave an empty control DB
-    # behind. The collectors are the primary redaction authority, so no extra known secrets here.
-    try:
-        pseudonymizer = load_pseudonym_key(config, paths)
-    except PrivacyError as error:
-        if error.code == "MH_PRIVACY_KEY_NOT_FOUND":
-            raise BootstrapCommandError(
-                bootstrap.BootstrapError("MH_NOT_INITIALIZED", "run milhouse init first")
-            ) from None
-        raise CollectCommandError(error) from None
-    redactor = LayeredRedactor(pseudonymizer, known_secrets=())
-
-    # Full mode delivers committed segments to ClickHouse via the pipeline's delivery tail, so it
-    # needs an authenticated client and the ClickHouse exporter; spool_only needs neither. Open the
-    # client BEFORE the control handle so a storage-config failure (clickhouse disabled/unbuildable,
-    # or a bad secret env) surfaces its own coded exit without ever acquiring a control handle.
-    client: storage.ConnectedClickHouseClient | None = None
-    database: str | None = None
-    if config.runtime.mode == "full":
-        database, client = _storage_client(state)
-    control = open_control_database(bootstrap.database_path(paths))
-    try:
-        exporters: dict[str, Exporter] = {}
-        if client is not None and database is not None:
-            # Refuse to deliver to a destination this installation does not own (fail closed) — the
-            # same read barrier ``storage export`` takes: an UNCLAIMED destination raises
-            # ``MH_STORAGE_OWNERSHIP`` with "run storage migrate first", a FOREIGN owner is refused.
-            # Placed BEFORE the pipeline commits/exports, so a full run over an unowned ClickHouse
-            # strands nothing.
-            storage.require_owner(client, database, installation_id=installation_id)
-            exporters = {
-                storage.CLICKHOUSE_EXPORTER_ID: storage.ClickHouseExporter(client, database)
-            }
-        pipeline = _build_collect_pipeline(
-            config,
-            paths,
-            installation_id,
-            control,
-            mode=config.runtime.mode,
-            exporters=exporters,
-            redactor=redactor,
-        )
-        # The full target set is passed for lookup; the collector filters above scope the run.
-        summary = pipeline.run(tuple(collectors), tuple(config.targets))
-    except (SpoolError, StateError, PipelineError, storage.StorageError) as error:
-        # A spool-integrity, control-state, pipeline-construction, or ClickHouse-ownership failure
-        # (e.g. DurableSpool reconciliation, a tampered barrier, a crashed-prior-writer orphan, an
-        # unclaimed/foreign destination) must surface as the coded exit-1 contract every other
-        # command produces -- a clean ``error: MH_...`` rather than a raw traceback. Per-collector
-        # faults AND a contained ClickHouse delivery failure are already isolated INTO the summary
-        # (records_failed / export_error_code → exit 1 below); this catches only failures that abort
-        # the whole run. The key-missing / other PrivacyError mapping ran earlier (before any handle
-        # opened), so it never reaches here.
-        raise CollectCommandError(error) from None
-    finally:
-        # Close the ClickHouse client and the control handle on EVERY path (ownership failure,
-        # pipeline error, or clean success), so a full run never leaks the client; spool_only opens
-        # none, so ``client is None`` and only the control handle is closed.
-        if client is not None:
-            client.close()
-        control.close()
-
-    if as_json:
-        click.echo(json.dumps(_collect_run_payload(summary), sort_keys=True))
-    else:
-        click.echo(
-            f"collect: mode={summary.mode} committed={summary.records_committed} "
-            f"delivered={summary.records_delivered} failed={summary.records_failed} "
-            f"alerts_fired={summary.alerts_fired} alerts_resolved={summary.alerts_resolved} "
-            f"intents_emitted={summary.intents_emitted}"
-        )
-        for collector in summary.collectors:
-            code = collector.error_code or "none"
-            batch = collector.batch_id or "none"
-            click.echo(
-                f"  {collector.collector_id}: status={collector.status} error={code} "
-                f"drafts={collector.drafts_produced} committed={collector.records_committed} "
-                f"delivered={collector.records_delivered} failed={collector.records_failed} "
-                f"batch={batch}"
-            )
-    stage_error_codes: tuple[tuple[str, str | None], ...] = (
-        ("export", summary.export_error_code),
-        ("alerts", summary.alerts_error_code),
-        ("intents", summary.intents_error_code),
-    )
-    for label, stage_code in stage_error_codes:
-        if stage_code is not None:
-            click.echo(f"WARNING: the {label} stage reported {stage_code}", err=True)
-    # A failed/error collector forces exit 1; emit a uniform per-collector stderr WARNING (the same
-    # operator signal the stage errors give), privacy-safe: only the config-declared collector id
-    # and its fixed error code -- never a payload, path, URL, or secret.
-    for collector in summary.collectors:
-        if collector.status in ("failed", "error"):
-            click.echo(
-                f"WARNING: collector {collector.collector_id} ended {collector.status} "
-                f"({collector.error_code or 'none'})",
-                err=True,
-            )
-    if _collect_run_failed(summary):
-        context.exit(1)
+    # The selected collectors and the full target set (for lookup) drive the shared run body, which
+    # owns the key/redactor load, the mode-aware client lifecycle, the summary, and the exit codes.
+    _run_collect(context, state, config, paths, collectors, config.targets, as_json=as_json)
 
 
 @collect_group.command(name="list")
@@ -612,6 +640,79 @@ def collect_list_command(state: CliState, as_json: bool) -> None:
         return
     for row in rows:
         click.echo(f"{row['id']}  type={row['type']}")
+
+
+@main.command(name="canary")
+@click.option(
+    "--target",
+    "target_id",
+    default=None,
+    metavar="TARGET_ID",
+    help="Run only the site_canary collectors bound to this declared target id.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the run summary as stable JSON.")
+@click.pass_context
+def canary_command(context: click.Context, target_id: str | None, as_json: bool) -> None:
+    """Run the configured ``site_canary`` collectors once — a shorthand for ``collect run``.
+
+    A convenience wrapper that scopes a single runtime run to the configured ``site_canary``
+    collectors (a network probe turned into one availability event each) and drives them through the
+    SAME pipeline ``collect run`` uses: collect → redact → spool, plus the configured canary alert
+    rules and notification-intent records evaluated in the same run, and — in ``full`` mode — the
+    exactly-once ClickHouse delivery tail. Like ``collect run`` it requires an initialized install
+    (the pipeline's redactor needs the keyed pseudonym key ``init`` provisions), and what a run does
+    follows the required ``runtime.mode``: ``spool_only`` spools locally with no egress, while
+    ``full`` additionally delivers to a ClickHouse destination that must already be migrated and
+    claimed by THIS installation — run ``storage migrate`` first.
+
+    ``--target`` runs only the canaries bound to that declared target; an unknown target id is a
+    configuration error. If no ``site_canary`` collector matches, nothing is run: the command says
+    so and exits 0 without opening any handle. The emitted summary carries ONLY privacy-safe counts,
+    fixed codes, and config-declared ids — never a secret, PII, path, payload, URL, or target host.
+
+    Exit codes match ``collect run``: 0 clean; 1 if any stage error code is set OR any records fail
+    (including a contained ClickHouse delivery failure) OR any collector ended ``failed``/``error``
+    OR the run aborts with a coded spool/state/pipeline failure OR (full mode) the ClickHouse
+    destination is unclaimed/foreign-owned or ClickHouse is disabled/unbuildable; 2 for an invalid
+    configuration — an unknown target id, or (full mode) an unresolvable ClickHouse secret/config.
+    """
+
+    state = context.ensure_object(CliState)
+    config, paths = _resolve_config(state)
+
+    collectors = [
+        collector for collector in config.collectors if collector.type == SITE_CANARY_TYPE
+    ]
+    if target_id is not None:
+        if target_id not in {target.id for target in config.targets}:
+            raise ConfigCommandError(
+                ConfigError(
+                    "config.target.unknown", "no target with the requested id is configured"
+                )
+            )
+        collectors = [
+            collector for collector in collectors if getattr(collector, "target", None) == target_id
+        ]
+
+    # Nothing to run: report a clear, privacy-safe message (config-declared id only) and exit 0
+    # WITHOUT loading the key or opening a control/ClickHouse handle -- there is nothing to spool.
+    if not collectors:
+        message = (
+            f"no site_canary collectors bound to target {target_id}"
+            if target_id is not None
+            else "no site_canary collectors configured"
+        )
+        if as_json:
+            # Honor the --json contract even on an empty run so a machine consumer always parses:
+            # an empty ``collectors`` signals nothing ran.
+            click.echo(json.dumps({"collectors": [], "message": message}, sort_keys=True))
+        else:
+            click.echo(message)
+        return
+
+    # The selected canaries and the full target set (for lookup) drive the shared run body, which
+    # owns the key/redactor load, the mode-aware client lifecycle, the summary, and the exit codes.
+    _run_collect(context, state, config, paths, collectors, config.targets, as_json=as_json)
 
 
 @main.group(name="spool")

--- a/tests/unit/test_collect_cli.py
+++ b/tests/unit/test_collect_cli.py
@@ -45,6 +45,18 @@ _SECOND_TARGET = (
     '\n[[targets]]\nid = "other-app"\nname = "Other App"\nkind = "web_service"\n'
     'environment = "production"\n'
 )
+# A second site_canary collector bound to the second declared target, to prove ``--target`` scoping
+# on ``canary`` keeps only the canaries bound to the requested target.
+_OTHER_TARGET_CANARY = (
+    '\n[[collectors]]\nid = "other-canary"\ntype = "site_canary"\n'
+    'target = "other-app"\nurl = "https://other.example/health"\nexpected_statuses = [200]\n'
+)
+# A NON-canary collector (file_outbox) on the already-declared target, to prove ``canary`` filters
+# to the site_canary type and never resolves/runs a non-canary collector.
+_NON_CANARY_COLLECTOR = (
+    '\n[[collectors]]\nid = "example-outbox"\ntype = "file_outbox"\n'
+    'target = "example-app"\npath = "outbox"\n'
+)
 
 
 def _config_file(
@@ -679,3 +691,192 @@ def test_config_selection_digest_is_the_validated_config_digest(tmp_path: Path) 
         config, config_path=config_path, platform_data_root=tmp_path / "platform"
     )
     assert paths.config_selection.config_digest == validated_config_digest(config)
+
+
+# --- Part D: the ``canary`` shorthand -------------------------------------------------------------
+#
+# ``canary`` scopes a single runtime run to the configured ``site_canary`` collectors and reuses the
+# SAME shared ``_run_collect`` body ``collect run`` drives, so these tests reuse the fake registry
+# and fake-ClickHouse seams and assert the same privacy-safe summary shape and exit-code contract.
+
+
+def test_canary_runs_the_site_canary_collectors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = _config_file(tmp_path)
+    paths = _paths(config_file, tmp_path)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "canary", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["mode"] == "spool_only"
+    assert payload["records_committed"] >= 1
+    # The summary is the SAME privacy-safe shape ``collect run`` emits (shared helper).
+    assert set(payload) == _PRIVACY_SAFE_TOP_KEYS
+    for collector in payload["collectors"]:
+        assert set(collector) == _PRIVACY_SAFE_COLLECTOR_KEYS
+    # Only the configured site_canary collector ran, and a durable segment reached the spool.
+    assert {c["collector_id"] for c in payload["collectors"]} == {"example-canary"}
+    assert list((paths.spool / "pending").rglob("*.jsonl"))
+
+
+def test_canary_excludes_non_site_canary_collectors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A file_outbox collector shares the config; ``canary`` must filter to the site_canary type
+    # only, so the non-canary collector is never resolved/run (the fake registry has only canary).
+    config_file = _config_file(tmp_path, extra=_NON_CANARY_COLLECTOR)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "canary", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert {c["collector_id"] for c in payload["collectors"]} == {"example-canary"}
+
+
+def test_canary_target_filters_to_bound_canaries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Two canaries on two targets: ``--target example-app`` keeps only the canary bound to it.
+    config_file = _config_file(tmp_path, extra=_SECOND_TARGET + _OTHER_TARGET_CANARY)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(
+        main, ["--config", str(config_file), "canary", "--target", "example-app", "--json"]
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert {c["collector_id"] for c in payload["collectors"]} == {"example-canary"}
+
+
+def test_canary_target_with_no_bound_canaries_reports_and_exits_zero(tmp_path: Path) -> None:
+    # other-app has no bound canary: ``canary`` reports the target-scoped message and exits 0
+    # without running anything -- so no init is required and no handle is opened.
+    config_file = _config_file(tmp_path, extra=_SECOND_TARGET)
+    result = CliRunner().invoke(
+        main, ["--config", str(config_file), "canary", "--target", "other-app"]
+    )
+    assert result.exit_code == 0
+    assert "no site_canary collectors bound to target other-app" in result.output
+
+
+def test_canary_unknown_target_is_config_error(tmp_path: Path) -> None:
+    config_file = _config_file(tmp_path)
+    CliRunner().invoke(main, ["--config", str(config_file), "init"])
+    result = CliRunner().invoke(main, ["--config", str(config_file), "canary", "--target", "nope"])
+    assert result.exit_code == 2
+
+
+def test_canary_with_no_site_canary_collectors_reports_and_opens_no_handles(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A config that HAS a collector but NO site_canary one: ``canary`` reports the message and exits
+    # 0 WITHOUT loading the key or opening any control/ClickHouse handle -- there is nothing to run.
+    body = _LOCAL_ONLY_CONFIG[: _LOCAL_ONLY_CONFIG.index("[[collectors]]")]
+    body += (
+        '[[collectors]]\nid = "local-outbox"\ntype = "file_outbox"\n'
+        'target = "local-tool"\npath = "outbox"\n'
+    )
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    config_file = config_dir / "config.toml"
+    config_file.write_text(body, encoding="utf-8")
+    paths = _paths(config_file, tmp_path)
+
+    def _boom_control(path: object) -> object:
+        raise AssertionError("the empty canary run must not open a control database")
+
+    monkeypatch.setattr(root, "open_control_database", _boom_control)
+
+    result = CliRunner().invoke(main, ["--config", str(config_file), "canary"])
+
+    assert result.exit_code == 0
+    assert "no site_canary collectors configured" in result.output
+    # Nothing was opened or spooled (the empty-run guard precedes every handle).
+    assert not bootstrap.database_path(paths).exists()
+    assert not list((paths.spool / "pending").rglob("*.jsonl"))
+
+
+def test_canary_json_on_an_empty_run_emits_parseable_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # --json must ALWAYS emit parseable JSON, even when nothing runs: an empty ``collectors``
+    # signals nothing ran, and (as with the plain path) no handle is opened.
+    body = _LOCAL_ONLY_CONFIG[: _LOCAL_ONLY_CONFIG.index("[[collectors]]")]
+    body += (
+        '[[collectors]]\nid = "local-outbox"\ntype = "file_outbox"\n'
+        'target = "local-tool"\npath = "outbox"\n'
+    )
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    config_file = config_dir / "config.toml"
+    config_file.write_text(body, encoding="utf-8")
+
+    def _boom_control(path: object) -> object:
+        raise AssertionError("the empty canary run must not open a control database")
+
+    monkeypatch.setattr(root, "open_control_database", _boom_control)
+
+    result = CliRunner().invoke(main, ["--config", str(config_file), "canary", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["collectors"] == []
+    assert "message" in payload
+
+
+def test_canary_full_mode_delivers_to_clickhouse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Full-mode ``canary`` reaches the SAME delivery tail: on a migrated (claimed) destination the
+    # committed canary segment is delivered through the ClickHouse exporter and the client closes.
+    config_file = _config_file(tmp_path, mode="full")
+    client = _CloseSpyClient()
+    _stub_clickhouse(monkeypatch, client)
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    _migrate(config_file)
+    client.close_calls = 0  # isolate the canary run's own finally-close from migrate's client close
+    _use_fake_registry(monkeypatch, fake_factory(("probe ok",)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "canary", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["mode"] == "full"
+    assert payload["records_committed"] >= 1
+    assert payload["records_delivered"] >= 1
+    assert payload["records_failed"] == 0
+    assert payload["export_error_code"] is None
+    # The delivery tail actually wrote the event's record row to ClickHouse (not just migrate DDL).
+    assert "records" in [table for _db, table, *_ in client.inserts]
+    assert client.close_calls >= 1  # closed on the success path (no leak)
+
+
+def test_canary_json_is_privacy_safe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_file = _config_file(tmp_path)
+    runner = CliRunner()
+    runner.invoke(main, ["--config", str(config_file), "init"])
+    # The fake canary emits a draft whose free-text message ACTUALLY carries the target URL/host, so
+    # the no-leak assertions prove the summary is privacy-safe rather than vacuously true.
+    _use_fake_registry(monkeypatch, fake_factory((_URL_BEARING_MESSAGE,)))
+
+    result = runner.invoke(main, ["--config", str(config_file), "canary", "--json"])
+
+    assert result.exit_code == 0
+    json_line = result.output.strip().splitlines()[-1]
+    payload = json.loads(json_line)
+    assert json_line == json.dumps(payload, sort_keys=True)
+    assert set(payload) == _PRIVACY_SAFE_TOP_KEYS
+    assert _TARGET_URL not in result.output
+    assert _TARGET_HOST not in result.output


### PR DESCRIPTION
## What & why

Adds the plan's documented `milhouse canary` shorthand (docs/implementation-plan.md:1225) — a convenience for the common "check my sites" case. `milhouse canary [--target TARGET_ID] [--json]` runs the configured **site_canary** collectors once through the *same* runtime pipeline `collect run` uses (collect → redact → spool → alert → notify-intents → [ClickHouse export in full mode]), scoped to canary collectors. Completes the last core piece of the W06 collect CLI. Refs #147, #141.

## How
- **Shared `_run_collect` helper (pure extraction).** The "run these collectors and report" body of `collect_run_command` — the fail-closed key guard *before* any handle opens, the full-mode `_storage_client` + `require_owner` + `ClickHouseExporter` client lifecycle (client closed in `finally` on every path), the `except (SpoolError, StateError, PipelineError, storage.StorageError)`, the privacy-safe summary + WARNINGs, and the exit-code contract — is extracted into a module-level helper. `collect_run_command` keeps its own filtering (incl. the exit-2 unbound-collector check) and delegates; **all 28 existing `collect run` tests pass unchanged** (behavior-identical).
- **`canary_command`** filters `config.collectors` to `type == "site_canary"` (+ `--target`, with an unknown target → exit 2), and:
  - if no canary matches, prints a fixed privacy-safe message and exits 0 **without opening any handle** (nothing to spool);
  - otherwise runs them through `_run_collect`. Same modes/summary/exit-code contract as `collect run` (full needs `storage migrate` first).

## Review
A 2-angle adversarial workflow returned **`SAFE-TO-PR`, 0 blocking** — the extraction's behavior-identity (collect run unchanged, full-mode lifecycle intact) and the canary command's correctness both `safe`. One P3 was folded in: **`canary --json` now emits parseable JSON even on an empty match** (`{"collectors": [], "message": …}`) instead of a plain-text line, so a machine consumer always parses; covered by a new test.

## Tests (offline, reusing the fake-registry + fake-CH seams)
canary runs the site_canary collectors (exit 0, same privacy-safe key-set as collect run, committed record); excludes non-canary collectors; `--target` filters to bound canaries; unknown `--target` → exit 2; no-canary config → message + exit 0 with **no handle/DB/spool** (proven by a raising `open_control_database` monkeypatch); full-mode canary **delivers** via the fake ClickHouse client; `--json` privacy (no URL/host leak); `--json` empty-run emits parseable JSON. `test` → 5114 passed / 6 skipped / 0 failed; `quality` clean. DCO + co-author trailers, no session locator.

## Scope / not here
`--dry-run` and `collect run --fixture` are deferred (a design decision — the pipeline commits inside `run()`; tracked on #147), as is the `milhouse run [--once]` scheduler (W15). The real ClickHouse round-trip remains live/E06 (#108); **G06/G05 stay *not passed*.**

Refs #147
Refs #141
