### PR TITLE
feat(outbox): W07 increment 1 — .milhouse outbox reader spine (#150)

### DIFF
--- a/src/milhouse/outbox/__init__.py
+++ b/src/milhouse/outbox/__init__.py
@@ -1,0 +1,64 @@
+"""W07 ``.milhouse`` outbox: the untrusted frame envelope, cursor codec, ack file, and reader.
+
+Increment 1 delivers a pure, offline-testable reader spine (plan section 4.9): a compliant producer
+appends ``feedback-outbox.jsonl`` and Milhouse reads it without ever truncating, rotating, or
+rewriting it. This package owns the versioned inbound envelope (:class:`OutboxFrameV1`), the opaque
+cursor position codec anchored on a consumed-prefix hash, the Milhouse-owned atomic
+``outbox-ack.json`` format, and :func:`read_outbox`, which turns a file/cursor/config into new
+frames, a next cursor, an optional P1 data-loss signal, and privacy-safe diagnostics. Collector
+wiring, the durable ``advance_cursor`` write, and the frame-to-record mapping are later increments.
+"""
+
+from __future__ import annotations
+
+from milhouse.outbox.ack import (
+    MAX_ACK_BYTES,
+    OutboxAckV1,
+    outbox_ack_bytes,
+    read_outbox_ack,
+    write_outbox_ack,
+)
+from milhouse.outbox.cursor import (
+    OUTBOX_POSITION_VERSION,
+    OutboxPosition,
+    decode_outbox_position,
+    encode_outbox_position,
+    outbox_position_from_cursor,
+)
+from milhouse.outbox.errors import OutboxError
+from milhouse.outbox.frame import (
+    MAX_OUTBOX_FRAME_BYTES,
+    OutboxActionabilityV1,
+    OutboxFrameV1,
+    parse_outbox_frame_line,
+)
+from milhouse.outbox.reader import (
+    OutboxDiagnostics,
+    OutboxLossSignal,
+    OutboxReaderConfig,
+    OutboxReadResult,
+    read_outbox,
+)
+
+__all__ = [
+    "MAX_ACK_BYTES",
+    "MAX_OUTBOX_FRAME_BYTES",
+    "OUTBOX_POSITION_VERSION",
+    "OutboxAckV1",
+    "OutboxActionabilityV1",
+    "OutboxDiagnostics",
+    "OutboxError",
+    "OutboxFrameV1",
+    "OutboxLossSignal",
+    "OutboxPosition",
+    "OutboxReadResult",
+    "OutboxReaderConfig",
+    "decode_outbox_position",
+    "encode_outbox_position",
+    "outbox_ack_bytes",
+    "outbox_position_from_cursor",
+    "parse_outbox_frame_line",
+    "read_outbox",
+    "read_outbox_ack",
+    "write_outbox_ack",
+]

--- a/src/milhouse/outbox/ack.py
+++ b/src/milhouse/outbox/ack.py
@@ -1,0 +1,378 @@
+"""The Milhouse-owned ``outbox-ack.json`` format and its atomic ``0600`` read/writer (section 4.9).
+
+Ownership (ADR 0012 / plan section 4.9): the application appends ``feedback-outbox.jsonl`` and
+Milhouse never rewrites it, but Milhouse OWNS ``outbox-ack.json`` -- a small atomic file recording
+which producer/file identity and byte offset it has committed, plus the last committed line's digest
+and the acknowledgement time. This module defines that value-safe format (:class:`OutboxAckV1`) and
+a canonical, atomic, mode-``0600`` writer/reader that live strictly inside the configured
+``<repo>/.milhouse`` directory after canonical-path and no-follow symlink checks, reusing the vetted
+secure-file primitives (:mod:`milhouse.config.filesystem`) rather than hand-rolling file security.
+Both the writer and reader pass ``require_private_parent=True``, so the ``.milhouse`` directory must
+be an owner-only ``0700`` directory with no extended ACL -- the Milhouse-owned posture, stricter
+than the app-owned outbox the reader tolerates.
+
+The writer stages the canonical ack bytes with :func:`create_regular_file_no_follow` (a no-follow
+directory-chain walk, private-parent check, ``O_EXCL`` create, ``0600`` mode, full write, ``fsync``,
+and content read-back), then atomically ``os.replace``-es the staged name onto ``outbox-ack.json``
+and fsyncs the directory -- so the ack is either the complete prior value or the complete new value,
+never a torn one. The reader opens no-follow under the same private parent and requires an
+owner-only, ``0600``, single-link, ACL-safe regular file, rejecting a symlinked or foreign path with
+a fixed code. The post-``create`` /
+pre-``replace`` one-syscall window is closed for cooperating writers by the exclusive maintenance
+barrier and for a hostile same-account process by the installation-account trust boundary (ADR
+0008 / amendment A06), matching :func:`remove_regular_file_no_follow`.
+
+Writing the ack AFTER a durable segment commits is a later increment; this module owns only the
+format and the atomic file surface, both of which are fully offline-testable here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import stat
+from pathlib import Path
+from typing import Literal
+
+from pydantic import ConfigDict
+
+from milhouse.config.filesystem import (
+    SecureFileError,
+    SecureFileErrorKind,
+    create_regular_file_no_follow,
+    lexical_absolute_path,
+    open_regular_file_no_follow,
+    sync_parent_directory_no_follow,
+)
+from milhouse.core.canonical import CanonicalizationError, canonical_json_bytes
+from milhouse.domain._validation import ValueSafeRecordModel
+from milhouse.domain.identity import MachineIdV1, Sha256HexV1
+from milhouse.domain.records import UtcTimestampV1
+from milhouse.outbox.errors import OutboxError
+
+#: A generous ceiling for the canonical ack object (it holds a handful of small scalar fields).
+MAX_ACK_BYTES = 4_096
+_ACK_MODE = 0o600
+_ACK_FILENAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,254}", flags=re.ASCII)
+_ACK_KEYS = frozenset(
+    {
+        "acknowledged_at",
+        "committed_offset",
+        "content_sha256",
+        "file_device",
+        "file_inode",
+        "last_line_sha256",
+        "producer_id",
+        "schema_version",
+    }
+)
+
+
+class OutboxAckV1(ValueSafeRecordModel):
+    """The atomic acknowledgement Milhouse owns for one outbox producer/file (plan section 4.9).
+
+    ``producer_id`` plus ``file_device``/``file_inode`` fix the identity of the acknowledged file,
+    ``committed_offset`` is the byte length Milhouse has durably committed, ``content_sha256`` is
+    the SHA-256 over that whole ``[0, committed_offset)`` prefix (the same anchor the cursor
+    carries), ``last_line_sha256`` is the digest of the last committed line (the "last record hash",
+    ``None`` for an empty commit), and ``acknowledged_at`` is the commit time.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        strict=True,
+        frozen=True,
+        hide_input_in_errors=True,
+        revalidate_instances="always",
+        validate_default=True,
+    )
+
+    schema_version: Literal["1.0"] = "1.0"
+    producer_id: MachineIdV1
+    file_device: int
+    file_inode: int
+    committed_offset: int
+    content_sha256: Sha256HexV1
+    last_line_sha256: Sha256HexV1 | None = None
+    acknowledged_at: UtcTimestampV1
+
+
+def outbox_ack_bytes(ack: OutboxAckV1) -> bytes:
+    """Project one ack to its bounded canonical JSON bytes (no trailing line feed)."""
+
+    if not isinstance(ack, OutboxAckV1):
+        raise OutboxError("MH_OUTBOX_ACK", "an outbox ack is required")
+    failed = False
+    content = b""
+    try:
+        content = canonical_json_bytes(
+            ack.model_dump(mode="python", exclude_none=True), max_bytes=MAX_ACK_BYTES
+        )
+    except CanonicalizationError:
+        failed = True
+    if failed:
+        raise OutboxError("MH_OUTBOX_ACK", "the outbox ack exceeds its canonical byte bound")
+    return content
+
+
+def _require_platform() -> None:
+    if (
+        getattr(os, "O_NOFOLLOW", 0) == 0
+    ):  # pragma: no cover - Milhouse supports only no-follow hosts
+        raise OutboxError(
+            "MH_OUTBOX_ACK_UNSUPPORTED", "safe outbox ack file operations are unavailable"
+        )
+
+
+def _ack_path(directory: str | Path, filename: str) -> Path:
+    if (
+        type(filename) is not str
+        or _ACK_FILENAME.fullmatch(filename) is None
+        or filename in {".", ".."}
+    ):
+        raise OutboxError("MH_OUTBOX_ACK_PATH", "a safe single-component ack filename is required")
+    failed = False
+    resolved: Path | None = None
+    try:
+        base = lexical_absolute_path(directory)
+        resolved = lexical_absolute_path(base / filename)
+    except Exception:
+        failed = True
+    if failed or resolved is None or resolved.parent != lexical_absolute_path(directory):
+        # The joined leaf must stay directly inside the configured .milhouse dir: no traversal.
+        raise OutboxError(
+            "MH_OUTBOX_ACK_PATH", "the ack path must resolve inside the repo .milhouse directory"
+        )
+    return resolved
+
+
+def _current_uid() -> int:
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:  # pragma: no cover - Milhouse supports only POSIX hosts
+        raise OutboxError(
+            "MH_OUTBOX_ACK_UNSUPPORTED", "the outbox ack requires a POSIX ownership model"
+        )
+    return int(geteuid())
+
+
+def write_outbox_ack(directory: str | Path, filename: str, ack: OutboxAckV1) -> None:
+    """Atomically publish ``ack`` as ``<directory>/<filename>`` at ``0600``, then fsync the dir.
+
+    The bytes are staged with the secure no-follow primitive (which validates the whole directory
+    chain, creates ``O_EXCL`` at ``0600``, writes, fsyncs, and reads the content back), then
+    ``os.replace``-d onto the final name and the parent directory is fsynced. A pre-existing ack --
+    or even a symlink planted at the final name -- is atomically replaced, never followed. Any
+    failure raises a fixed ``MH_OUTBOX_ACK*`` code and best-effort removes the staged artifact.
+    """
+
+    _require_platform()
+    if not isinstance(ack, OutboxAckV1):
+        raise OutboxError("MH_OUTBOX_ACK", "an outbox ack is required")
+    ack_path = _ack_path(directory, filename)
+    content = outbox_ack_bytes(ack)
+    staged_path = ack_path.parent / f".{filename}.{secrets.token_hex(16)}.tmp"
+
+    try:
+        create_regular_file_no_follow(
+            staged_path, content, mode=_ACK_MODE, require_private_parent=True
+        )
+    except SecureFileError as error:
+        raise _write_error(error) from None
+    except OutboxError:
+        raise
+    except Exception:
+        raise OutboxError(
+            "MH_OUTBOX_ACK_WRITE", "the outbox ack could not be safely staged"
+        ) from None
+
+    replaced = False
+    try:
+        os.replace(os.fspath(staged_path), os.fspath(ack_path))
+        replaced = True
+        sync_parent_directory_no_follow(ack_path, require_private_parent=True)
+    except SecureFileError:
+        # The replace already landed; only the durability fsync failed -> commit-uncertain.
+        raise OutboxError(
+            "MH_OUTBOX_ACK_COMMIT_UNCERTAIN", "the outbox ack durability is unconfirmed"
+        ) from None
+    except OSError:
+        if not replaced:
+            _best_effort_unlink(staged_path)
+            raise OutboxError(
+                "MH_OUTBOX_ACK_WRITE", "the outbox ack could not be atomically published"
+            ) from None
+        raise OutboxError(
+            "MH_OUTBOX_ACK_COMMIT_UNCERTAIN", "the outbox ack durability is unconfirmed"
+        ) from None
+
+
+def read_outbox_ack(directory: str | Path, filename: str) -> OutboxAckV1 | None:
+    """Read and validate a prior ack, or ``None`` when the file does not exist.
+
+    The file is opened no-follow (a symlinked leaf or ancestor fails closed) and must be an
+    owner-only, ``0600``, single-link, ACL-safe regular file; its snapshot is re-checked after the
+    bounded read to reject a mid-read swap. The bytes are parsed defensively into
+    :class:`OutboxAckV1` -- a value-safe model, so a corrupt or foreign object fails with a fixed
+    code that carries none of its content. A present-but-unsafe or malformed ack RAISES; only
+    genuine absence returns ``None``.
+    """
+
+    _require_platform()
+    ack_path = _ack_path(directory, filename)
+    opened = None
+    try:
+        opened = open_regular_file_no_follow(ack_path, require_private_parent=True)
+    except SecureFileError as error:
+        if error.kind is SecureFileErrorKind.NOT_FOUND:
+            return None
+        raise _read_error(error) from None
+
+    descriptor = opened.descriptor
+    failure: OutboxError | None = None
+    raw = b""
+    try:
+        before = os.fstat(descriptor)
+        _require_ack_file(before)
+        if before.st_size > MAX_ACK_BYTES:
+            raise OutboxError("MH_OUTBOX_ACK_SIZE", "the outbox ack exceeds its byte bound")
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, MAX_ACK_BYTES + 1)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        raw = b"".join(chunks)
+        after = os.fstat(descriptor)
+        _require_ack_file(after)
+        if (before.st_dev, before.st_ino, before.st_size) != (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+        ):
+            raise OutboxError("MH_OUTBOX_ACK_CHANGED", "the outbox ack changed while it was read")
+    except OutboxError as error:
+        failure = error
+    except OSError:
+        failure = OutboxError("MH_OUTBOX_ACK_READ", "the outbox ack could not be read")
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError:  # pragma: no cover - defensive close failure
+            failure = failure or OutboxError(
+                "MH_OUTBOX_ACK_READ", "the outbox ack could not be read"
+            )
+    if failure is not None:
+        raise failure
+    return _parse_ack(raw)
+
+
+def _require_ack_file(metadata: os.stat_result) -> None:
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != _current_uid()
+        or stat.S_IMODE(metadata.st_mode) != _ACK_MODE
+        or metadata.st_nlink != 1
+    ):
+        raise OutboxError(
+            "MH_OUTBOX_ACK_UNSAFE", "the outbox ack must be an owner-only single-link 0600 file"
+        )
+
+
+def _parse_ack(raw: bytes) -> OutboxAckV1:
+    failed = False
+    value: object = None
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError, RecursionError):
+        failed = True
+    if failed or type(value) is not dict:
+        raise OutboxError("MH_OUTBOX_ACK", "the outbox ack must be a canonical JSON object")
+    if not frozenset(value).issubset(_ACK_KEYS):
+        raise OutboxError("MH_OUTBOX_ACK", "the outbox ack has unexpected fields")
+    ack: OutboxAckV1 | None = None
+    invalid = False
+    try:
+        ack = OutboxAckV1.model_validate_json(raw)
+    except Exception:
+        invalid = True
+    if invalid or ack is None:
+        raise OutboxError("MH_OUTBOX_ACK", "the outbox ack failed field validation")
+    if outbox_ack_bytes(ack) != raw:
+        raise OutboxError("MH_OUTBOX_ACK", "the outbox ack is not canonical")
+    return ack
+
+
+def _best_effort_unlink(path: Path) -> None:
+    try:
+        os.unlink(os.fspath(path))
+    except OSError:  # pragma: no cover - best-effort staged cleanup
+        pass
+
+
+def _write_error(error: SecureFileError) -> OutboxError:
+    mapping = {
+        SecureFileErrorKind.SECURITY_UNSUPPORTED: (
+            "MH_OUTBOX_ACK_UNSUPPORTED",
+            "safe outbox ack creation is unavailable",
+        ),
+        SecureFileErrorKind.NOT_FOUND: (
+            "MH_OUTBOX_ACK_PARENT_MISSING",
+            "the .milhouse directory does not exist",
+        ),
+        SecureFileErrorKind.NOT_REGULAR: (
+            "MH_OUTBOX_ACK_PATH",
+            "the outbox ack path is not a regular file",
+        ),
+        SecureFileErrorKind.COMMIT_UNCERTAIN: (
+            "MH_OUTBOX_ACK_COMMIT_UNCERTAIN",
+            "the outbox ack durability is unconfirmed",
+        ),
+        SecureFileErrorKind.ACCESS_CONTROL_UNSAFE: (
+            "MH_OUTBOX_ACK_UNSAFE",
+            "the outbox ack path has unsafe access control",
+        ),
+        SecureFileErrorKind.PARENT_UNSAFE: (
+            "MH_OUTBOX_ACK_UNSAFE",
+            "the .milhouse directory is unsafe",
+        ),
+    }
+    code, message = mapping.get(
+        error.kind, ("MH_OUTBOX_ACK_WRITE", "the outbox ack could not be safely written")
+    )
+    return OutboxError(code, message)
+
+
+def _read_error(error: SecureFileError) -> OutboxError:
+    mapping = {
+        SecureFileErrorKind.NOT_REGULAR: (
+            "MH_OUTBOX_ACK_UNSAFE",
+            "the outbox ack must be a regular non-symlink file",
+        ),
+        SecureFileErrorKind.SECURITY_UNSUPPORTED: (
+            "MH_OUTBOX_ACK_UNSUPPORTED",
+            "safe outbox ack loading is unavailable",
+        ),
+        SecureFileErrorKind.PARENT_UNSAFE: (
+            "MH_OUTBOX_ACK_UNSAFE",
+            "the .milhouse directory is unsafe",
+        ),
+        SecureFileErrorKind.ACCESS_CONTROL_UNSAFE: (
+            "MH_OUTBOX_ACK_UNSAFE",
+            "the outbox ack path has unsafe access control",
+        ),
+    }
+    code, message = mapping.get(
+        error.kind, ("MH_OUTBOX_ACK_READ", "the outbox ack could not be safely read")
+    )
+    return OutboxError(code, message)
+
+
+__all__ = [
+    "MAX_ACK_BYTES",
+    "OutboxAckV1",
+    "outbox_ack_bytes",
+    "read_outbox_ack",
+    "write_outbox_ack",
+]

--- a/src/milhouse/outbox/cursor.py
+++ b/src/milhouse/outbox/cursor.py
@@ -1,0 +1,156 @@
+"""The opaque outbox cursor position codec (W07, plan section 4.9).
+
+A source cursor's ``position`` (``_cursors.position``, see :mod:`milhouse.state.cursors`) is an
+opaque, source-defined, payload-free string. This module defines the outbox source's encoding of it:
+a small versioned, self-describing canonical-JSON object binding the consumed file's identity
+``(device, inode)``, the committed byte ``offset``, and ``content_sha256`` -- the SHA-256 over the
+ENTIRE consumed prefix ``[0, offset)`` of that exact file.
+
+Why that hash detects truncation and rewrite of already-consumed bytes: on every incremental read
+the reader re-hashes the live file's ``[0, offset)`` prefix and compares it to ``content_sha256``. A
+producer that truncated unacknowledged bytes shrinks the file below ``offset`` (caught by a size
+check); a producer that rewrote consumed bytes in place changes the prefix hash (caught here). Only
+an append that leaves ``[0, offset)`` byte-identical -- exactly what a compliant append-only
+producer does -- reproduces the hash, so any consumed-byte discontinuity is a fail-closed P1 loss
+signal rather than a silent resync. The string never carries a raw payload byte: only the integer
+identity/offset and a hex digest.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+from milhouse.core.canonical import (
+    MAX_CANONICAL_INT,
+    CanonicalizationError,
+    canonical_json_text,
+)
+from milhouse.outbox.errors import OutboxError
+from milhouse.state.cursors import SourceCursor
+
+#: The opaque position encoding version. Bumping it is how a future consumed-prefix hash mechanism
+#: is introduced without silently reinterpreting an existing durable position string.
+OUTBOX_POSITION_VERSION = 1
+#: A defensive ceiling for a decoded position string, far above the fixed-shape object it must hold.
+MAX_POSITION_BYTES = 512
+_SHA256_HEX = re.compile(r"[0-9a-f]{64}", flags=re.ASCII)
+#: The exact key set a v1 position object carries; any other set is refused.
+_POSITION_KEYS = frozenset({"dev", "inode", "offset", "sha256", "v"})
+
+
+@dataclass(frozen=True, slots=True)
+class OutboxPosition:
+    """The decoded outbox cursor position: the consumed file's identity, offset, and prefix hash.
+
+    ``device``/``inode`` identify the exact file the offset refers to (so a rotation or inode reuse
+    is detectable), ``offset`` is the byte length of the consumed, LF-terminated prefix, and
+    ``content_sha256`` is the SHA-256 over that whole ``[0, offset)`` prefix.
+    """
+
+    device: int
+    inode: int
+    offset: int
+    content_sha256: str
+
+    def __post_init__(self) -> None:
+        for value, subject in ((self.device, "device"), (self.inode, "inode")):
+            if type(value) is not int or not 0 <= value <= MAX_CANONICAL_INT:
+                raise OutboxError(
+                    "MH_OUTBOX_POSITION", f"a bounded non-negative {subject} is required"
+                )
+        if type(self.offset) is not int or not 0 <= self.offset <= MAX_CANONICAL_INT:
+            raise OutboxError("MH_OUTBOX_POSITION", "a bounded non-negative offset is required")
+        if (
+            type(self.content_sha256) is not str
+            or _SHA256_HEX.fullmatch(self.content_sha256) is None
+        ):
+            raise OutboxError(
+                "MH_OUTBOX_POSITION", "a lowercase hex sha-256 prefix digest is required"
+            )
+
+
+def encode_outbox_position(position: OutboxPosition) -> str:
+    """Encode a decoded position to its opaque, versioned, canonical ``_cursors.position`` value."""
+
+    if not isinstance(position, OutboxPosition):
+        raise OutboxError("MH_OUTBOX_POSITION", "an outbox position is required")
+    payload = {
+        "dev": position.device,
+        "inode": position.inode,
+        "offset": position.offset,
+        "sha256": position.content_sha256,
+        "v": OUTBOX_POSITION_VERSION,
+    }
+    failed = False
+    text = ""
+    try:
+        text = canonical_json_text(payload, max_bytes=MAX_POSITION_BYTES)
+    except CanonicalizationError:
+        failed = True
+    if failed:
+        raise OutboxError("MH_OUTBOX_POSITION", "the outbox position could not be encoded")
+    return text
+
+
+def decode_outbox_position(position: str) -> OutboxPosition:
+    """Decode an opaque ``_cursors.position`` string, failing closed on any malformed value.
+
+    Every structural violation -- an over-long string, non-UTF-8/non-object JSON, an unexpected key
+    set, a wrong version, a non-integer identity/offset, or a malformed digest -- raises a fixed
+    ``MH_OUTBOX_POSITION`` :class:`OutboxError`. The string is Milhouse-owned control metadata, but
+    it is parsed as defensively as untrusted input so a tampered SQLite row cannot resume at a fake
+    offset.
+    """
+
+    if (
+        type(position) is not str
+        or not position
+        or len(position.encode("utf-8")) > MAX_POSITION_BYTES
+    ):
+        raise OutboxError("MH_OUTBOX_POSITION", "a bounded outbox position string is required")
+    failed = False
+    value: object = None
+    try:
+        value = json.loads(position)
+    except (UnicodeDecodeError, ValueError, RecursionError):
+        failed = True
+    if failed or type(value) is not dict:
+        raise OutboxError("MH_OUTBOX_POSITION", "an outbox position must be a JSON object")
+    if frozenset(value) != _POSITION_KEYS or value.get("v") != OUTBOX_POSITION_VERSION:
+        raise OutboxError("MH_OUTBOX_POSITION", "an unsupported or malformed outbox position")
+    device, inode, offset, digest = value["dev"], value["inode"], value["offset"], value["sha256"]
+    # ``bool`` is an ``int`` subtype; reject it so a stray flag cannot pose as an offset/identity.
+    for candidate in (device, inode, offset):
+        if type(candidate) is not int:
+            raise OutboxError(
+                "MH_OUTBOX_POSITION", "outbox position identity and offset must be integers"
+            )
+    if type(digest) is not str:
+        raise OutboxError("MH_OUTBOX_POSITION", "the outbox position digest must be a string")
+    # OutboxPosition.__post_init__ enforces the numeric and digest bounds; canonicality is below.
+    decoded = OutboxPosition(device=device, inode=inode, offset=offset, content_sha256=digest)
+    if encode_outbox_position(decoded) != position:
+        # A non-canonical encoding (extra whitespace, reordered keys, redundant sign) is refused so
+        # exactly one byte string ever represents a given position.
+        raise OutboxError("MH_OUTBOX_POSITION", "the outbox position is not canonical")
+    return decoded
+
+
+def outbox_position_from_cursor(cursor: SourceCursor) -> OutboxPosition:
+    """Decode the outbox position carried by a source cursor's opaque ``position`` string."""
+
+    if not isinstance(cursor, SourceCursor):
+        raise OutboxError("MH_OUTBOX_POSITION", "a source cursor is required")
+    return decode_outbox_position(cursor.position)
+
+
+__all__ = [
+    "MAX_POSITION_BYTES",
+    "OUTBOX_POSITION_VERSION",
+    "OutboxPosition",
+    "decode_outbox_position",
+    "encode_outbox_position",
+    "outbox_position_from_cursor",
+]

--- a/src/milhouse/outbox/errors.py
+++ b/src/milhouse/outbox/errors.py
@@ -1,0 +1,15 @@
+"""Fixed, privacy-safe failures for the ``.milhouse`` outbox reader (W07, plan section 4.9).
+
+Every outbox failure is a stable ``MH_OUTBOX_*`` code raised outside any active exception handler,
+so no filesystem, JSON, or producer-supplied detail reaches the error's cause, context, args, or
+traceback. The stable codes -- and the privacy-safe counts, offsets, and hex digests carried by the
+reader's result -- are the only machine surface; a rejected line's raw bytes never appear anywhere.
+"""
+
+from __future__ import annotations
+
+from milhouse.core.errors import MilhouseValueError
+
+
+class OutboxError(MilhouseValueError):
+    """A stable, value-free outbox reader/ack failure carrying only a code and static message."""

--- a/src/milhouse/outbox/frame.py
+++ b/src/milhouse/outbox/frame.py
@@ -1,0 +1,123 @@
+"""The versioned, untrusted inbound outbox line envelope ``OutboxFrameV1`` (plan section 4.9:1079).
+
+An outbox line is UNTRUSTED producer input. ``OutboxFrameV1`` is the value-safe, strictly bounded
+model every complete line is parsed against: it enforces the declared ``schema_version`` range,
+every field length and count cap, an absolute canonical byte ceiling, and rejects unknown or extra
+fields. Like the canonical record models it inherits :class:`ValueSafeRecordModel`, so any failed
+validation raises a fixed, rejected-value-free error -- the offending bytes or values never reach
+the exception's message, args, cause, context, or traceback, and therefore never reach a log, a
+diagnostic, or the reader's result. It is deliberately a SEPARATE contract from the canonical
+``RecordDraftV1``: mapping a frame to a draft is a later increment, so this envelope can be
+versioned and bounded independently of the internal record wire.
+
+This module owns ONLY the typed envelope and its defensive line parser. It has no filesystem,
+cursor, or acknowledgement concern.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self
+
+from pydantic import AfterValidator, ConfigDict, Field, model_validator
+
+from milhouse.core.canonical import CanonicalizationError, canonical_json_bytes
+from milhouse.core.immutable import freeze_list
+from milhouse.domain._validation import ValueSafeRecordModel
+from milhouse.domain.identity import MachineIdV1, MachineNameV1
+from milhouse.domain.records import DimensionsV1, OpaqueIdV1, UtcTimestampV1
+from milhouse.outbox.errors import OutboxError
+
+#: Absolute structural ceiling for one frame's canonical projection. The reader additionally applies
+#: the configured, typically smaller, ``max_line_bytes`` bound to the RAW line before parsing; this
+#: model-level ceiling is a fail-closed backstop against structural amplification and equals the
+#: canonical record byte bound a frame can ever legally map onto.
+MAX_OUTBOX_FRAME_BYTES = 262_144
+#: The maximum number of producer-supplied evidence references one frame may carry.
+MAX_EVIDENCE_REFERENCES = 100
+
+#: The one accepted inbound outbox line actionability vocabulary (mirrors the feedback contract).
+OutboxActionabilityV1 = Literal["observe", "investigate", "agent_safe", "needs_approval"]
+
+EvidenceReferencesV1 = Annotated[
+    list[OpaqueIdV1],
+    Field(max_length=MAX_EVIDENCE_REFERENCES),
+    AfterValidator(freeze_list),
+]
+
+
+class OutboxFrameV1(ValueSafeRecordModel):
+    """One versioned, bounded outbox line: the untrusted inbound envelope of plan section 4.9.
+
+    ``schema_version`` is a closed ``"1.0"`` literal, so an unknown or future declared version is
+    rejected rather than parsed. ``producer_id`` is the stable, bounded producer identity;
+    ``target`` is the referenced bounded target id; ``kind`` names the observation kind;
+    ``actionability`` is a closed vocabulary; ``evidence_references`` is a count-bounded list of
+    opaque producer references; and ``data`` is a bounded structured mapping. Extra or unknown keys
+    are forbidden, and the whole canonical projection is bounded by :data:`MAX_OUTBOX_FRAME_BYTES`.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        strict=True,
+        frozen=True,
+        hide_input_in_errors=True,
+        revalidate_instances="always",
+        validate_default=True,
+    )
+
+    schema_version: Literal["1.0"] = "1.0"
+    producer_id: MachineIdV1
+    occurred_at: UtcTimestampV1
+    target: MachineIdV1
+    kind: MachineNameV1
+    actionability: OutboxActionabilityV1
+    evidence_references: EvidenceReferencesV1 = Field(default_factory=list)
+    data: DimensionsV1 = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_bounds(self) -> Self:
+        try:
+            canonical_json_bytes(
+                self.model_dump(mode="python", exclude_none=True),
+                max_bytes=MAX_OUTBOX_FRAME_BYTES,
+            )
+        except CanonicalizationError as error:
+            raise ValueError("outbox frame is outside the canonical frame bounds") from error
+        return self
+
+
+def parse_outbox_frame_line(line: bytes) -> OutboxFrameV1:
+    """Parse one complete outbox line into a validated :class:`OutboxFrameV1`, or fail value-free.
+
+    ``line`` is UNTRUSTED producer bytes (the caller has already applied the ``max_line_bytes`` raw
+    bound and stripped the trailing line feed). Parsing runs through pydantic's JSON path so
+    canonical RFC3339 timestamp strings decode exactly as written, and the value-safe model
+    guarantees a malformed value never reaches the raised error. Any failure -- non-UTF-8,
+    non-object JSON, an unknown field, a bound violation, or a bad discriminator -- raises a fixed
+    ``MH_OUTBOX_FRAME`` :class:`OutboxError` with NO offending bytes attached, so a caller can count
+    the rejection without ever persisting, logging, or echoing the raw line.
+    """
+
+    if type(line) is not bytes:
+        raise OutboxError("MH_OUTBOX_FRAME", "an outbox line must be raw bytes")
+    failed = False
+    frame: OutboxFrameV1 | None = None
+    try:
+        frame = OutboxFrameV1.model_validate_json(line)
+    except Exception:
+        # The value-safe model already detaches every rejected value; discarding the exception
+        # entirely (never binding it, never re-raising from it) is belt-and-suspenders so not even a
+        # fixed pydantic message or a __context__ chain can carry a byte outward.
+        failed = True
+    if failed or frame is None:
+        raise OutboxError("MH_OUTBOX_FRAME", "an outbox line is not a valid v1 frame")
+    return frame
+
+
+__all__ = [
+    "MAX_EVIDENCE_REFERENCES",
+    "MAX_OUTBOX_FRAME_BYTES",
+    "OutboxActionabilityV1",
+    "OutboxFrameV1",
+    "parse_outbox_frame_line",
+]

--- a/src/milhouse/outbox/reader.py
+++ b/src/milhouse/outbox/reader.py
@@ -1,0 +1,569 @@
+"""The pure, offline-testable ``.milhouse`` outbox reader (W07 increment 1, plan section 4.9).
+
+Given a file path, a prior cursor (or ``None``), and a bounded configuration, :func:`read_outbox`
+returns the new frames since the cursor, the next cursor position, an optional P1 data-loss signal,
+and privacy-safe diagnostics. It is a PURE primitive: it opens the outbox no-follow and reads it,
+but it NEVER writes, never truncates or rotates the producer's file, never persists a cursor, and
+never maps a frame to a canonical record -- those belong to later increments. It mirrors the
+``local_log`` reader's fail-closed discipline (ADR 0016 / plan section 4.15): a torn, non-LF-
+terminated tail of the ACTIVE file is left unconsumed for the next read, while any discontinuity in
+already-consumed bytes fails closed.
+
+Guarantees:
+
+* **Unchanged input yields zero new frames.** Re-reading the same file at the same offset with a
+  byte-identical consumed prefix advances nothing.
+* **Append yields only new complete lines.** Only LF-terminated lines past the cursor are parsed.
+* **Compliant rotation recovers without loss or duplication.** When the active inode differs from
+  the cursor's, retained rotated files are discovered by their parsed INTEGER sequence (numeric
+  order, not lexical), the cursor's file is read from its offset to EOF, the contiguous rotations
+  above it are read whole, and reading continues into the new active file -- all in one call.
+* **Truncation or removal of unacknowledged bytes is a P1 loss.** A file shorter than the cursor
+  offset, a rewritten consumed prefix (hash mismatch), a gap in the rotated sequence above the
+  cursor (a dropped intermediate segment), an unparseable or duplicate rotated name, a crossed
+  rotated file with a torn tail, or a changed active inode with no way to locate the cursor's file
+  all produce an explicit ``MH_OUTBOX_LOSS_*`` signal and advance nothing -- Milhouse cannot claim
+  recovery of deleted bytes.
+* **Invalid or oversized lines are rejected without raw persistence.** A line over
+  ``max_line_bytes``, or one that fails :class:`OutboxFrameV1` validation, or one from a
+  non-allowlisted producer, is skipped and counted by a FIXED code; its raw bytes never enter a
+  frame, a diagnostic, a loss signal, or an exception. Skip-and-count keeps one bad line from
+  blocking the valid lines around it while still advancing the cursor past it exactly once.
+
+Every hard failure is a fixed ``MH_OUTBOX_*`` :class:`OutboxError`; every diagnostic and loss field
+is an integer, a hex digest, or a fixed code -- never a producer byte.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Literal
+
+from milhouse.config.filesystem import (
+    SecureFileError,
+    SecureFileErrorKind,
+    lexical_absolute_path,
+    open_regular_file_no_follow,
+)
+from milhouse.core.canonical import MAX_CANONICAL_INT
+from milhouse.outbox.cursor import (
+    OutboxPosition,
+    encode_outbox_position,
+    outbox_position_from_cursor,
+)
+from milhouse.outbox.errors import OutboxError
+from milhouse.outbox.frame import OutboxFrameV1, parse_outbox_frame_line
+from milhouse.state.cursors import SourceCursor
+
+_LF = b"\n"
+
+_LINE_OVERSIZE_CODE = "MH_OUTBOX_LINE_OVERSIZE"
+_PRODUCER_DENIED_CODE = "MH_OUTBOX_PRODUCER_DENIED"
+
+#: A valid ``rotation_glob``: safe filename literals around EXACTLY one ``*`` sequence wildcard.
+_ROTATION_GLOB = re.compile(r"[A-Za-z0-9._-]*\*[A-Za-z0-9._-]*", flags=re.ASCII)
+
+
+@dataclass(frozen=True, slots=True)
+class OutboxReaderConfig:
+    """The bounded knobs the reader needs (a subset of the ``file_outbox`` collector config).
+
+    ``rotation_glob`` is a single-component filename glob resolved against the outbox's own
+    directory; it is required to discover retained rotations. ``producer_allowlist`` -- when
+    non-empty -- rejects any frame whose ``producer_id`` is not listed.
+    """
+
+    max_line_bytes: int = 65_536
+    max_file_bytes: int = 104_857_600
+    rotation_glob: str | None = None
+    producer_allowlist: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for value, subject in (
+            (self.max_line_bytes, "max_line_bytes"),
+            (self.max_file_bytes, "max_file_bytes"),
+        ):
+            if type(value) is not int or not 0 < value <= MAX_CANONICAL_INT:
+                raise OutboxError("MH_OUTBOX_CONFIG", f"a bounded positive {subject} is required")
+        if self.max_line_bytes > self.max_file_bytes:
+            raise OutboxError("MH_OUTBOX_CONFIG", "max_line_bytes must not exceed max_file_bytes")
+        if self.rotation_glob is not None:
+            if (
+                type(self.rotation_glob) is not str
+                or not self.rotation_glob
+                or len(self.rotation_glob) > 255
+            ):
+                raise OutboxError("MH_OUTBOX_CONFIG", "a bounded rotation glob is required")
+            # Exactly one ``*`` -- the monotonic integer sequence wildcard -- surrounded by literal
+            # safe filename characters, so Path.glob matching and the sequence-parsing regex derived
+            # from the same glob agree byte-for-byte and no second metacharacter can escape.
+            if _ROTATION_GLOB.fullmatch(self.rotation_glob) is None:
+                raise OutboxError(
+                    "MH_OUTBOX_CONFIG",
+                    "the rotation glob must be a single filename component with one '*' sequence "
+                    "wildcard",
+                )
+        if type(self.producer_allowlist) is not tuple or any(
+            type(entry) is not str for entry in self.producer_allowlist
+        ):
+            raise OutboxError(
+                "MH_OUTBOX_CONFIG", "the producer allowlist must be a tuple of strings"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class OutboxLossSignal:
+    """A privacy-safe P1 data-loss signal: fixed code plus offsets, sizes, and hex digests only."""
+
+    code: str
+    cursor_device: int
+    cursor_inode: int
+    cursor_offset: int
+    cursor_sha256: str
+    observed_size: int | None = None
+    observed_sha256: str | None = None
+    priority: Literal["P1"] = "P1"
+
+
+@dataclass(frozen=True, slots=True)
+class OutboxDiagnostics:
+    """Privacy-safe read diagnostics: only counts, codes, and byte totals -- never a payload."""
+
+    frames_emitted: int
+    rejected_lines: int
+    rejected_codes: Mapping[str, int]
+    bytes_consumed: int
+    rotations_crossed: int
+    torn_tail_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class OutboxReadResult:
+    """The outcome of one incremental read.
+
+    On success ``next_position`` is the advanced cursor (encoded in ``next_position_string`` for the
+    later durable ``advance_cursor`` write) and ``loss_signal`` is ``None``. On a data-loss find
+    ``loss_signal`` is set, ``new_frames`` is empty, and ``next_position``/``next_position_string``
+    equal the prior cursor unchanged -- the caller must raise the P1 alert and NOT advance.
+    """
+
+    new_frames: tuple[OutboxFrameV1, ...]
+    next_position: OutboxPosition | None
+    next_position_string: str | None
+    loss_signal: OutboxLossSignal | None
+    diagnostics: OutboxDiagnostics
+
+
+@dataclass(frozen=True, slots=True)
+class _FileRead:
+    device: int
+    inode: int
+    content: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _Parsed:
+    frames: list[OutboxFrameV1] = field(default_factory=list)
+    rejected: Counter[str] = field(default_factory=Counter)
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _has_torn_tail(content: bytes) -> bool:
+    return content != b"" and not content.endswith(_LF)
+
+
+def _read_regular_file(path: str | Path, max_file_bytes: int) -> _FileRead:
+    """Open ``path`` no-follow and read it whole under ``max_file_bytes``; fail closed value-free.
+
+    The active outbox may be appended concurrently, so the identity (device, inode) is required to
+    stay stable across the read but the size is allowed to grow; the returned content is the exact
+    bytes read to end-of-file, from which the reader derives its own complete-line boundary.
+    """
+
+    try:
+        opened = open_regular_file_no_follow(path)
+    except SecureFileError as error:
+        raise _open_error(error) from None
+
+    descriptor = opened.descriptor
+    device = opened.snapshot.device
+    inode = opened.snapshot.inode
+    failure: OutboxError | None = None
+    chunks: list[bytes] = []
+    total = 0
+    try:
+        if opened.snapshot.size > max_file_bytes:
+            raise OutboxError("MH_OUTBOX_FILE_OVERSIZE", "the outbox file exceeds its byte bound")
+        while True:
+            chunk = os.read(descriptor, 1 << 20)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > max_file_bytes:
+                raise OutboxError(
+                    "MH_OUTBOX_FILE_OVERSIZE", "the outbox file exceeds its byte bound"
+                )
+        after = os.fstat(descriptor)
+        if (after.st_dev, after.st_ino) != (device, inode):
+            raise OutboxError("MH_OUTBOX_READ", "the outbox file identity changed during the read")
+    except OutboxError as error:
+        failure = error
+    except OSError:
+        failure = OutboxError("MH_OUTBOX_READ", "the outbox file could not be read")
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError:  # pragma: no cover - defensive close failure
+            failure = failure or OutboxError("MH_OUTBOX_READ", "the outbox file could not be read")
+    if failure is not None:
+        raise failure
+    return _FileRead(device=device, inode=inode, content=b"".join(chunks))
+
+
+def _open_error(error: SecureFileError) -> OutboxError:
+    if error.kind is SecureFileErrorKind.NOT_FOUND:
+        return OutboxError("MH_OUTBOX_NOT_FOUND", "the outbox file does not exist")
+    if error.kind is SecureFileErrorKind.NOT_REGULAR:
+        return OutboxError(
+            "MH_OUTBOX_NOT_REGULAR", "the outbox file must be a regular non-symlink file"
+        )
+    if error.kind is SecureFileErrorKind.SECURITY_UNSUPPORTED:
+        return OutboxError("MH_OUTBOX_UNSUPPORTED", "safe outbox file access is unavailable")
+    return OutboxError("MH_OUTBOX_READ", "the outbox file could not be opened")
+
+
+def _iter_complete_lines(region: bytes) -> list[bytes]:
+    """Split an all-complete (LF-terminated or empty) region into its lines, each keeping its LF."""
+
+    if not region:
+        return []
+    parts = region.split(_LF)[:-1]
+    return [part + _LF for part in parts]
+
+
+def _parse_region(region: bytes, config: OutboxReaderConfig, into: _Parsed) -> None:
+    """Parse every complete line in ``region``, rejecting oversized/invalid/denied lines by code.
+
+    A rejected line's raw bytes are never captured: the oversize branch never parses, and the parse
+    branch discards the value-safe :class:`OutboxError` after reading only its fixed ``.code``.
+    """
+
+    allowlist = config.producer_allowlist
+    for line in _iter_complete_lines(region):
+        if len(line) > config.max_line_bytes:
+            into.rejected[_LINE_OVERSIZE_CODE] += 1
+            continue
+        payload = line[:-1] if line.endswith(_LF) else line
+        try:
+            frame = parse_outbox_frame_line(payload)
+        except OutboxError as error:
+            into.rejected[error.code] += 1
+            continue
+        if allowlist and frame.producer_id not in allowlist:
+            into.rejected[_PRODUCER_DENIED_CODE] += 1
+            continue
+        into.frames.append(frame)
+
+
+def _loss(
+    code: str,
+    prior: OutboxPosition,
+    prior_string: str,
+    *,
+    observed_size: int | None = None,
+    observed_sha256: str | None = None,
+) -> OutboxReadResult:
+    signal = OutboxLossSignal(
+        code=code,
+        cursor_device=prior.device,
+        cursor_inode=prior.inode,
+        cursor_offset=prior.offset,
+        cursor_sha256=prior.content_sha256,
+        observed_size=observed_size,
+        observed_sha256=observed_sha256,
+    )
+    diagnostics = OutboxDiagnostics(
+        frames_emitted=0,
+        rejected_lines=0,
+        rejected_codes=MappingProxyType({}),
+        bytes_consumed=0,
+        rotations_crossed=0,
+        torn_tail_bytes=0,
+    )
+    return OutboxReadResult(
+        new_frames=(),
+        next_position=prior,
+        next_position_string=prior_string,
+        loss_signal=signal,
+        diagnostics=diagnostics,
+    )
+
+
+def _success(
+    frames: list[OutboxFrameV1],
+    rejected: Counter[str],
+    *,
+    next_position: OutboxPosition,
+    bytes_consumed: int,
+    rotations_crossed: int,
+    torn_tail_bytes: int,
+) -> OutboxReadResult:
+    diagnostics = OutboxDiagnostics(
+        frames_emitted=len(frames),
+        rejected_lines=sum(rejected.values()),
+        rejected_codes=MappingProxyType(dict(rejected)),
+        bytes_consumed=bytes_consumed,
+        rotations_crossed=rotations_crossed,
+        torn_tail_bytes=torn_tail_bytes,
+    )
+    return OutboxReadResult(
+        new_frames=tuple(frames),
+        next_position=next_position,
+        next_position_string=encode_outbox_position(next_position),
+        loss_signal=None,
+        diagnostics=diagnostics,
+    )
+
+
+def read_outbox(
+    *,
+    file_path: str | Path,
+    prior_cursor: SourceCursor | None,
+    config: OutboxReaderConfig,
+) -> OutboxReadResult:
+    """Incrementally read the outbox from ``prior_cursor``; see the module docstring for details."""
+
+    if not isinstance(config, OutboxReaderConfig):
+        raise OutboxError("MH_OUTBOX_CONFIG", "an outbox reader configuration is required")
+    if prior_cursor is not None and not isinstance(prior_cursor, SourceCursor):
+        raise OutboxError("MH_OUTBOX_CURSOR", "a source cursor or None is required")
+
+    prior = outbox_position_from_cursor(prior_cursor) if prior_cursor is not None else None
+    prior_string = prior_cursor.position if prior_cursor is not None else None
+    active = _read_regular_file(file_path, config.max_file_bytes)
+
+    if prior is None or (active.device, active.inode) == (prior.device, prior.inode):
+        return _read_same_file(active, prior, config)
+    assert prior_string is not None
+    return _recover_rotation(file_path, active, prior, prior_string, config)
+
+
+def _read_same_file(
+    active: _FileRead, prior: OutboxPosition | None, config: OutboxReaderConfig
+) -> OutboxReadResult:
+    content = active.content
+    start = 0
+    if prior is not None:
+        prior_string = encode_outbox_position(prior)
+        if len(content) < prior.offset:
+            return _loss(
+                "MH_OUTBOX_LOSS_TRUNCATED", prior, prior_string, observed_size=len(content)
+            )
+        prefix_hash = _sha256_hex(content[: prior.offset])
+        if prefix_hash != prior.content_sha256:
+            return _loss(
+                "MH_OUTBOX_LOSS_REWRITE",
+                prior,
+                prior_string,
+                observed_size=len(content),
+                observed_sha256=prefix_hash,
+            )
+        start = prior.offset
+
+    complete_end = content.rfind(_LF) + 1  # 0 when the file holds no complete line
+    if complete_end < start:  # pragma: no cover - start is always a prior LF boundary
+        complete_end = start
+    region = content[start:complete_end]
+    parsed = _Parsed()
+    _parse_region(region, config, parsed)
+    next_position = OutboxPosition(
+        device=active.device,
+        inode=active.inode,
+        offset=complete_end,
+        content_sha256=_sha256_hex(content[:complete_end]),
+    )
+    return _success(
+        parsed.frames,
+        parsed.rejected,
+        next_position=next_position,
+        bytes_consumed=complete_end - start,
+        rotations_crossed=0,
+        torn_tail_bytes=len(content) - complete_end,
+    )
+
+
+def _recover_rotation(
+    file_path: str | Path,
+    active: _FileRead,
+    prior: OutboxPosition,
+    prior_string: str,
+    config: OutboxReaderConfig,
+) -> OutboxReadResult:
+    """Recover across a rotation, requiring a parseable, CONTIGUOUS rotated sequence (no gaps).
+
+    Producer naming contract this enforces: each retained rotated file is named by the configured
+    ``rotation_glob`` with its ``*`` wildcard a parseable, monotonic, CONTIGUOUS integer sequence;
+    the active file is that sequence's live successor. The reader parses the integer (not a lexical
+    key), orders numerically, finds the cursor's file by identity at sequence S, and requires the
+    retained rotations above S to be exactly ``{S+1, S+2, ..., S+k}`` before continuing into the
+    active file. ANY gap -- a missing intermediate sequence -- is un-recoverable P1 data loss
+    (``MH_OUTBOX_LOSS_ROTATION_GONE``): a single-file cursor cannot re-materialize deleted bytes.
+
+    Residual limitation (documented, not a silent skip): the active file carries no sequence in its
+    name, so the reader treats the highest retained rotation as the active file's immediate
+    predecessor. Deletion of ANY RUN of the TOPMOST rotated segments -- the most-recent ones next
+    to the active file, with nothing retained above the survivors -- therefore leaves the retained
+    set a contiguous run that passes the gap check, and the missing top segments are
+    indistinguishable from "there were no further rotations". A stateless single-file cursor cannot
+    detect this: it keeps no record of the highest sequence ever seen. Requiring a contiguous
+    sequence makes every gap BELOW the highest survivor a detected loss; the top-run case is closed
+    in increment 2 by the durable ack persisting the last committed sequence (so the reader can tell
+    the current top is below what it already acknowledged).
+    """
+
+    if config.rotation_glob is None:
+        # A different active inode with no way to discover retained rotations: never blindly resume
+        # at the old offset in a different file.
+        return _loss("MH_OUTBOX_LOSS_INODE_REUSE", prior, prior_string)
+
+    directory = lexical_absolute_path(file_path).parent
+    by_sequence, discovery_loss = _discover_rotations(directory, active, config)
+    if discovery_loss is not None:
+        return _loss(discovery_loss, prior, prior_string)
+
+    cursor_sequence = next(
+        (
+            sequence
+            for sequence, read in by_sequence.items()
+            if (read.device, read.inode) == (prior.device, prior.inode)
+        ),
+        None,
+    )
+    if cursor_sequence is None:
+        # The file the cursor was consuming is not among the retained, parseable rotations: its
+        # unacknowledged bytes are gone and cannot be recovered.
+        return _loss("MH_OUTBOX_LOSS_ROTATION_GONE", prior, prior_string)
+
+    # The retained rotations strictly above the cursor MUST be the contiguous run
+    # {S+1, S+2, ..., S+k}; any gap is a dropped unconsumed segment we cannot recover.
+    above = sorted(sequence for sequence in by_sequence if sequence > cursor_sequence)
+    if above != list(range(cursor_sequence + 1, cursor_sequence + 1 + len(above))):
+        return _loss("MH_OUTBOX_LOSS_ROTATION_GONE", prior, prior_string)
+
+    # Phase A: validate the whole chain BEFORE emitting anything, so any loss yields zero frames.
+    cursor_file = by_sequence[cursor_sequence]
+    if len(cursor_file.content) < prior.offset:
+        return _loss(
+            "MH_OUTBOX_LOSS_TRUNCATED", prior, prior_string, observed_size=len(cursor_file.content)
+        )
+    prefix_hash = _sha256_hex(cursor_file.content[: prior.offset])
+    if prefix_hash != prior.content_sha256:
+        return _loss(
+            "MH_OUTBOX_LOSS_REWRITE",
+            prior,
+            prior_string,
+            observed_size=len(cursor_file.content),
+            observed_sha256=prefix_hash,
+        )
+    if _has_torn_tail(cursor_file.content):
+        return _loss(
+            "MH_OUTBOX_LOSS_ROTATED_TORN",
+            prior,
+            prior_string,
+            observed_size=len(cursor_file.content),
+        )
+
+    regions: list[bytes] = [cursor_file.content[prior.offset :]]
+    bytes_consumed = len(regions[0])
+    for sequence in above:
+        read = by_sequence[sequence]
+        if _has_torn_tail(read.content):
+            return _loss(
+                "MH_OUTBOX_LOSS_ROTATED_TORN", prior, prior_string, observed_size=len(read.content)
+            )
+        regions.append(read.content)
+        bytes_consumed += len(read.content)
+
+    complete_end = active.content.rfind(_LF) + 1
+    active_region = active.content[:complete_end]
+    regions.append(active_region)
+    bytes_consumed += complete_end
+
+    # Phase B: parse every region now that the chain is proven continuous.
+    parsed = _Parsed()
+    for region in regions:
+        _parse_region(region, config, parsed)
+
+    next_position = OutboxPosition(
+        device=active.device,
+        inode=active.inode,
+        offset=complete_end,
+        content_sha256=_sha256_hex(active.content[:complete_end]),
+    )
+    return _success(
+        parsed.frames,
+        parsed.rejected,
+        next_position=next_position,
+        bytes_consumed=bytes_consumed,
+        rotations_crossed=1 + len(above),
+        torn_tail_bytes=len(active.content) - complete_end,
+    )
+
+
+def _discover_rotations(
+    directory: Path, active: _FileRead, config: OutboxReaderConfig
+) -> tuple[dict[int, _FileRead], str | None]:
+    """Read retained rotated files keyed by their parsed integer sequence; fail closed on ambiguity.
+
+    Each rotated filename is matched against a regex derived from the SAME ``rotation_glob``, with
+    the single ``*`` wildcard bound to a run of ASCII digits, and the captured integer is the
+    segment's monotonic sequence -- so ordering is numeric, not lexical (``...9`` before ``...10``).
+    A match whose wildcard is not a pure integer run (``MH_OUTBOX_LOSS_ROTATION_UNPARSEABLE``), or
+    two retained files parsing to the SAME sequence (``MH_OUTBOX_LOSS_ROTATION_AMBIGUOUS``), fail
+    closed with a returned loss code, not a silent skip. The active file's identity (and any link to
+    it) is excluded so a glob that also matches the active name cannot double-count a segment. Each
+    file is opened no-follow and read whole under the size bound.
+
+    Returns ``(sequence -> file, None)`` on success, or ``({}, loss_code)`` on a fail-closed skip.
+    """
+
+    assert config.rotation_glob is not None
+    prefix, suffix = config.rotation_glob.split("*", 1)
+    pattern = re.compile(
+        "^" + re.escape(prefix) + r"(\d+)" + re.escape(suffix) + "$", flags=re.ASCII
+    )
+    by_sequence: dict[int, _FileRead] = {}
+    for candidate in sorted(
+        Path(directory).glob(config.rotation_glob), key=lambda entry: entry.name
+    ):
+        match = pattern.fullmatch(candidate.name)
+        if match is None:
+            return {}, "MH_OUTBOX_LOSS_ROTATION_UNPARSEABLE"
+        read = _read_regular_file(candidate, config.max_file_bytes)
+        if (read.device, read.inode) == (active.device, active.inode):
+            continue  # the glob also matched the active file (or a hard link to it): not a rotation
+        sequence = int(match.group(1))
+        if sequence in by_sequence:
+            return {}, "MH_OUTBOX_LOSS_ROTATION_AMBIGUOUS"
+        by_sequence[sequence] = read
+    return by_sequence, None
+
+
+__all__ = [
+    "OutboxDiagnostics",
+    "OutboxLossSignal",
+    "OutboxReadResult",
+    "OutboxReaderConfig",
+    "read_outbox",
+]

--- a/tests/unit/test_outbox_reader.py
+++ b/tests/unit/test_outbox_reader.py
@@ -1,0 +1,768 @@
+"""W07 increment 1: the ``.milhouse`` outbox reader spine fault matrix (plan section 4.9).
+
+These offline tests drive :func:`read_outbox`, the frame parser, the cursor codec, and the atomic
+ack read/writer against temp files, exercising every recovery/detection branch the gate requires:
+unchanged input, single/multi append, torn tails, malformed and oversized lines, compliant and
+multi-step rotation, and each data-loss discontinuity (truncation, consumed-prefix rewrite, a
+removed rotated file, a torn rotated file, and inode reuse). Privacy is asserted directly: a canary
+planted in a rejected line never appears in any frame, diagnostic, loss signal, or raised error.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import traceback
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from milhouse.outbox import (
+    MAX_OUTBOX_FRAME_BYTES,
+    OUTBOX_POSITION_VERSION,
+    OutboxAckV1,
+    OutboxFrameV1,
+    OutboxPosition,
+    OutboxReaderConfig,
+    decode_outbox_position,
+    encode_outbox_position,
+    outbox_ack_bytes,
+    parse_outbox_frame_line,
+    read_outbox,
+    read_outbox_ack,
+    write_outbox_ack,
+)
+from milhouse.outbox.errors import OutboxError
+from milhouse.state.cursors import SourceCursor
+
+_OUTBOX_NAME = "feedback-outbox.jsonl"
+_ROTATION_GLOB = "feedback-outbox.*.jsonl"
+_TS = "2026-08-17T12:00:00.000Z"
+
+
+# --- helpers ------------------------------------------------------------------------------------
+
+
+def _frame_document(**overrides: object) -> dict[str, object]:
+    document: dict[str, object] = {
+        "schema_version": "1.0",
+        "producer_id": "web-ci",
+        "occurred_at": _TS,
+        "target": "web-service",
+        "kind": "deploy.completed",
+        "actionability": "observe",
+        "evidence_references": ["ev-1"],
+        "data": {"count": 3},
+    }
+    document.update(overrides)
+    return document
+
+
+def _frame_line(**overrides: object) -> bytes:
+    return json.dumps(_frame_document(**overrides)).encode("utf-8") + b"\n"
+
+
+def _cursor(position: str) -> SourceCursor:
+    return SourceCursor(
+        source="outbox", position=position, batch_id=None, revision=0, updated_at=_TS
+    )
+
+
+def _write(path: Path, data: bytes) -> None:
+    path.write_bytes(data)
+
+
+def _append(path: Path, data: bytes) -> None:
+    with path.open("ab") as handle:
+        handle.write(data)
+
+
+def _outbox(tmp_path: Path, data: bytes = b"") -> Path:
+    path = tmp_path / _OUTBOX_NAME
+    _write(path, data)
+    return path
+
+
+def _cursor_for(path: Path, consumed: bytes) -> SourceCursor:
+    """Build a cursor that has consumed exactly ``consumed`` bytes from ``path``'s current inode."""
+
+    info = os.stat(path)
+    position = OutboxPosition(
+        device=info.st_dev,
+        inode=info.st_ino,
+        offset=len(consumed),
+        content_sha256=hashlib.sha256(consumed).hexdigest(),
+    )
+    return _cursor(encode_outbox_position(position))
+
+
+def _surfaces(*values: object) -> str:
+    return "\n".join(repr(value) for value in values)
+
+
+# --- OutboxFrameV1 ------------------------------------------------------------------------------
+
+
+def test_valid_frame_parses_with_bounded_fields() -> None:
+    frame = parse_outbox_frame_line(_frame_line(evidence_references=["ev-1", "ev-2"]))
+    assert type(frame) is OutboxFrameV1
+    assert frame.producer_id == "web-ci"
+    assert frame.kind == "deploy.completed"
+    assert frame.actionability == "observe"
+    assert list(frame.evidence_references) == ["ev-1", "ev-2"]
+    assert dict(frame.data) == {"count": 3}
+
+
+def test_frame_at_bounds_accepted_and_one_over_rejected() -> None:
+    max_producer = "p" + "0" * 63  # 64 chars: the MachineId ceiling
+    parse_outbox_frame_line(_frame_line(producer_id=max_producer))
+    with pytest.raises(OutboxError) as over:
+        parse_outbox_frame_line(_frame_line(producer_id="p" + "0" * 64))
+    assert over.value.code == "MH_OUTBOX_FRAME"
+
+    max_evidence = [f"ev-{index}" for index in range(100)]
+    parse_outbox_frame_line(_frame_line(evidence_references=max_evidence))
+    with pytest.raises(OutboxError):
+        parse_outbox_frame_line(_frame_line(evidence_references=[*max_evidence, "ev-100"]))
+
+
+def test_frame_ceiling_rejects_oversized_structured_data() -> None:
+    huge = "z" * (MAX_OUTBOX_FRAME_BYTES // 2)
+    with pytest.raises(OutboxError):
+        parse_outbox_frame_line(_frame_line(data={"blob": huge, "blob_two": huge}))
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        b'{"schema_version":"2.0","producer_id":"web-ci","occurred_at":"'
+        + _TS.encode()
+        + b'","target":"t","kind":"k","actionability":"observe"}',
+        b'{"producer_id":"web-ci","occurred_at":"'
+        + _TS.encode()
+        + b'","target":"t","kind":"k","actionability":"nope"}',
+        b'{"producer_id":"web-ci","occurred_at":"'
+        + _TS.encode()
+        + b'","target":"t","kind":"k","actionability":"observe","surprise":1}',
+        b"not json at all",
+        b"",
+        b"\xff\xfe not utf-8",
+    ],
+)
+def test_frame_rejects_malformed_input_with_fixed_code(line: bytes) -> None:
+    with pytest.raises(OutboxError) as raised:
+        parse_outbox_frame_line(line)
+    assert raised.value.code == "MH_OUTBOX_FRAME"
+
+
+def test_frame_parse_error_never_carries_raw_value() -> None:
+    canary = f"PRIVATE-{secrets.token_hex(12)}"
+    line = json.dumps({**_frame_document(), "secret_field": canary}).encode("utf-8")
+    with pytest.raises(OutboxError) as raised:
+        parse_outbox_frame_line(line)
+    error = raised.value
+    surfaces = (
+        str(error),
+        repr(error),
+        repr(error.args),
+        "".join(traceback.format_exception(error)),
+    )
+    assert all(canary not in surface for surface in surfaces)
+    assert error.__cause__ is None
+    assert error.__context__ is None
+
+
+# --- cursor codec -------------------------------------------------------------------------------
+
+
+def test_cursor_codec_round_trips_and_is_self_describing() -> None:
+    position = OutboxPosition(device=7, inode=99, offset=4096, content_sha256="a" * 64)
+    encoded = encode_outbox_position(position)
+    assert json.loads(encoded)["v"] == OUTBOX_POSITION_VERSION
+    assert decode_outbox_position(encoded) == position
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"v":2,"dev":1,"inode":1,"offset":0,"sha256":"' + "a" * 64 + '"}',  # wrong version
+        '{"v":1,"dev":1,"inode":1,"offset":0}',  # missing key
+        '{"v":1,"dev":1,"inode":1,"offset":0,"sha256":"a","extra":1}',  # extra key
+        '{"v":1,"dev":1,"inode":1,"offset":-1,"sha256":"' + "a" * 64 + '"}',  # negative offset
+        '{"v":1,"dev":1,"inode":1,"offset":0,"sha256":"nothex"}',  # bad digest
+        '{ "v":1, "dev":1, "inode":1, "offset":0, "sha256":"' + "a" * 64 + '" }',  # non-canonical
+        "not json",
+    ],
+)
+def test_cursor_codec_rejects_malformed_position(payload: str) -> None:
+    with pytest.raises(OutboxError) as raised:
+        decode_outbox_position(payload)
+    assert raised.value.code == "MH_OUTBOX_POSITION"
+
+
+# --- reader: steady state -----------------------------------------------------------------------
+
+
+def test_empty_file_yields_no_frames_and_establishes_cursor(tmp_path: Path) -> None:
+    path = _outbox(tmp_path)
+    result = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+    assert result.new_frames == ()
+    assert result.loss_signal is None
+    assert result.next_position is not None
+    assert result.next_position.offset == 0
+    assert result.next_position.content_sha256 == hashlib.sha256(b"").hexdigest()
+
+
+def test_single_append_reads_only_new_frame(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="deploy.started"))
+    first = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+    assert len(first.new_frames) == 1
+
+    _append(path, _frame_line(kind="deploy.completed"))
+    second = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(first.next_position_string),
+        config=OutboxReaderConfig(),
+    )
+    assert [frame.kind for frame in second.new_frames] == ["deploy.completed"]
+    assert second.diagnostics.frames_emitted == 1
+
+
+def test_unchanged_input_yields_no_new_frames(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line() + _frame_line(kind="deploy.started"))
+    first = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+    assert len(first.new_frames) == 2
+
+    second = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(first.next_position_string),
+        config=OutboxReaderConfig(),
+    )
+    assert second.new_frames == ()
+    assert second.diagnostics.frames_emitted == 0
+    assert second.next_position_string == first.next_position_string
+
+
+def test_multi_append_reads_only_the_appended_frames(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    first = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+
+    _append(path, _frame_line(kind="b") + _frame_line(kind="c") + _frame_line(kind="d"))
+    second = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(first.next_position_string),
+        config=OutboxReaderConfig(),
+    )
+    assert [frame.kind for frame in second.new_frames] == ["b", "c", "d"]
+
+
+def test_partial_torn_tail_is_not_consumed_then_completes(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    first = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+
+    # Append one complete line plus a torn (no trailing LF) partial line.
+    complete = _frame_line(kind="b")
+    partial = _frame_line(kind="c")[:-10]
+    _append(path, complete + partial)
+    second = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(first.next_position_string),
+        config=OutboxReaderConfig(),
+    )
+    assert [frame.kind for frame in second.new_frames] == ["b"]
+    assert second.diagnostics.torn_tail_bytes == len(partial)
+
+    # Completing the torn line makes it available on the next read, with no duplication of "b".
+    _append(path, _frame_line(kind="c")[-10:])
+    third = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(second.next_position_string),
+        config=OutboxReaderConfig(),
+    )
+    assert [frame.kind for frame in third.new_frames] == ["c"]
+    assert third.diagnostics.torn_tail_bytes == 0
+
+
+# --- reader: rejection posture ------------------------------------------------------------------
+
+
+def test_malformed_line_rejected_and_neighbors_are_read(tmp_path: Path) -> None:
+    canary = f"PRIVATE-{secrets.token_hex(12)}"
+    malformed = b'{"kind": "broken", "leak": "' + canary.encode() + b'"\n'  # no closing brace
+    data = _frame_line(kind="before") + malformed + _frame_line(kind="after")
+    path = _outbox(tmp_path, data)
+    result = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+
+    assert [frame.kind for frame in result.new_frames] == ["before", "after"]
+    assert result.diagnostics.rejected_lines == 1
+    assert result.diagnostics.rejected_codes["MH_OUTBOX_FRAME"] == 1
+    # The whole malformed line was consumed exactly once: re-reading yields nothing new.
+    assert result.next_position.offset == len(data)
+    assert canary not in _surfaces(result, result.diagnostics, *result.new_frames)
+
+
+def test_oversized_line_rejected_without_raw_persistence(tmp_path: Path) -> None:
+    canary = f"PRIVATE-{secrets.token_hex(12)}"
+    config = OutboxReaderConfig(max_line_bytes=256)
+    oversized = (
+        json.dumps(_frame_document(data={"blob": canary + "x" * 512})).encode("utf-8") + b"\n"
+    )
+    data = _frame_line(kind="ok") + oversized
+    path = _outbox(tmp_path, data)
+    result = read_outbox(file_path=path, prior_cursor=None, config=config)
+
+    assert [frame.kind for frame in result.new_frames] == ["ok"]
+    assert result.diagnostics.rejected_codes["MH_OUTBOX_LINE_OVERSIZE"] == 1
+    assert canary not in _surfaces(result, result.diagnostics, *result.new_frames)
+
+
+def test_producer_allowlist_denies_unlisted_producers(tmp_path: Path) -> None:
+    config = OutboxReaderConfig(producer_allowlist=("web-ci",))
+    data = _frame_line(producer_id="web-ci", kind="ok") + _frame_line(
+        producer_id="rogue", kind="no"
+    )
+    path = _outbox(tmp_path, data)
+    result = read_outbox(file_path=path, prior_cursor=None, config=config)
+
+    assert [frame.kind for frame in result.new_frames] == ["ok"]
+    assert result.diagnostics.rejected_codes["MH_OUTBOX_PRODUCER_DENIED"] == 1
+
+
+# --- reader: rotation ---------------------------------------------------------------------------
+
+
+def _rotate(path: Path, sequence: int) -> Path:
+    rotated = path.parent / f"feedback-outbox.{sequence:08d}.jsonl"
+    os.rename(path, rotated)
+    return rotated
+
+
+def test_compliant_rotation_recovers_without_loss_or_duplication(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))  # consumed only "a"
+
+    _rotate(path, 1)
+    _write(path, _frame_line(kind="c") + _frame_line(kind="d"))
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+
+    assert result.loss_signal is None
+    assert [frame.kind for frame in result.new_frames] == ["b", "c", "d"]
+    assert result.diagnostics.rotations_crossed == 1
+    # The next cursor points into the new active file.
+    assert result.next_position.inode == os.stat(path).st_ino
+
+
+def test_multiple_rotations_recovered_in_monotonic_order(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))
+
+    _rotate(path, 1)
+    _write(path, _frame_line(kind="c"))
+    _rotate(path, 2)
+    _write(path, _frame_line(kind="d") + _frame_line(kind="e"))
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+
+    assert result.loss_signal is None
+    assert [frame.kind for frame in result.new_frames] == ["b", "c", "d", "e"]
+    assert result.diagnostics.rotations_crossed == 2
+
+
+def test_needed_rotated_file_removed_is_p1_loss(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))
+    _rotate(path, 1)
+    _write(path, _frame_line(kind="c"))
+    os.unlink(path.parent / "feedback-outbox.00000001.jsonl")  # the file the cursor still needs
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+    assert result.new_frames == ()
+    assert result.loss_signal is not None
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_ROTATION_GONE"
+    assert result.loss_signal.priority == "P1"
+
+
+def test_rotated_file_with_torn_tail_is_p1_loss(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    cursor = _cursor_for(path, b"")  # nothing consumed yet
+    rotated = _rotate(path, 1)
+    _append(rotated, b'{"torn": "no-final-lf"')  # rotated (immutable) file left non-LF-terminated
+    _write(path, _frame_line(kind="b"))
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+    assert result.new_frames == ()
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_ROTATED_TORN"
+
+
+def _rotate_to(path: Path, name: str) -> Path:
+    """Rename the active file to an explicit rotated name (mirrors a producer rotation)."""
+
+    rotated = path.parent / name
+    os.rename(path, rotated)
+    return rotated
+
+
+def test_gap_in_rotated_sequence_above_cursor_is_p1_loss(tmp_path: Path) -> None:
+    # Cursor in segment 1; the producer rotates twice more (segments 2 and 3 retained above it),
+    # then the intermediate segment 2 is removed. The surviving segment 3 above the gap makes the
+    # missing sequence detectable: a dropped unconsumed segment is un-recoverable P1 loss.
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))
+    _rotate(path, 1)
+    _write(path, _frame_line(kind="c"))
+    _rotate(path, 2)
+    _write(path, _frame_line(kind="d"))
+    _rotate(path, 3)
+    _write(path, _frame_line(kind="e"))
+    os.unlink(path.parent / "feedback-outbox.00000002.jsonl")  # drop the intermediate segment
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+    assert result.new_frames == ()
+    assert result.loss_signal is not None
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_ROTATION_GONE"
+    assert result.loss_signal.priority == "P1"
+    assert result.next_position_string == cursor.position  # cursor NOT advanced
+
+
+def test_gap_not_at_the_boundary_is_p1_loss(tmp_path: Path) -> None:
+    # Cursor in segment 1; segments 2, 3, 4 rotate above it, then the MIDDLE segment 3 is removed
+    # (2 present, 3 missing, 4 present). The hole between two survivors is detected.
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))
+    for sequence, kind in ((1, "c"), (2, "d"), (3, "e")):
+        _rotate(path, sequence)
+        _write(path, _frame_line(kind=kind))
+    _rotate(path, 4)
+    _write(path, _frame_line(kind="f"))
+    os.unlink(path.parent / "feedback-outbox.00000003.jsonl")  # 2 present, 3 missing, 4 present
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+    assert result.new_frames == ()
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_ROTATION_GONE"
+
+
+def test_unpadded_monotonic_names_order_numerically_without_false_loss(tmp_path: Path) -> None:
+    # Unpadded names: "...10"/"...11" sort lexically BEFORE "...9" but must order numerically.
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))
+    _rotate_to(path, "feedback-outbox.9.jsonl")
+    _write(path, _frame_line(kind="c"))
+    _rotate_to(path, "feedback-outbox.10.jsonl")
+    _write(path, _frame_line(kind="d"))
+    _rotate_to(path, "feedback-outbox.11.jsonl")
+    _write(path, _frame_line(kind="e"))
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+    assert result.loss_signal is None
+    # b (rest of seq 9), then seq 10, seq 11, then the active file -- each read exactly once.
+    assert [frame.kind for frame in result.new_frames] == ["b", "c", "d", "e"]
+    assert result.diagnostics.rotations_crossed == 3
+
+
+def test_top_run_deletion_is_the_documented_undetectable_residual(tmp_path: Path) -> None:
+    # DOCUMENTED RESIDUAL (increment 1, reader._recover_rotation docstring): the active file carries
+    # no sequence, so deletion of a RUN of the TOPMOST rotated segments (next to the active file)
+    # leaves the survivors a contiguous run that passes the gap check -- a stateless single-file
+    # cursor keeps no record of the highest sequence that ever existed, so it cannot know those top
+    # segments were dropped. This is closed in increment 2 by the durable ack persisting the last
+    # committed sequence. We PIN the known window here so a future change that widens OR (once
+    # increment 2 lands) narrows it is caught.
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))
+    for sequence, kind in ((1, "c"), (2, "d"), (3, "e")):
+        _rotate(path, sequence)
+        _write(path, _frame_line(kind=kind))
+    _rotate(path, 4)
+    _write(path, _frame_line(kind="f"))  # active
+    # seg1=[a,b] seg2=[c] seg3=[d] seg4=[e] active=[f]; drop the TOP RUN (segs 3+4) below active.
+    os.unlink(path.parent / "feedback-outbox.00000003.jsonl")
+    os.unlink(path.parent / "feedback-outbox.00000004.jsonl")
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+
+    # NO loss is signalled (the known increment-1 limitation) and d (seg3) + e (seg4) are silently
+    # absent -- exactly the top-run window increment 2's ack must close.
+    assert result.loss_signal is None
+    assert [frame.kind for frame in result.new_frames] == ["b", "c", "f"]
+
+
+def test_unparseable_rotated_name_fails_closed(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    cursor = _cursor_for(path, b"")
+    _rotate(path, 1)
+    _write(path, _frame_line(kind="b"))
+    # A glob match whose wildcard is not a pure integer run breaks ordering/contiguity reasoning.
+    _write(tmp_path / "feedback-outbox.backup.jsonl", _frame_line(kind="x"))
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+    assert result.new_frames == ()
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_ROTATION_UNPARSEABLE"
+
+
+def test_duplicate_rotated_sequence_fails_closed(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    cursor = _cursor_for(path, b"")
+    _rotate(path, 2)  # feedback-outbox.00000002.jsonl -> parses to 2
+    _write(path, _frame_line(kind="b"))
+    _write(tmp_path / "feedback-outbox.2.jsonl", _frame_line(kind="x"))  # also parses to 2
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+    assert result.new_frames == ()
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_ROTATION_AMBIGUOUS"
+
+
+# --- reader: data-loss discontinuities ----------------------------------------------------------
+
+
+def test_truncation_below_offset_is_p1_loss(tmp_path: Path) -> None:
+    data = _frame_line(kind="a") + _frame_line(kind="b")
+    path = _outbox(tmp_path, data)
+    first = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+
+    _write(path, _frame_line(kind="a")[:5])  # shrink below the committed offset
+    result = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(first.next_position_string),
+        config=OutboxReaderConfig(),
+    )
+    assert result.new_frames == ()
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_TRUNCATED"
+    assert result.loss_signal.observed_size == 5
+    assert result.next_position_string == first.next_position_string  # cursor NOT advanced
+
+
+def test_consumed_prefix_rewrite_is_p1_loss(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    first = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+
+    # Same length or longer, but the already-consumed bytes differ -> prefix hash mismatch.
+    _write(path, _frame_line(kind="X") + _frame_line(kind="b") + _frame_line(kind="c"))
+    result = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(first.next_position_string),
+        config=OutboxReaderConfig(),
+    )
+    assert result.new_frames == ()
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_REWRITE"
+    assert result.loss_signal.observed_sha256 is not None
+
+
+def test_a_replaced_file_at_the_same_path_fails_closed(tmp_path: Path) -> None:
+    # The outbox file is unlinked and a DIFFERENT file written at the same path. Whether the OS
+    # recycles the freed inode (Linux -> same inode number, so the consumed-prefix hash catches the
+    # discontinuity as REWRITE) or assigns a fresh one (macOS -> INODE_REUSE), the reader must FAIL
+    # CLOSED: zero frames, a P1 loss, cursor kept -- never resuming at the old offset in a replaced
+    # file. (Defense-in-depth: inode identity AND the consumed-prefix hash.)
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    first = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+
+    os.unlink(path)
+    _write(path, _frame_line(kind="b"))  # a different file at the same path, no rotation glob
+    result = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(first.next_position_string),
+        config=OutboxReaderConfig(),
+    )
+    assert result.new_frames == ()
+    assert result.loss_signal is not None
+    assert result.loss_signal.priority == "P1"
+    assert result.loss_signal.code in ("MH_OUTBOX_LOSS_INODE_REUSE", "MH_OUTBOX_LOSS_REWRITE")
+    assert result.next_position_string == first.next_position_string  # cursor NOT advanced
+
+
+def test_a_genuinely_different_inode_at_the_path_is_inode_reuse(tmp_path: Path) -> None:
+    # Deterministic INODE_REUSE on every platform: create a second file (a fresh inode, distinct
+    # from the still-live outbox), then atomically rename it onto the outbox path so the path now
+    # resolves to an inode that is NOT the cursor's. With no rotation glob the reader cannot find
+    # where the old bytes went -> MH_OUTBOX_LOSS_INODE_REUSE (zero frames, cursor unadvanced).
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    first = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+
+    replacement = tmp_path / "replacement.jsonl"
+    _write(replacement, _frame_line(kind="b"))
+    os.rename(replacement, path)  # path now resolves to the replacement's (different) inode
+    result = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(first.next_position_string),
+        config=OutboxReaderConfig(),
+    )
+    assert result.new_frames == ()
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_INODE_REUSE"
+    assert result.next_position_string == first.next_position_string
+
+
+def test_loss_signal_and_diagnostics_are_privacy_safe(tmp_path: Path) -> None:
+    canary = f"PRIVATE-{secrets.token_hex(12)}"
+    path = _outbox(tmp_path, _frame_line(kind="a", data={"note": canary}))
+    first = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+    # Rewrite the consumed prefix (whose bytes carried the canary) -> loss.
+    _write(path, _frame_line(kind="Z", data={"note": canary}) + _frame_line(kind="b"))
+    result = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(first.next_position_string),
+        config=OutboxReaderConfig(),
+    )
+    assert result.loss_signal is not None
+    assert canary not in _surfaces(result.loss_signal, result.diagnostics)
+
+
+# --- reader: hard failures ----------------------------------------------------------------------
+
+
+def test_missing_file_fails_closed(tmp_path: Path) -> None:
+    with pytest.raises(OutboxError) as raised:
+        read_outbox(
+            file_path=tmp_path / "absent.jsonl", prior_cursor=None, config=OutboxReaderConfig()
+        )
+    assert raised.value.code == "MH_OUTBOX_NOT_FOUND"
+
+
+def test_symlinked_outbox_is_rejected(tmp_path: Path) -> None:
+    real = _outbox(tmp_path, _frame_line())
+    link = tmp_path / "link.jsonl"
+    link.symlink_to(real)
+    with pytest.raises(OutboxError) as raised:
+        read_outbox(file_path=link, prior_cursor=None, config=OutboxReaderConfig())
+    assert raised.value.code == "MH_OUTBOX_NOT_REGULAR"
+
+
+def test_file_over_max_bytes_fails_closed(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line() * 4)
+    config = OutboxReaderConfig(max_line_bytes=16, max_file_bytes=32)
+    with pytest.raises(OutboxError) as raised:
+        read_outbox(file_path=path, prior_cursor=None, config=config)
+    assert raised.value.code == "MH_OUTBOX_FILE_OVERSIZE"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_line_bytes": 0},
+        {"max_line_bytes": 100, "max_file_bytes": 50},
+        {"rotation_glob": "sub/dir/*.jsonl"},
+        {"rotation_glob": ".."},
+        {"rotation_glob": "no-wildcard.jsonl"},  # missing the '*' sequence wildcard
+        {"rotation_glob": "a*b*c"},  # two wildcards -> ambiguous sequence position
+    ],
+)
+def test_reader_config_rejects_invalid_knobs(kwargs: dict[str, object]) -> None:
+    with pytest.raises(OutboxError) as raised:
+        OutboxReaderConfig(**kwargs)  # type: ignore[arg-type]
+    assert raised.value.code == "MH_OUTBOX_CONFIG"
+
+
+# --- ack format + atomic writer -----------------------------------------------------------------
+
+
+def _ack(**overrides: object) -> OutboxAckV1:
+    values: dict[str, object] = {
+        "producer_id": "web-ci",
+        "file_device": 1,
+        "file_inode": 42,
+        "committed_offset": 128,
+        "content_sha256": hashlib.sha256(b"prefix").hexdigest(),
+        "last_line_sha256": hashlib.sha256(b"line").hexdigest(),
+        "acknowledged_at": datetime(2026, 8, 17, 12, 0, 0, tzinfo=UTC),
+    }
+    values.update(overrides)
+    return OutboxAckV1(**values)  # type: ignore[arg-type]
+
+
+def _ack_dir(tmp_path: Path) -> Path:
+    """A guaranteed owner-only 0700 `.milhouse` dir (the ack now requires a private parent)."""
+
+    directory = tmp_path / ".milhouse"
+    directory.mkdir()
+    os.chmod(directory, 0o700)
+    return directory
+
+
+def test_ack_round_trips_atomically_at_0600(tmp_path: Path) -> None:
+    directory = _ack_dir(tmp_path)
+    ack = _ack()
+    write_outbox_ack(directory, "outbox-ack.json", ack)
+    published = directory / "outbox-ack.json"
+    assert (published.stat().st_mode & 0o777) == 0o600
+    assert read_outbox_ack(directory, "outbox-ack.json") == ack
+
+
+def test_ack_atomic_replace_overwrites_prior_value(tmp_path: Path) -> None:
+    directory = _ack_dir(tmp_path)
+    write_outbox_ack(directory, "outbox-ack.json", _ack(committed_offset=1))
+    write_outbox_ack(directory, "outbox-ack.json", _ack(committed_offset=2))
+    assert read_outbox_ack(directory, "outbox-ack.json").committed_offset == 2
+    # No staging artifact is left behind.
+    leftovers = [entry.name for entry in directory.iterdir() if entry.name != "outbox-ack.json"]
+    assert leftovers == []
+
+
+def test_ack_absent_returns_none(tmp_path: Path) -> None:
+    assert read_outbox_ack(_ack_dir(tmp_path), "outbox-ack.json") is None
+
+
+def test_ack_rejects_symlinked_path(tmp_path: Path) -> None:
+    directory = _ack_dir(tmp_path)
+    real = directory / "real.json"
+    real.write_bytes(outbox_ack_bytes(_ack()))
+    os.chmod(real, 0o600)
+    link = directory / "outbox-ack.json"
+    link.symlink_to(real)
+    with pytest.raises(OutboxError) as raised:
+        read_outbox_ack(directory, "outbox-ack.json")
+    assert raised.value.code == "MH_OUTBOX_ACK_UNSAFE"
+
+
+def test_ack_rejects_non_0600_file(tmp_path: Path) -> None:
+    directory = _ack_dir(tmp_path)
+    published = directory / "outbox-ack.json"
+    published.write_bytes(outbox_ack_bytes(_ack()))
+    os.chmod(published, 0o644)
+    with pytest.raises(OutboxError) as raised:
+        read_outbox_ack(directory, "outbox-ack.json")
+    assert raised.value.code == "MH_OUTBOX_ACK_UNSAFE"
+
+
+def test_ack_requires_owner_only_0700_parent(tmp_path: Path) -> None:
+    # The ack lives in the Milhouse-owned .milhouse dir, so a group/world-accessible parent is bad.
+    insecure = tmp_path / "insecure"
+    insecure.mkdir()
+    os.chmod(insecure, 0o755)
+    with pytest.raises(OutboxError) as write_raised:
+        write_outbox_ack(insecure, "outbox-ack.json", _ack())
+    assert write_raised.value.code == "MH_OUTBOX_ACK_UNSAFE"
+
+    published = insecure / "outbox-ack.json"
+    published.write_bytes(outbox_ack_bytes(_ack()))
+    os.chmod(published, 0o600)
+    with pytest.raises(OutboxError) as read_raised:
+        read_outbox_ack(insecure, "outbox-ack.json")
+    assert read_raised.value.code == "MH_OUTBOX_ACK_UNSAFE"
+
+
+@pytest.mark.parametrize("filename", ["../escape.json", "sub/ack.json", "..", "."])
+def test_ack_rejects_traversal_filenames(tmp_path: Path, filename: str) -> None:
+    with pytest.raises(OutboxError) as raised:
+        read_outbox_ack(_ack_dir(tmp_path), filename)
+    assert raised.value.code == "MH_OUTBOX_ACK_PATH"
+
+
+def test_ack_read_rejects_corrupt_and_foreign_content(tmp_path: Path) -> None:
+    directory = _ack_dir(tmp_path)
+    published = directory / "outbox-ack.json"
+    published.write_bytes(b'{"not":"an ack"}')
+    os.chmod(published, 0o600)
+    with pytest.raises(OutboxError) as raised:
+        read_outbox_ack(directory, "outbox-ack.json")
+    assert raised.value.code == "MH_OUTBOX_ACK"


### PR DESCRIPTION
## What & why

W07 increment 1 — the **`.milhouse` outbox reader spine**, the durable, incremental, safety-critical primitive the W07 file collectors + receiver all build on. A **pure, offline-testable** module (no live service): given `(file_path, prior_cursor, config)` → `(new_frames, next_cursor, loss_signal, diagnostics)`. First slice of the W07 epic (#149). Refs #150, #149.

## What's here (`src/milhouse/outbox/`)
- **`OutboxFrameV1`** (`frame.py`) — the versioned inbound outbox line envelope (plan §4.9): `schema_version` (closed literal), `producer_id`, `occurred_at`, `target`, `kind`, `actionability`, `evidence_references`, bounded `data`. Value-safe (`extra="forbid"`, frozen, `hide_input_in_errors`) — **untrusted** input parsed defensively, every bound enforced, violations surface only a fixed `MH_OUTBOX_*` code with the offending bytes detached.
- **cursor codec** (`cursor.py`) — encodes `(dev, inode, offset, sha256-of-consumed-prefix)` into the opaque `_cursors.position` string (**no schema change**). The prefix hash detects any truncation/rewrite of consumed bytes; only a byte-identical append reproduces it.
- **incremental read** (`reader.py`) — verifies inode identity, seeks to the prior offset, reads only new LF-complete lines; unchanged input → zero frames; a torn tail is left unconsumed (ADR 0016 precedent).
- **rotation** — parses a **monotonic integer sequence** from rotated filenames (numeric order, not lexical), and requires the retained rotations above the cursor to be a **contiguous run** before the active file — any gap → explicit `MH_OUTBOX_LOSS_ROTATION_GONE`; a non-integer name → `UNPARSEABLE`; a duplicate sequence → `AMBIGUOUS` (all fail-closed).
- **fault handling** — malformed/oversized lines rejected **without raw persistence** (fixed code + counts only); inode reuse; truncation/rewrite of consumed bytes → P1 loss.
- **`outbox-ack.json`** (`ack.py`) — atomic 0600 no-follow writer/reader inside the owner-only `0700 .milhouse` dir (`require_private_parent=True`).

Everything Phase-A-validates the whole rotation chain before Phase-B emits, so **any loss yields zero frames and an unadvanced cursor** — never a partial/duplicate emission.

## Review (two adversarial rounds — this is a no-silent-loss primitive)
A 4-angle workflow found **two real silent-data-loss bugs** in the rotation logic, both fixed:
- **P0**: a removed *intermediate* rotated file went undetected → now caught by the contiguity requirement;
- **P1**: rotated files were ordered *lexically*, so unpadded numeric names silently skipped a segment → now ordered numerically.

A focused re-verify then found a **P1 truthfulness gap**: the residual-limitation docstring under-claimed the undetectable window. **Fixed** — the docstring now accurately states it, and a **characterization test pins it**. The other angles (no-raw-persistence, filesystem-security/ack-atomicity, correctness/codec/config-glob) are all `safe`.

### Documented residual (a fundamental stateless-cursor limit — closed in increment 2)
The active file carries no sequence in its name, so a stateless single-file cursor cannot detect deletion of a **run of the *topmost* rotated segments** (adjacent to the active file). Every gap *below* the highest survivor is detected; the top-run case is closed by **increment 2's durable ack** persisting the last committed sequence. This is documented in the reader and pinned by `test_top_run_deletion_is_the_documented_undetectable_residual`, and tracked as an explicit increment-2 obligation on #149.

## Tests
`tests/unit/test_outbox_reader.py` — a full fault-injection matrix (frame bounds/malformed/oversized/no-raw-leak; cursor codec round-trip + tamper rejection; append/unchanged/torn-tail; rotation compliant/gap/gap-not-at-boundary/unpadded-numeric/unparseable/ambiguous/top-run-residual; truncation/rewrite/inode-reuse → loss; ack atomic/0700-parent/symlink/traversal/corrupt). `test` → **5173 passed / 6 skipped / 0 failed**; `quality` clean (mypy strict, 111 files) apart from a **transient external-link probe** on a pre-existing, live ClickHouse URL in the *untouched* `implementation-plan.md` (verified HTTP 200 out-of-band). DCO + co-author trailers, no session locator.

## Scope / deferred
Increment 2: the durable cursor advance (post-commit against the committed `batch_id`, closing the top-run residual via the ack) + the `file_outbox`/`workflow_file`/`error_report_file` collectors + the pipeline post-commit cursor-advance wiring. The **authenticated HTTP receiver** stays deferred (crypto primitives exist; the non-loopback bind is owner-ack-gated). **G07 is NOT claimed passed.**

Refs #150
Refs #149
