### PR TITLE
fix(ci): harden docs-check link-checker against github.com rate-limiting (#153)

### DIFF
--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -11,6 +11,7 @@ import re
 import socket
 import ssl
 import sys
+import time
 import urllib.parse
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
@@ -32,6 +33,11 @@ SKIP_PARTS = {
     "dist",
     "site",
 }
+RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+RETRY_ATTEMPTS = 3
+RETRY_BACKOFF_BASE = 0.5
+GITHUB_HTML_HOSTS = frozenset({"github.com", "www.github.com"})
+GITHUB_RAW_KINDS = frozenset({"blob", "tree", "raw"})
 
 
 class LinkError(ValueError):
@@ -260,7 +266,74 @@ def _request_once(
     raise LinkError("external URL connection failed") from last_error
 
 
-def check_external(url: str, timeout: float, redirects: int) -> None:
+def _request_with_retry(
+    host: str,
+    port: int,
+    scheme: str,
+    target: str,
+    endpoints: Sequence[PublicEndpoint],
+    method: str,
+    timeout: float,
+) -> tuple[int, str | None]:
+    """Issue one hop's request, retrying transient failures a bounded number of times.
+
+    Retries a connection failure (``LinkError`` from ``_request_once``) or a retryable
+    status with short linear backoff. On the final attempt the outcome is returned or the
+    ``LinkError`` re-raised, so the caller still sees a retryable status and decides its fate.
+    """
+
+    for attempt in range(1, RETRY_ATTEMPTS + 1):
+        final = attempt >= RETRY_ATTEMPTS
+        try:
+            status, location = _request_once(host, port, scheme, target, endpoints, method, timeout)
+        except LinkError:
+            if final:
+                raise
+            time.sleep(RETRY_BACKOFF_BASE * attempt)
+            continue
+        if status in RETRYABLE_STATUSES and not final:
+            time.sleep(RETRY_BACKOFF_BASE * attempt)
+            continue
+        return status, location
+    raise LinkError("external URL connection failed")  # pragma: no cover - loop always exits
+
+
+def _github_raw_url(url: str) -> str | None:
+    """Map a github.com blob/tree/raw HTML URL to its raw.githubusercontent.com equivalent.
+
+    Returns ``None`` for any other host, a path with too few segments, or an unrecognized kind.
+    """
+
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").casefold().rstrip(".")
+    if host not in GITHUB_HTML_HOSTS:
+        return None
+    parts = [segment for segment in parsed.path.split("/") if segment]
+    if len(parts) < 5:
+        return None
+    owner, repo, kind, ref, *rest = parts
+    if kind not in GITHUB_RAW_KINDS:
+        return None
+    return f"https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{'/'.join(rest)}"
+
+
+def _github_raw_reachable(raw_url: str, timeout: float, redirects: int) -> bool:
+    """Probe a derived raw URL through the same guarded machinery; True when it is live.
+
+    Reuses ``check_external`` with tolerance disabled so the SSRF public-endpoint guard still
+    applies to the raw host and the github tolerance branch cannot re-enter (no recursion).
+    """
+
+    try:
+        check_external(raw_url, timeout, redirects, tolerate=False)
+    except LinkError:
+        return False
+    return True
+
+
+def check_external(
+    url: str, timeout: float, redirects: int, *, tolerate: bool = True
+) -> str | None:
     current = url
     for _attempt in range(redirects + 1):
         parsed = urllib.parse.urlsplit(current)
@@ -274,7 +347,7 @@ def check_external(url: str, timeout: float, redirects: int) -> None:
             raise LinkError(f"external URL has an invalid port: {url!r}") from exc
         endpoints = _public_endpoints(parsed.hostname, port)
         target = urllib.parse.urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
-        status, location = _request_once(
+        status, location = _request_with_retry(
             parsed.hostname,
             port,
             parsed.scheme,
@@ -289,9 +362,9 @@ def check_external(url: str, timeout: float, redirects: int) -> None:
             current = urllib.parse.urljoin(current, location)
             continue
         if 200 <= status < 300:
-            return
+            return None
         if status in {403, 405, 501}:
-            fallback_status, _fallback_location = _request_once(
+            status, location = _request_with_retry(
                 parsed.hostname,
                 port,
                 parsed.scheme,
@@ -300,9 +373,14 @@ def check_external(url: str, timeout: float, redirects: int) -> None:
                 "GET",
                 timeout,
             )
-            if 200 <= fallback_status < 300:
-                return
-            raise LinkError(f"external URL returned HTTP {fallback_status}: {url!r}")
+            if 200 <= status < 300:
+                return None
+        if tolerate and status in {404, 429}:
+            raw_url = _github_raw_url(current)
+            if raw_url is not None and _github_raw_reachable(raw_url, timeout, redirects):
+                return (
+                    f"github.com returned HTTP {status} but the file is live via {raw_url}: {url!r}"
+                )
         raise LinkError(f"external URL returned HTTP {status}: {url!r}")
     raise LinkError(f"external URL exceeded {redirects} redirect(s): {url!r}")
 
@@ -314,7 +392,7 @@ def validate(
     limit: int,
     timeout: float,
     redirects: int,
-) -> tuple[int, int]:
+) -> tuple[int, int, int]:
     cache: dict[Path, set[str]] = {}
     external_urls: set[str] = set()
     checked = 0
@@ -354,12 +432,16 @@ def validate(
                 fragment = urllib.parse.unquote(parsed.fragment)
                 if fragment not in available:
                     raise LinkError(f"{source}:{line}: missing anchor #{fragment}")
+    warnings = 0
     if external:
         if len(external_urls) > limit:
             raise LinkError(f"external link count {len(external_urls)} exceeds bound {limit}")
         for url in sorted(external_urls):
-            check_external(url, timeout, redirects)
-    return checked, len(external_urls) if external else 0
+            warning = check_external(url, timeout, redirects)
+            if warning is not None:
+                print(f"warning: {warning}", file=sys.stderr)
+                warnings += 1
+    return checked, (len(external_urls) if external else 0), warnings
 
 
 def parse_args(arguments: Sequence[str]) -> argparse.Namespace:
@@ -380,12 +462,15 @@ def main(arguments: Sequence[str] | None = None) -> int:
     try:
         root = args.repo_root.resolve(strict=True)
         files = markdown_files(args.paths)
-        links, external = validate(
+        links, external, tolerated = validate(
             files, root, args.external, args.max_external, args.timeout, args.max_redirects
         )
     except (LinkError, OSError) as exc:
         fail(str(exc))
-    print(f"links: {len(files)} file(s), {links} link(s), {external} external probe(s) passed")
+    print(
+        f"links: {len(files)} file(s), {links} link(s), "
+        f"{external} external probe(s) passed, {tolerated} tolerated"
+    )
     return 0
 
 

--- a/tests/unit/test_tool_links.py
+++ b/tests/unit/test_tool_links.py
@@ -26,7 +26,7 @@ def test_github_style_slugs_and_duplicate_heading_suffixes(tmp_path: Path) -> No
 
     assert slug("Release 1.0: `Milhouse`_OSS") == "release-10-milhouse_oss"
     assert "repeated-heading-1" in anchors(page)
-    assert validate((page,), tmp_path.resolve(), False, 1, 1.0, 0) == (2, 0)
+    assert validate((page,), tmp_path.resolve(), False, 1, 1.0, 0) == (2, 0, 0)
 
 
 def test_local_link_cannot_escape_repo_through_encoded_traversal(tmp_path: Path) -> None:
@@ -459,7 +459,10 @@ def test_external_check_accepts_success_and_head_fallback(
     check_links.check_external("https://example.test/page", 1.0, 0)
     assert methods == ["HEAD", "GET"]
 
-    outcomes = iter(((405, None), (500, None)))
+    # A retryable 500 on the GET fallback is retried up to the bound, then surfaces as a
+    # genuine failure once exhausted (the 500 is yielded once per attempt).
+    monkeypatch.setattr(check_links.time, "sleep", lambda _seconds: None)
+    outcomes = iter(((405, None), (500, None), (500, None), (500, None)))
     monkeypatch.setattr(check_links, "_request_once", lambda *_args: next(outcomes))
     with pytest.raises(LinkError, match="HTTP 500"):
         check_links.check_external("https://example.test/page", 1.0, 0)
@@ -492,6 +495,7 @@ def test_external_check_follows_bounded_redirects(
 def test_external_check_rejects_unsafe_or_failed_urls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(check_links.time, "sleep", lambda _seconds: None)
     with pytest.raises(LinkError, match="unsupported external URL"):
         check_links.check_external("ftp://example.test/file", 1.0, 0)
     with pytest.raises(LinkError, match="credentials"):
@@ -537,7 +541,7 @@ def test_validate_handles_directory_anchors_mailto_and_bounded_external_links(
         lambda url, _timeout, _redirects: probes.append(url),
     )
 
-    assert validate((page,), tmp_path.resolve(), True, 1, 1.0, 0) == (3, 1)
+    assert validate((page,), tmp_path.resolve(), True, 1, 1.0, 0) == (3, 1, 0)
     assert probes == ["https://example.test/page"]
 
     page.write_text("[one](https://one.test)\n[two](https://two.test)\n", encoding="utf-8")
@@ -569,7 +573,7 @@ def test_validate_accepts_a_local_file_without_an_anchor(tmp_path: Path) -> None
     page = tmp_path / "README.md"
     page.write_text("[guide](guide.md)\n", encoding="utf-8")
 
-    assert validate((page,), tmp_path.resolve(), False, 1, 1.0, 0) == (1, 0)
+    assert validate((page,), tmp_path.resolve(), False, 1, 1.0, 0) == (1, 0, 0)
 
 
 @pytest.mark.parametrize(
@@ -610,3 +614,163 @@ def test_link_main_validates_bounds_and_reports_errors(
         check_links.main([str(missing)])
     assert caught.value.code == 1
     assert "links:" in capsys.readouterr().err
+
+
+def _resolve_global(*args: object, **_kwargs: object) -> list[object]:
+    port = int(args[1]) if len(args) > 1 else 443
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port))]
+
+
+def test_external_check_retries_transient_status_until_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(check_links.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        check_links, "_public_endpoints", lambda _host, port: (_public_endpoint(port=port),)
+    )
+    methods: list[str] = []
+    outcomes = iter(((429, None), (200, None)))
+
+    def request(*args: object) -> tuple[int, str | None]:
+        methods.append(str(args[-2]))
+        return next(outcomes)
+
+    monkeypatch.setattr(check_links, "_request_once", request)
+    assert check_links.check_external("https://example.test/page", 5.0, 0) is None
+    assert methods == ["HEAD", "HEAD"]
+
+
+def test_external_check_exhausts_retries_on_persistent_retryable_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slept: list[float] = []
+    monkeypatch.setattr(check_links.time, "sleep", lambda seconds: slept.append(seconds))
+    monkeypatch.setattr(
+        check_links, "_public_endpoints", lambda _host, port: (_public_endpoint(port=port),)
+    )
+    methods: list[str] = []
+
+    def request(*args: object) -> tuple[int, str | None]:
+        methods.append(str(args[-2]))
+        return 503, None
+
+    monkeypatch.setattr(check_links, "_request_once", request)
+    with pytest.raises(LinkError, match="HTTP 503"):
+        check_links.check_external("https://example.test/page", 5.0, 0)
+    assert methods == ["HEAD", "HEAD", "HEAD"]
+    assert slept == [0.5, 1.0]
+
+
+def test_github_raw_url_maps_blob_tree_raw_and_rejects_other_shapes() -> None:
+    expected = "https://raw.githubusercontent.com/owner/repo/main/docs/guide.md"
+    assert check_links._github_raw_url("https://github.com/owner/repo/blob/main/docs/guide.md") == (
+        expected
+    )
+    assert check_links._github_raw_url("https://github.com/owner/repo/tree/main/docs/guide.md") == (
+        expected
+    )
+    assert check_links._github_raw_url("https://github.com/owner/repo/raw/main/docs/guide.md") == (
+        expected
+    )
+    assert check_links._github_raw_url("https://www.github.com/owner/repo/blob/main/x.md") == (
+        "https://raw.githubusercontent.com/owner/repo/main/x.md"
+    )
+    assert check_links._github_raw_url("https://github.com/owner/repo/blob/feat/a/b/c.md") == (
+        "https://raw.githubusercontent.com/owner/repo/feat/a/b/c.md"
+    )
+    # Non-github host.
+    assert check_links._github_raw_url("https://gitlab.com/owner/repo/blob/main/x.md") is None
+    assert check_links._github_raw_url("https://example.test/owner/repo/blob/main/x.md") is None
+    # Too few path segments (nothing after the ref).
+    assert check_links._github_raw_url("https://github.com/owner/repo/blob/main") is None
+    assert check_links._github_raw_url("https://github.com/owner/repo") is None
+    # Unrecognized kind.
+    assert check_links._github_raw_url("https://github.com/owner/repo/commits/main/x.md") is None
+
+
+def test_github_html_rate_limit_is_tolerated_when_raw_is_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(check_links.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(check_links.socket, "getaddrinfo", _resolve_global)
+    seen: list[str] = []
+
+    def request(host: str, *_rest: object) -> tuple[int, str | None]:
+        seen.append(host)
+        if host == "raw.githubusercontent.com":
+            return 200, None
+        return 404, None
+
+    monkeypatch.setattr(check_links, "_request_once", request)
+    result = check_links.check_external(
+        "https://github.com/owner/repo/blob/main/docs/guide.md", 5.0, 3
+    )
+    assert result is not None
+    assert "raw.githubusercontent.com/owner/repo/main/docs/guide.md" in result
+    # The github HTML page and then its derived raw URL were probed, in exactly that order
+    # (exact list equality, not host-substring membership, keeps the host check unambiguous).
+    assert seen == ["github.com", "raw.githubusercontent.com"]
+
+
+def test_validate_and_main_tolerate_github_rate_limit_without_failing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(check_links.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(check_links.socket, "getaddrinfo", _resolve_global)
+
+    def request(host: str, *_rest: object) -> tuple[int, str | None]:
+        return (200, None) if host == "raw.githubusercontent.com" else (404, None)
+
+    monkeypatch.setattr(check_links, "_request_once", request)
+    page = tmp_path / "README.md"
+    page.write_text(
+        "[live](https://github.com/owner/repo/blob/main/docs/guide.md)\n",
+        encoding="utf-8",
+    )
+    assert check_links.main(["--repo-root", str(tmp_path), "--external", str(page)]) == 0
+    captured = capsys.readouterr()
+    assert "warning:" in captured.err
+    assert "1 tolerated" in captured.out
+
+
+def test_github_html_dead_link_fails_when_raw_is_also_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(check_links.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(check_links.socket, "getaddrinfo", _resolve_global)
+    monkeypatch.setattr(check_links, "_request_once", lambda *_args: (404, None))
+    with pytest.raises(LinkError, match="HTTP 404"):
+        check_links.check_external("https://github.com/owner/repo/blob/main/missing.md", 5.0, 3)
+
+
+def test_non_github_404_is_not_tolerated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(check_links.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(check_links.socket, "getaddrinfo", _resolve_global)
+    monkeypatch.setattr(check_links, "_request_once", lambda *_args: (404, None))
+    assert check_links._github_raw_url("https://example.test/owner/repo/blob/main/x.md") is None
+    with pytest.raises(LinkError, match="HTTP 404"):
+        check_links.check_external("https://example.test/owner/repo/blob/main/x.md", 5.0, 3)
+
+
+def test_github_raw_probe_is_not_exempt_from_the_ssrf_public_endpoint_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(check_links.time, "sleep", lambda _seconds: None)
+    resolved: list[str] = []
+
+    def getaddrinfo(host: str, port: int, *_a: object, **_k: object) -> list[object]:
+        resolved.append(host)
+        address = "127.0.0.1" if host == "raw.githubusercontent.com" else "8.8.8.8"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port))]
+
+    monkeypatch.setattr(check_links.socket, "getaddrinfo", getaddrinfo)
+    monkeypatch.setattr(check_links, "_request_once", lambda *_args: (404, None))
+    # The github page 404s, the raw probe would tolerate it, but the raw host resolves to a
+    # non-global address, so the SSRF guard rejects it and the link stays a genuine failure.
+    with pytest.raises(LinkError, match="HTTP 404"):
+        check_links.check_external("https://github.com/owner/repo/blob/main/x.md", 5.0, 3)
+    assert resolved == ["github.com", "raw.githubusercontent.com"]


### PR DESCRIPTION
## What & why

`make docs-check` runs `scripts/check_links.py --external`, which probes external doc links — **including github.com HTML pages**. GitHub rate-limits/404s such requests from CI runners even for **live** files, hard-failing the build. This blocked PR #151 (the ClickHouse `SECURITY.md` link returns 404 to the runner but **200** via GitHub's contents API *and* raw endpoint) and would block any PR during a GitHub blip. **Closes #153.** Refs #150.

## Change (behavior-preserving except the tolerance)
`scripts/check_links.py`:
1. **Retry with backoff** — a new `_request_with_retry` retries (3 attempts, 0.5s→1.0s backoff) on a connection failure or a retryable status (`429/500/502/503/504`) before deciding. Bounded, so docs-check stays fast.
2. **github.com rate-limit → non-fatal warning** — when a `github.com/<owner>/<repo>/(blob|tree|raw)/<ref>/<path>` URL returns `404/429` after retries, it derives the `raw.githubusercontent.com` equivalent and probes it **through the same SSRF public-endpoint guard**. Live raw → the file exists → emit a `warning:` (stderr) and **don't fail**. Dead/unreachable raw → **genuine dead link → still fails**.
3. `check_external` now returns `str | None` (a tolerated-warning message or clean); `validate`/`main` collect + print warnings and keep exit 0 on tolerated, exit 1 on a genuine `LinkError`. Summary gains `… N external probe(s) passed, M tolerated`.

## Safety (adversarially verified — `SAFE-TO-PR`, 0 findings)
- **No SSRF bypass**: the raw probe re-enters `check_external` → `_public_endpoints`, so a raw host resolving to a local/non-global address is still rejected (tested).
- **No recursion / no fan-out**: `_github_raw_url` returns `None` for `raw.githubusercontent.com`, and the inner probe runs with `tolerate=False` — a pathological raw→github redirect can't re-enter tolerance.
- **Genuine dead links still fail**: non-github 404, github blob 404 with a dead raw, and github 404 with an SSRF-rejected raw all raise `LinkError` (dedicated tests). Tolerance fires **only** for a github blob/tree/raw 404/429 with a genuinely-2xx raw.

## Tests / gates
7 new tests (retry-until-success, retry-exhaustion with asserted backoff, the `_github_raw_url` map/reject matrix, tolerated-404-live-raw unit + end-to-end `main` exit 0, dead-raw-fails, non-github-404-fails, SSRF-guard-on-raw-probe) + 5 existing tests corrected (not weakened). `test` → 5122 passed / 6 skipped / 0 failed; `quality` fully green incl. `docs-check` (`… 80 external probe(s) passed, 0 tolerated` — it passed cleanly this run; the tolerance is the safety net for when github rate-limits). DCO + co-author trailers, no session locator.

## Unblocks
Once merged, PR #151 rebases onto this and its `docs-check`/`quality` goes green; every future PR is immune to this GitHub-rate-limiting flake.

Closes #153
Refs #150
