### PR TITLE
feat(outbox): W07 increment 2a — narrow the top-run rotation-deletion residual (#155)

### DIFF
--- a/src/milhouse/outbox/ack.py
+++ b/src/milhouse/outbox/ack.py
@@ -49,7 +49,7 @@ from milhouse.config.filesystem import (
 from milhouse.core.canonical import CanonicalizationError, canonical_json_bytes
 from milhouse.domain._validation import ValueSafeRecordModel
 from milhouse.domain.identity import MachineIdV1, Sha256HexV1
-from milhouse.domain.records import UtcTimestampV1
+from milhouse.domain.records import NonNegativeIntV1, UtcTimestampV1
 from milhouse.outbox.errors import OutboxError
 
 #: A generous ceiling for the canonical ack object (it holds a handful of small scalar fields).
@@ -64,6 +64,7 @@ _ACK_KEYS = frozenset(
         "file_device",
         "file_inode",
         "last_line_sha256",
+        "last_sequence",
         "producer_id",
         "schema_version",
     }
@@ -78,6 +79,14 @@ class OutboxAckV1(ValueSafeRecordModel):
     the SHA-256 over that whole ``[0, committed_offset)`` prefix (the same anchor the cursor
     carries), ``last_line_sha256`` is the digest of the last committed line (the "last record hash",
     ``None`` for an empty commit), and ``acknowledged_at`` is the commit time.
+
+    ``last_sequence`` is the durable ROTATION high-water mark: the highest rotated-file integer
+    sequence the reader has ever OBSERVED (``None`` until a rotation is seen). It is the anchor the
+    reader's top-run detection reads back as ``last_acknowledged_sequence`` (plan section 4.9 /
+    :func:`milhouse.outbox.reader.read_outbox`): if the highest retained rotated sequence has since
+    dropped below it, a run of the topmost (unconsumed) segments was deleted -- a P1 data loss that
+    a stateless single-file cursor could not otherwise see. The caller advances this monotonically
+    as ``max(persisted, reader_output)``; the reader never lowers it.
     """
 
     model_config = ConfigDict(
@@ -96,6 +105,7 @@ class OutboxAckV1(ValueSafeRecordModel):
     committed_offset: int
     content_sha256: Sha256HexV1
     last_line_sha256: Sha256HexV1 | None = None
+    last_sequence: NonNegativeIntV1 | None = None
     acknowledged_at: UtcTimestampV1
 
 

--- a/src/milhouse/outbox/reader.py
+++ b/src/milhouse/outbox/reader.py
@@ -152,6 +152,15 @@ class OutboxReadResult:
     later durable ``advance_cursor`` write) and ``loss_signal`` is ``None``. On a data-loss find
     ``loss_signal`` is set, ``new_frames`` is empty, and ``next_position``/``next_position_string``
     equal the prior cursor unchanged -- the caller must raise the P1 alert and NOT advance.
+
+    ``max_observed_sequence`` is the highest RETAINED rotated-file integer sequence this single read
+    saw: ``M`` (the top of the contiguous rotated run) during a rotation read, the cursor's own
+    sequence when the cursor is in a rotated file with nothing retained above it, and ``None`` when
+    the cursor is in the active file (or no rotated files were seen). It is a pure per-read
+    observation -- the reader NEVER reads or lowers any persisted state. The CALLER owns the durable
+    monotonic rotation high-water and advances it as ``max(persisted, max_observed_sequence)``, then
+    threads it back as ``read_outbox(..., last_acknowledged_sequence=...)`` so a later read can flag
+    a deleted top-run of rotated segments (``MH_OUTBOX_LOSS_TOP_RUN_GONE``).
     """
 
     new_frames: tuple[OutboxFrameV1, ...]
@@ -159,6 +168,7 @@ class OutboxReadResult:
     next_position_string: str | None
     loss_signal: OutboxLossSignal | None
     diagnostics: OutboxDiagnostics
+    max_observed_sequence: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -283,6 +293,7 @@ def _loss(
     *,
     observed_size: int | None = None,
     observed_sha256: str | None = None,
+    max_observed_sequence: int | None = None,
 ) -> OutboxReadResult:
     signal = OutboxLossSignal(
         code=code,
@@ -307,6 +318,7 @@ def _loss(
         next_position_string=prior_string,
         loss_signal=signal,
         diagnostics=diagnostics,
+        max_observed_sequence=max_observed_sequence,
     )
 
 
@@ -318,6 +330,7 @@ def _success(
     bytes_consumed: int,
     rotations_crossed: int,
     torn_tail_bytes: int,
+    max_observed_sequence: int | None = None,
 ) -> OutboxReadResult:
     diagnostics = OutboxDiagnostics(
         frames_emitted=len(frames),
@@ -333,6 +346,7 @@ def _success(
         next_position_string=encode_outbox_position(next_position),
         loss_signal=None,
         diagnostics=diagnostics,
+        max_observed_sequence=max_observed_sequence,
     )
 
 
@@ -341,13 +355,32 @@ def read_outbox(
     file_path: str | Path,
     prior_cursor: SourceCursor | None,
     config: OutboxReaderConfig,
+    last_acknowledged_sequence: int | None = None,
 ) -> OutboxReadResult:
-    """Incrementally read the outbox from ``prior_cursor``; see the module docstring for details."""
+    """Incrementally read the outbox from ``prior_cursor``; see the module docstring for details.
+
+    ``last_acknowledged_sequence`` is the caller-maintained durable ROTATION high-water mark: the
+    highest rotated-file integer sequence the reader has OBSERVED in prior reads (``None`` if never
+    set; persisted in the ack's ``last_sequence`` field). It is consulted only during rotation
+    recovery to detect a deleted top-run of the most-recent rotated segments -- see
+    :func:`_recover_rotation`. Passing ``None`` is the fully backward-compatible increment-1
+    behaviour. The reader never reads or writes this durable state itself; the caller advances it
+    monotonically as ``max(persisted, result.max_observed_sequence)`` and threads it back here.
+    """
 
     if not isinstance(config, OutboxReaderConfig):
         raise OutboxError("MH_OUTBOX_CONFIG", "an outbox reader configuration is required")
     if prior_cursor is not None and not isinstance(prior_cursor, SourceCursor):
         raise OutboxError("MH_OUTBOX_CURSOR", "a source cursor or None is required")
+    if last_acknowledged_sequence is not None and (
+        type(last_acknowledged_sequence) is not int
+        or not 0 <= last_acknowledged_sequence <= MAX_CANONICAL_INT
+    ):
+        # ``bool`` is an ``int`` subtype; the ``type is int`` check rejects it so a stray flag
+        # cannot pose as a high-water sequence. Fail closed rather than reason from a bogus mark.
+        raise OutboxError(
+            "MH_OUTBOX_HIGH_WATER", "a bounded non-negative high-water sequence or None is required"
+        )
 
     prior = outbox_position_from_cursor(prior_cursor) if prior_cursor is not None else None
     prior_string = prior_cursor.position if prior_cursor is not None else None
@@ -356,7 +389,9 @@ def read_outbox(
     if prior is None or (active.device, active.inode) == (prior.device, prior.inode):
         return _read_same_file(active, prior, config)
     assert prior_string is not None
-    return _recover_rotation(file_path, active, prior, prior_string, config)
+    return _recover_rotation(
+        file_path, active, prior, prior_string, config, last_acknowledged_sequence
+    )
 
 
 def _read_same_file(
@@ -409,6 +444,7 @@ def _recover_rotation(
     prior: OutboxPosition,
     prior_string: str,
     config: OutboxReaderConfig,
+    last_acknowledged_sequence: int | None,
 ) -> OutboxReadResult:
     """Recover across a rotation, requiring a parseable, CONTIGUOUS rotated sequence (no gaps).
 
@@ -420,16 +456,32 @@ def _recover_rotation(
     active file. ANY gap -- a missing intermediate sequence -- is un-recoverable P1 data loss
     (``MH_OUTBOX_LOSS_ROTATION_GONE``): a single-file cursor cannot re-materialize deleted bytes.
 
-    Residual limitation (documented, not a silent skip): the active file carries no sequence in its
-    name, so the reader treats the highest retained rotation as the active file's immediate
-    predecessor. Deletion of ANY RUN of the TOPMOST rotated segments -- the most-recent ones next
-    to the active file, with nothing retained above the survivors -- therefore leaves the retained
-    set a contiguous run that passes the gap check, and the missing top segments are
-    indistinguishable from "there were no further rotations". A stateless single-file cursor cannot
-    detect this: it keeps no record of the highest sequence ever seen. Requiring a contiguous
-    sequence makes every gap BELOW the highest survivor a detected loss; the top-run case is closed
-    in increment 2 by the durable ack persisting the last committed sequence (so the reader can tell
-    the current top is below what it already acknowledged).
+    Top-run detection via the high-water (increment 2a): the active file carries no sequence in its
+    name, so the reader treats the highest retained rotation ``M`` as the active file's immediate
+    predecessor. Deletion of a RUN of the TOPMOST rotated segments -- the most-recent ones adjacent
+    to the active file, with nothing retained above the survivors -- leaves the retained set a
+    contiguous run that passes the gap check above. To catch THAT, once ``{S+1..M}`` is proven
+    contiguous the reader compares ``M`` against ``last_acknowledged_sequence`` (``H``, the durable
+    high-water of the highest rotated sequence ever OBSERVED). If ``H`` is set and ``M < H`` the
+    segments ``(M+1 .. H)`` that were once observed are gone from the top; because this branch runs
+    only during rotation recovery (the cursor sits in a rotated file at ``S <= M < H``), those
+    missing segments are strictly ABOVE the cursor and therefore UNCONSUMED -- a genuine P1 loss,
+    ``MH_OUTBOX_LOSS_TOP_RUN_GONE``.
+
+    Why this has NO false positive: a compliant producer deletes a rotated segment only once the
+    ack covers it (fully consumed). Deleting a CONSUMED segment at or below the cursor never reaches
+    this branch -- a consumed segment means the cursor already advanced to/past it, so the next read
+    finds the cursor either in the ACTIVE file (which never enters this function) or in a HIGHER
+    rotated file, and a missing lower file surfaces as the ``ROTATION_GONE`` cursor-file-missing
+    case, not this one. This branch fires only for segments strictly ABOVE the cursor that were
+    previously observed, i.e. genuinely unconsumed loss.
+
+    Irreducible residual (documented, not papered over): a top-run is caught only for PREVIOUSLY
+    OBSERVED segments (those the high-water recorded). Segments a producer creates AND deletes
+    entirely BETWEEN two reads never enter the reader's observation, so they are absent from the
+    high-water and remain undetectable -- fundamentally so for a cursor-based reader unless the
+    producer sequences the active file (out of scope). Everything the reader has ever seen at the
+    top is now detected.
     """
 
     if config.rotation_glob is None:
@@ -442,6 +494,12 @@ def _recover_rotation(
     if discovery_loss is not None:
         return _loss(discovery_loss, prior, prior_string)
 
+    # The highest retained rotated sequence seen THIS read (``None`` if the glob matched only the
+    # active file). This is the pure per-read observation the caller folds into its high-water; it
+    # is reported on every post-discovery return, loss or success alike, and the reader never uses
+    # it to lower any persisted state.
+    max_observed = max(by_sequence) if by_sequence else None
+
     cursor_sequence = next(
         (
             sequence
@@ -453,19 +511,51 @@ def _recover_rotation(
     if cursor_sequence is None:
         # The file the cursor was consuming is not among the retained, parseable rotations: its
         # unacknowledged bytes are gone and cannot be recovered.
-        return _loss("MH_OUTBOX_LOSS_ROTATION_GONE", prior, prior_string)
+        return _loss(
+            "MH_OUTBOX_LOSS_ROTATION_GONE",
+            prior,
+            prior_string,
+            max_observed_sequence=max_observed,
+        )
 
     # The retained rotations strictly above the cursor MUST be the contiguous run
     # {S+1, S+2, ..., S+k}; any gap is a dropped unconsumed segment we cannot recover.
     above = sorted(sequence for sequence in by_sequence if sequence > cursor_sequence)
     if above != list(range(cursor_sequence + 1, cursor_sequence + 1 + len(above))):
-        return _loss("MH_OUTBOX_LOSS_ROTATION_GONE", prior, prior_string)
+        return _loss(
+            "MH_OUTBOX_LOSS_ROTATION_GONE",
+            prior,
+            prior_string,
+            max_observed_sequence=max_observed,
+        )
+
+    # Top-run high-water check: with ``{S+1..M}`` now proven contiguous, ``max_observed`` == M (the
+    # cursor's own sequence when nothing is retained above it). If a strictly higher sequence H was
+    # observed before but M has since fallen below it, the top run (M+1 .. H) was deleted. Those
+    # segments are above the cursor (S <= M < H) hence unconsumed -> a genuine P1 loss. See the
+    # docstring for the no-false-positive argument; ``max_observed is not None`` here because the
+    # cursor itself is a retained rotation.
+    if (
+        last_acknowledged_sequence is not None
+        and max_observed is not None
+        and (max_observed < last_acknowledged_sequence)
+    ):
+        return _loss(
+            "MH_OUTBOX_LOSS_TOP_RUN_GONE",
+            prior,
+            prior_string,
+            max_observed_sequence=max_observed,
+        )
 
     # Phase A: validate the whole chain BEFORE emitting anything, so any loss yields zero frames.
     cursor_file = by_sequence[cursor_sequence]
     if len(cursor_file.content) < prior.offset:
         return _loss(
-            "MH_OUTBOX_LOSS_TRUNCATED", prior, prior_string, observed_size=len(cursor_file.content)
+            "MH_OUTBOX_LOSS_TRUNCATED",
+            prior,
+            prior_string,
+            observed_size=len(cursor_file.content),
+            max_observed_sequence=max_observed,
         )
     prefix_hash = _sha256_hex(cursor_file.content[: prior.offset])
     if prefix_hash != prior.content_sha256:
@@ -475,6 +565,7 @@ def _recover_rotation(
             prior_string,
             observed_size=len(cursor_file.content),
             observed_sha256=prefix_hash,
+            max_observed_sequence=max_observed,
         )
     if _has_torn_tail(cursor_file.content):
         return _loss(
@@ -482,6 +573,7 @@ def _recover_rotation(
             prior,
             prior_string,
             observed_size=len(cursor_file.content),
+            max_observed_sequence=max_observed,
         )
 
     regions: list[bytes] = [cursor_file.content[prior.offset :]]
@@ -490,7 +582,11 @@ def _recover_rotation(
         read = by_sequence[sequence]
         if _has_torn_tail(read.content):
             return _loss(
-                "MH_OUTBOX_LOSS_ROTATED_TORN", prior, prior_string, observed_size=len(read.content)
+                "MH_OUTBOX_LOSS_ROTATED_TORN",
+                prior,
+                prior_string,
+                observed_size=len(read.content),
+                max_observed_sequence=max_observed,
             )
         regions.append(read.content)
         bytes_consumed += len(read.content)
@@ -518,6 +614,7 @@ def _recover_rotation(
         bytes_consumed=bytes_consumed,
         rotations_crossed=1 + len(above),
         torn_tail_bytes=len(active.content) - complete_end,
+        max_observed_sequence=max_observed,
     )
 
 

--- a/tests/unit/test_outbox_reader.py
+++ b/tests/unit/test_outbox_reader.py
@@ -468,14 +468,16 @@ def test_unpadded_monotonic_names_order_numerically_without_false_loss(tmp_path:
     assert result.diagnostics.rotations_crossed == 3
 
 
-def test_top_run_deletion_is_the_documented_undetectable_residual(tmp_path: Path) -> None:
-    # DOCUMENTED RESIDUAL (increment 1, reader._recover_rotation docstring): the active file carries
-    # no sequence, so deletion of a RUN of the TOPMOST rotated segments (next to the active file)
-    # leaves the survivors a contiguous run that passes the gap check -- a stateless single-file
-    # cursor keeps no record of the highest sequence that ever existed, so it cannot know those top
-    # segments were dropped. This is closed in increment 2 by the durable ack persisting the last
-    # committed sequence. We PIN the known window here so a future change that widens OR (once
-    # increment 2 lands) narrows it is caught.
+def test_top_run_deletion_is_undetectable_without_a_high_water(tmp_path: Path) -> None:
+    # DOCUMENTED RESIDUAL when NO high-water is supplied (reader._recover_rotation docstring): the
+    # active file carries no sequence, so deletion of a RUN of the TOPMOST rotated segments (next to
+    # the active file) leaves the survivors a contiguous run that passes the gap check. A stateless
+    # single-file cursor keeps no record of the highest sequence that ever existed, so on its own it
+    # cannot know those top segments were dropped. Increment 2a CLOSES this by threading a durable
+    # rotation high-water (the ack's ``last_sequence``) back as ``last_acknowledged_sequence`` (see
+    # test_top_run_deletion_detected_with_high_water). We keep this test with NO high-water passed
+    # to PIN that, without one, the window is still (necessarily) silent, so a regression that
+    # either widens it or spuriously fires here is caught.
     path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
     cursor = _cursor_for(path, _frame_line(kind="a"))
     for sequence, kind in ((1, "c"), (2, "d"), (3, "e")):
@@ -490,10 +492,161 @@ def test_top_run_deletion_is_the_documented_undetectable_residual(tmp_path: Path
     config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
     result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
 
-    # NO loss is signalled (the known increment-1 limitation) and d (seg3) + e (seg4) are silently
-    # absent -- exactly the top-run window increment 2's ack must close.
+    # NO high-water -> NO loss is signalled and d (seg3) + e (seg4) are silently absent. But the
+    # reader still REPORTS the surviving top M (=2) so a caller that persisted it as the high-water
+    # would trip the detector on the next read (that is exactly the closure path).
     assert result.loss_signal is None
     assert [frame.kind for frame in result.new_frames] == ["b", "c", "f"]
+    assert result.max_observed_sequence == 2
+
+
+def test_top_run_deletion_detected_with_high_water(tmp_path: Path) -> None:
+    # TRUE POSITIVE (increment 2a): identical top-run deletion, but this time the reader is told the
+    # durable high-water H=4 (segment 4 was OBSERVED in a prior read). The current top retained
+    # rotated sequence M is only 2, so the run (segs 3, 4) -- above the cursor in seg1, hence
+    # UNCONSUMED -- is a genuine data loss the reader now flags.
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))  # cursor in seg1, consumed only "a"
+    for sequence, kind in ((1, "c"), (2, "d"), (3, "e")):
+        _rotate(path, sequence)
+        _write(path, _frame_line(kind=kind))
+    _rotate(path, 4)
+    _write(path, _frame_line(kind="f"))  # active
+    # seg1=[a,b] seg2=[c] seg3=[d] seg4=[e] active=[f]; drop the TOP RUN (segs 3+4).
+    os.unlink(path.parent / "feedback-outbox.00000003.jsonl")
+    os.unlink(path.parent / "feedback-outbox.00000004.jsonl")
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(
+        file_path=path, prior_cursor=cursor, config=config, last_acknowledged_sequence=4
+    )
+    assert result.new_frames == ()  # zero frames on a loss
+    assert result.loss_signal is not None
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_TOP_RUN_GONE"
+    assert result.loss_signal.priority == "P1"
+    assert result.next_position_string == cursor.position  # cursor NOT advanced
+    assert result.max_observed_sequence == 2  # the surviving top, reported for the caller
+
+
+@pytest.mark.parametrize("high_water", [None, 1, 2, 3])
+def test_contiguous_rotation_with_high_water_reports_no_top_run_loss(
+    tmp_path: Path, high_water: int | None
+) -> None:
+    # NO FALSE POSITIVE: a compliant contiguous rotation whose top retained M == 3. A high-water of
+    # None, or any value at/below M (nothing observed is missing from the top), must NOT trip the
+    # detector; the whole chain reads cleanly.
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))
+    _rotate(path, 1)
+    _write(path, _frame_line(kind="c"))
+    _rotate(path, 2)
+    _write(path, _frame_line(kind="d"))
+    _rotate(path, 3)
+    _write(path, _frame_line(kind="e"))
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(
+        file_path=path,
+        prior_cursor=cursor,
+        config=config,
+        last_acknowledged_sequence=high_water,
+    )
+    assert result.loss_signal is None
+    assert [frame.kind for frame in result.new_frames] == ["b", "c", "d", "e"]
+    assert result.diagnostics.rotations_crossed == 3
+    assert result.max_observed_sequence == 3
+
+
+def test_deleting_consumed_segment_below_cursor_does_not_flag_top_run(tmp_path: Path) -> None:
+    # NO FALSE POSITIVE on an acked-below deletion: a rotated segment the cursor already CONSUMED
+    # (strictly below it) may be deleted safely, and the top-run detector must not fire on it. The
+    # cursor is in seg2; seg1 (fully consumed) is removed while the top M (=3) still matches the
+    # high-water, so neither ROTATION_GONE nor TOP_RUN_GONE is raised.
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    _rotate(path, 1)  # seg1 = [a, b]
+    _write(path, _frame_line(kind="c") + _frame_line(kind="d"))
+    cursor = _cursor_for(path, _frame_line(kind="c"))  # cursor in the future seg2, consumed "c"
+    _rotate(path, 2)  # seg2 = [c, d]
+    _write(path, _frame_line(kind="e"))
+    _rotate(path, 3)  # seg3 = [e]
+    _write(path, _frame_line(kind="f"))  # active = [f]
+    os.unlink(path.parent / "feedback-outbox.00000001.jsonl")  # drop the consumed below-cursor seg
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(
+        file_path=path, prior_cursor=cursor, config=config, last_acknowledged_sequence=3
+    )
+    # seg1 was below the cursor and already consumed, so its deletion is invisible; M (=3) equals
+    # the high-water, so TOP_RUN_GONE does not fire either. (Deleting the cursor's OWN file would
+    # instead surface as ROTATION_GONE -- still not a top-run false positive.)
+    assert result.loss_signal is None
+    assert [frame.kind for frame in result.new_frames] == ["d", "e", "f"]
+    assert result.max_observed_sequence == 3
+
+
+def test_max_observed_sequence_reports_top_retained_padded_rotation(tmp_path: Path) -> None:
+    # The highest retained rotated sequence (M) is reported for the caller's monotonic high-water.
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))
+    _rotate(path, 1)
+    _write(path, _frame_line(kind="c"))
+    _rotate(path, 2)
+    _write(path, _frame_line(kind="d"))
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+    assert result.loss_signal is None
+    assert result.max_observed_sequence == 2
+
+
+def test_max_observed_sequence_orders_unpadded_names_numerically(tmp_path: Path) -> None:
+    # Unpadded "...9"/"...10"/"...11": M must be the NUMERIC max (11), not the lexical max ("9").
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))
+    _rotate_to(path, "feedback-outbox.9.jsonl")
+    _write(path, _frame_line(kind="c"))
+    _rotate_to(path, "feedback-outbox.10.jsonl")
+    _write(path, _frame_line(kind="d"))
+    _rotate_to(path, "feedback-outbox.11.jsonl")
+    _write(path, _frame_line(kind="e"))
+
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    result = read_outbox(file_path=path, prior_cursor=cursor, config=config)
+    assert result.loss_signal is None
+    assert result.max_observed_sequence == 11
+
+
+def test_max_observed_sequence_is_none_when_reading_only_active_file(tmp_path: Path) -> None:
+    # No rotation this read (the cursor stays in the active file): nothing rotated was observed, so
+    # the high-water output is None even when a rotation glob is configured.
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    first = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+    assert first.max_observed_sequence is None  # bootstrap read of the active file only
+
+    _append(path, _frame_line(kind="b"))
+    second = read_outbox(
+        file_path=path,
+        prior_cursor=_cursor(first.next_position_string),
+        config=OutboxReaderConfig(rotation_glob=_ROTATION_GLOB),
+    )
+    assert second.loss_signal is None
+    assert [frame.kind for frame in second.new_frames] == ["b"]
+    assert second.max_observed_sequence is None  # same active inode, no rotation crossed
+
+
+@pytest.mark.parametrize("bad_high_water", [-1, 2**63, "3"])
+def test_reader_rejects_malformed_high_water(tmp_path: Path, bad_high_water: object) -> None:
+    # The high-water is defensively bounded: a negative, over-ceiling, or non-int value fails closed
+    # with a fixed code rather than letting the reader reason from a bogus mark.
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    with pytest.raises(OutboxError) as raised:
+        read_outbox(
+            file_path=path,
+            prior_cursor=None,
+            config=OutboxReaderConfig(),
+            last_acknowledged_sequence=bad_high_water,  # type: ignore[arg-type]
+        )
+    assert raised.value.code == "MH_OUTBOX_HIGH_WATER"
 
 
 def test_unparseable_rotated_name_fails_closed(tmp_path: Path) -> None:
@@ -762,6 +915,34 @@ def test_ack_read_rejects_corrupt_and_foreign_content(tmp_path: Path) -> None:
     directory = _ack_dir(tmp_path)
     published = directory / "outbox-ack.json"
     published.write_bytes(b'{"not":"an ack"}')
+    os.chmod(published, 0o600)
+    with pytest.raises(OutboxError) as raised:
+        read_outbox_ack(directory, "outbox-ack.json")
+    assert raised.value.code == "MH_OUTBOX_ACK"
+
+
+def test_ack_round_trips_last_sequence_high_water(tmp_path: Path) -> None:
+    # The rotation high-water persists in the ack and reads back atomically; a default ack (None)
+    # still omits it, so the field is backward-compatible.
+    directory = _ack_dir(tmp_path)
+    assert _ack().last_sequence is None  # default: omitted from the canonical bytes
+    ack = _ack(last_sequence=7)
+    write_outbox_ack(directory, "outbox-ack.json", ack)
+    loaded = read_outbox_ack(directory, "outbox-ack.json")
+    assert loaded == ack
+    assert loaded is not None
+    assert loaded.last_sequence == 7
+
+
+@pytest.mark.parametrize("bad_value", [-1, 2**63, 1.5, "5"])
+def test_ack_rejects_malformed_last_sequence(tmp_path: Path, bad_value: object) -> None:
+    # A negative, over-ceiling, non-integer, or string last_sequence in a planted ack is rejected
+    # value-free with the fixed MH_OUTBOX_ACK code (never resuming from a bogus high-water).
+    directory = _ack_dir(tmp_path)
+    published = directory / "outbox-ack.json"
+    planted = json.loads(outbox_ack_bytes(_ack()))
+    planted["last_sequence"] = bad_value
+    published.write_bytes(json.dumps(planted).encode("utf-8"))
     os.chmod(published, 0o600)
     with pytest.raises(OutboxError) as raised:
         read_outbox_ack(directory, "outbox-ack.json")


### PR DESCRIPTION
## What & why

W07 increment **2a** — narrows the outbox reader's documented **top-run rotation-deletion residual** using a persisted high-water mark. Increment 1 (#151) noted that a stateless single-file cursor can't detect deletion of a run of the *topmost* rotated segments (the active file carries no sequence). This slice catches that case for segments the reader **previously observed**. Pure reader + ack change — **no pipeline blast radius**. **Closes #155.** Refs #149.

## The rule
- `read_outbox` gains `last_acknowledged_sequence: int | None = None` (H — the highest rotated sequence observed in prior reads, persisted in the ack; `None` = increment-1 behavior, fully backward-compatible).
- In `_recover_rotation`, **after** the existing contiguity check proves the retained rotations above the cursor S are a clean run `{S+1..M}` (M = highest retained): if `H is not None and M < H`, segments `(M+1..H)` once observed are gone from the top → new **`MH_OUTBOX_LOSS_TOP_RUN_GONE`** (P1, **zero frames, cursor unadvanced**, integer-only/privacy-safe).
- `read_outbox` now **returns** `max_observed_sequence` (M on a rotation read; the cursor's own sequence if nothing is retained above; **`None` on the active-file path**) so a later caller can persist it. The **caller** maintains the monotonic high-water as `max(persisted, output)` — the reader never reads or lowers persisted state.
- `OutboxAckV1` gains `last_sequence` (+ `_ACK_KEYS`) — the durable home per the reader's own docstring. `exclude_none` keeps a legacy ack (no field) parseable; a malformed/negative value is rejected value-free with a fixed code.

**No false positive** (verified): a producer deletes a rotated segment only once the ack covers it (fully consumed). A consumed segment at/below the cursor never reaches this branch — the reader is then in the active file (`_read_same_file`, not rotation recovery) or a higher file, and a missing cursor-file is `ROTATION_GONE`. This branch fires only during rotation recovery where `S ≤ M < H`, so the missing segments are strictly *above* the cursor = genuinely unconsumed.

**Honest limit** (documented, not papered over): segments a producer creates **and** deletes entirely *between* two reads are never observed, so they're absent from the high-water and remain irreducibly undetectable by any cursor-based reader — fully closing that would require the producer to sequence the active file (out of scope).

## Review
A 2-angle adversarial workflow (detection-rule correctness — false-pos/false-neg hunt — and ack/tests/scope) returned **`SAFE-TO-PR`, 0 findings**.

## Tests / gates
+17 tests: true-positive detection; no-false-positive parametrized (H ∈ {None, <M, ==M}); acked-below-deletion → no spurious loss; the increment-1 residual test kept (unchanged no-high-water behavior) + strengthened; `max_observed` padded/unpadded/None-active; malformed-high-water + malformed-ack rejection; ack round-trip. `test` → 5200 passed / 6 skipped / 0 failed; `quality` clean (mypy strict). No URL-substring/CodeQL pitfall (pure integer logic). DCO + co-author trailers, no session locator.

## Scope / next
Reader + ack only. Deferred: **2b** (the high-risk core-runtime pipeline post-commit cursor advance + `CollectorContext`/`CollectorResult` threading — to be designed with the owner before building) and **2c** (the `file_outbox` collector + `OutboxFrameV1`→`event` mapping).

Closes #155
Refs #149
