### PR TITLE
feat(runtime,outbox): W07 2b+2c — durable cursor advance + file_outbox collector (#157)

### DIFF
--- a/src/milhouse/cli/root.py
+++ b/src/milhouse/cli/root.py
@@ -14,6 +14,7 @@ from platformdirs import user_config_path, user_data_path
 
 from milhouse import __version__, storage
 from milhouse.cli import bootstrap, demo, views
+from milhouse.collectors.file_outbox import FileOutboxBinding, register_file_outbox
 from milhouse.collectors.site_canary import SITE_CANARY_TYPE, register_site_canary
 from milhouse.config import (
     ConfigError,
@@ -21,9 +22,15 @@ from milhouse.config import (
     generate_json_schema_bytes,
     load_config,
     load_secret_environment,
+    resolve_config_source_path,
     resolve_runtime_paths,
 )
-from milhouse.config._models import CollectorConfig, MilhouseConfig, TargetConfig
+from milhouse.config._models import (
+    CollectorConfig,
+    FileOutboxCollector,
+    MilhouseConfig,
+    TargetConfig,
+)
 from milhouse.core.clock import SystemClock
 from milhouse.privacy.keys import load_pseudonym_key
 from milhouse.privacy.pseudonym import PrivacyError
@@ -308,15 +315,30 @@ class CollectCommandError(_CodedCommandError):
     exit_code = 1
 
 
-def _new_collect_registry() -> CollectorRegistry:
-    """Build the production first-party collector registry (real HTTP-backed site_canary).
+def _new_collect_registry(config: MilhouseConfig, paths: RuntimePaths) -> CollectorRegistry:
+    """Build the production first-party collector registry (real HTTP-backed site_canary + outbox).
 
     A module-level seam so a network-free test can substitute a registry holding a fake collector;
-    production ``collect`` always calls it with the real registry.
+    production ``collect`` always calls it with the real registry. The ``file_outbox`` factory is
+    PATH-BOUND: each configured ``file_outbox`` collector's relative outbox path is resolved here
+    (symlink-free, from the config directory) into an absolute file, and its parent is the
+    owner-only ``.milhouse`` acknowledgement directory — so the collector, like site_canary with its
+    URL, is bound to a resolved path and never resolves an ambient one. Resolving a path never
+    requires the file to exist, so an outbox that has not been written yet still binds cleanly.
     """
 
     registry = CollectorRegistry()
     register_site_canary(registry)
+    outbox_bindings: dict[str, FileOutboxBinding] = {}
+    for collector in config.collectors:
+        if not isinstance(collector, FileOutboxCollector):
+            continue
+        outbox_path = resolve_config_source_path(collector.path, config_dir=paths.config_dir)
+        outbox_bindings[collector.id] = FileOutboxBinding(
+            outbox_path=outbox_path, ack_directory=outbox_path.parent
+        )
+    if outbox_bindings:
+        register_file_outbox(registry, outbox_paths=outbox_bindings)
     return registry
 
 
@@ -346,7 +368,7 @@ def _build_collect_pipeline(
     rather than in a separate reject guard.
     """
 
-    registry = _new_collect_registry()
+    registry = _new_collect_registry(config, paths)
     barrier = GlobalCommitBarrier(bootstrap.barrier_path(paths))
     return RuntimePipeline(
         mode=mode,
@@ -481,6 +503,13 @@ def _run_collect(
         )
         # The full target set is passed for lookup; the collector filters above scope the run.
         summary = pipeline.run(tuple(collectors), tuple(targets))
+    except ConfigError as error:
+        # Building the pipeline resolves each file_outbox collector's outbox path (symlink-free,
+        # from the config dir). A symlinked/uninspectable path is a CONFIGURATION fault, so surface
+        # it as the exit-2 config-error contract every other config problem uses -- a clean
+        # ``error: config.path.*`` rather than a raw traceback. Like the unknown-collector/target
+        # guards, a bad configured path is a whole-run config error, not a per-collector isolation.
+        raise ConfigCommandError(error) from None
     except (SpoolError, StateError, PipelineError, storage.StorageError) as error:
         # A spool-integrity, control-state, pipeline-construction, or ClickHouse-ownership failure
         # (e.g. DurableSpool reconciliation, a tampered barrier, a crashed-prior-writer orphan, an

--- a/src/milhouse/collectors/__init__.py
+++ b/src/milhouse/collectors/__init__.py
@@ -1,13 +1,22 @@
 """First-party collectors (W05 onward).
 
 Each collector satisfies the runtime :class:`~milhouse.runtime.registry.Collector` protocol and is
-registered against its configuration type through a first-party factory. Increment 2 delivers the
-``site_canary`` collector; :func:`register_site_canary` wires it into a runtime registry.
+registered against its configuration type through a first-party factory. The ``site_canary``
+collector turns one bounded probe into an availability event; the ``file_outbox`` collector (W07)
+turns a compliant ``.milhouse`` outbox into event records, resuming from its durable source cursor.
+Each ``register_*`` helper wires one collector into a runtime registry.
 """
 
 from __future__ import annotations
 
 from milhouse.collectors.errors import CollectorError
+from milhouse.collectors.file_outbox import (
+    FILE_OUTBOX_TYPE,
+    FileOutboxBinding,
+    FileOutboxCollector,
+    file_outbox_factory,
+    register_file_outbox,
+)
 from milhouse.collectors.site_canary import (
     SITE_CANARY_TYPE,
     SiteCanaryCollector,
@@ -17,10 +26,15 @@ from milhouse.collectors.site_canary import (
 )
 
 __all__ = [
+    "FILE_OUTBOX_TYPE",
     "SITE_CANARY_TYPE",
     "CollectorError",
+    "FileOutboxBinding",
+    "FileOutboxCollector",
     "SiteCanaryCollector",
     "build_collector",
+    "file_outbox_factory",
+    "register_file_outbox",
     "register_site_canary",
     "site_canary_factory",
 ]

--- a/src/milhouse/collectors/file_outbox.py
+++ b/src/milhouse/collectors/file_outbox.py
@@ -1,0 +1,418 @@
+"""The ``file_outbox`` collector: incremental ``.milhouse`` outbox frames into event records (W07).
+
+The file-outbox collector turns a compliant append-only ``.milhouse`` outbox
+(``feedback-outbox.jsonl``) into canonical ``event`` records, one per new
+:class:`~milhouse.outbox.frame.OutboxFrameV1`, resuming from its durable source cursor on every run.
+It is bound at construction to the resolved absolute outbox path and the (owner-only ``0700``)
+``.milhouse`` acknowledgement directory -- exactly as the site-canary collector binds its URL and
+HTTP client -- and it NEVER writes: it reads the prior ack to seed the reader's rotation high-water,
+reads the outbox incrementally through the pure :func:`~milhouse.outbox.reader.read_outbox`, maps
+each new frame to a draft, and hands the pipeline a
+:class:`~milhouse.outbox.advance.CursorAdvanceV1` so the pipeline can advance the cursor and write
+the ack STRICTLY AFTER the durable commit (W07 increment 2b). Every durable side effect stays the
+pipeline's.
+
+Three safety properties this collector upholds (the crux of the increment):
+
+* **(a) never advance without a commit.** An empty or unchanged read -- or a read that yielded only
+  rejected lines -- returns NO drafts and NO advance sidecar, so the pipeline commits and advances
+  nothing and the next run re-reads from the same position (idempotent). The cursor advance rides
+  the sidecar and is applied by the pipeline only after ``commit_segment`` returns.
+* **(b) deterministic record identity from the frame bytes.** Each frame's observation coordinate is
+  derived purely from the frame's own canonical bytes (its producer, its declared ``occurred_at``,
+  and a SHA-256 over the whole frame) -- NEVER from the run instant or a counter. The envelope's
+  identity- and content-affecting fields are likewise frame-derived, while the run-instant
+  timestamps it also carries (``observed_at`` / ``ingested_at`` / ``expires_at`` / ``operation_id``
+  / ``collector_run_id``) are excluded from both the record identity and the content projection. So
+  a commit-then-crash-before-advance replay re-reads the same frame and
+  :func:`~milhouse.domain.records.finalize_record` yields the SAME ``record_id`` -- which the
+  spool/exporter delivery ledger collapses. This is THE at-least-once safety property.
+* **(c) a data loss short-circuits.** If :func:`read_outbox` reports a ``loss_signal`` (truncation,
+  a rewritten consumed prefix, a dropped/torn rotated segment, a deleted top-run, or inode reuse),
+  the collector returns NO drafts, a ``failed`` status, and a sidecar carrying only the loss signal.
+  The pipeline commits nothing, advances nothing, and surfaces the fixed loss code -- Milhouse never
+  advances past bytes it cannot prove it read.
+
+Privacy: a rejected or malformed line's raw bytes never leave the reader; the drafts carry only the
+producer's declared, bounded frame fields (mapped through the value-safe record models), and the
+record's target is the collector's configured target, never a raw producer path or the outbox URL.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import cast
+
+from milhouse.collectors.errors import CollectorError
+from milhouse.config._models import CollectorConfig
+from milhouse.config._models import FileOutboxCollector as FileOutboxConfig
+from milhouse.core.canonical import canonical_json_bytes
+from milhouse.core.clock import format_timestamp
+from milhouse.domain.identity import ObservationCoordinateV1
+from milhouse.domain.records import (
+    MAX_DIMENSION_VALUE_BYTES,
+    CollectorDescriptorV1,
+    EventDataV1,
+    RecordDraftV1,
+    ScalarV1,
+    SourceDescriptorV1,
+)
+from milhouse.outbox import (
+    CursorAdvanceV1,
+    OutboxAckV1,
+    OutboxFrameV1,
+    OutboxReaderConfig,
+    read_outbox,
+    read_outbox_ack,
+)
+from milhouse.privacy.redact import LayeredRedactor
+from milhouse.runtime.context import CollectorContext
+from milhouse.runtime.registry import Collector, CollectorRegistry
+from milhouse.runtime.result import CollectorResult
+
+#: The configuration discriminator and registry key for this first-party collector.
+FILE_OUTBOX_TYPE = "file_outbox"
+
+_IMPLEMENTATION_VERSION = "1.0.0"
+_COLLECTOR_TYPE = "file.outbox"
+_SOURCE_TYPE = "source.outbox"
+_RECORD_NAME = "outbox.frame"
+_OBSERVATION_KIND = "outbox.frame"
+#: A fixed v4-shaped namespace for outbox source identity; stable so records stay idempotent across
+#: runs, restores, and config changes (it never folds in a mutable config value or a local path).
+_OUTBOX_NAMESPACE = "mh_ns1_0b17c0d1e2f34a5b8c6d7e8f9a0b1c2d"
+#: Nominal record expiry; true retention is governed by the segment header and storage TTL.
+_NOMINAL_EXPIRY = timedelta(days=30)
+
+
+@dataclass(frozen=True, slots=True)
+class FileOutboxBinding:
+    """The per-collector resolved paths the CLI binds a file-outbox factory to.
+
+    ``outbox_path`` is the resolved absolute outbox file; ``ack_directory`` is the owner-only
+    ``0700`` ``.milhouse`` directory that holds Milhouse's atomic acknowledgement (normally the
+    outbox file's own parent).
+    """
+
+    outbox_path: Path
+    ack_directory: Path
+
+
+class FileOutboxCollector:
+    """A resolved file-outbox collector: its descriptor plus one pure, bounded ``collect`` call."""
+
+    __slots__ = (
+        "_ack_directory",
+        "_ack_filename",
+        "_outbox_path",
+        "_reader_config",
+        "_source_generation_digest",
+        "descriptor",
+    )
+
+    def __init__(
+        self,
+        config: FileOutboxConfig,
+        *,
+        outbox_path: Path,
+        ack_directory: Path,
+    ) -> None:
+        if not isinstance(config, FileOutboxConfig):
+            raise CollectorError("MH_COLLECTOR_CONFIG", "a file_outbox configuration is required")
+        self._outbox_path = outbox_path
+        self._ack_directory = ack_directory
+        self._ack_filename = config.ack_filename
+        self._reader_config = OutboxReaderConfig(
+            max_line_bytes=config.max_line_bytes,
+            max_file_bytes=config.max_file_bytes,
+            rotation_glob=config.rotation_glob,
+            producer_allowlist=tuple(config.producer_allowlist),
+        )
+        self._source_generation_digest = _source_generation_digest()
+        self.descriptor = CollectorDescriptorV1(
+            id=config.id,
+            type=_COLLECTOR_TYPE,
+            implementation_version=_IMPLEMENTATION_VERSION,
+        )
+
+    def collect(self, context: CollectorContext) -> CollectorResult:
+        """Read new outbox frames from the cursor and return event drafts plus a cursor-advance."""
+
+        prior_ack = read_outbox_ack(self._ack_directory, self._ack_filename)
+        high_water = prior_ack.last_sequence if prior_ack is not None else None
+        result = read_outbox(
+            file_path=self._outbox_path,
+            prior_cursor=context.prior_cursor,
+            config=self._reader_config,
+            last_acknowledged_sequence=high_water,
+        )
+
+        if result.loss_signal is not None:
+            # INVARIANT (c): a data loss commits and advances NOTHING. Return no drafts and a
+            # sidecar carrying only the loss signal; the pipeline surfaces ``loss_signal.code`` as
+            # the fixed error and never advances past bytes it cannot prove it read.
+            return CollectorResult(
+                status="failed",
+                drafts=(),
+                diagnostics={"loss": 1},
+                cursor_advance=CursorAdvanceV1(loss_signal=result.loss_signal),
+            )
+
+        rejected = result.diagnostics.rejected_lines
+        if not result.new_frames:
+            # INVARIANT (a): no new frames -> no drafts -> no commit -> no advance. This also covers
+            # a region of only rejected lines: the cursor stays put and they are re-scanned (and
+            # re-counted) idempotently next run, advancing only once a valid frame lets one commit.
+            return CollectorResult(
+                status="ok",
+                drafts=(),
+                diagnostics={"frames": 0, "rejected": rejected},
+            )
+
+        drafts = tuple(
+            self._draft(context, frame, offset=offset)
+            for frame, offset in zip(result.new_frames, result.frame_offsets, strict=True)
+        )
+
+        # The reader guarantees a non-loss read with frames carries an advanced position + its
+        # encoded string; build the ack the pipeline writes AFTER it commits and advances.
+        position = result.next_position
+        next_position_string = result.next_position_string
+        assert position is not None and next_position_string is not None
+        ack = OutboxAckV1(
+            producer_id=context.collector.id,
+            file_device=position.device,
+            file_inode=position.inode,
+            committed_offset=position.offset,
+            content_sha256=position.content_sha256,
+            # The reader yields PARSED frames, not raw line bytes, so a raw last-line digest is not
+            # available here; the field is optional and unread, so it is left unset rather than
+            # populated with a differently-derived value that could be mistaken for a raw-line hash.
+            last_line_sha256=None,
+            # The collector owns the monotonic rotation high-water fold (it read the prior ack), so
+            # the ack the pipeline writes verbatim never regresses ``last_sequence``.
+            last_sequence=_fold_high_water(high_water, result.max_observed_sequence),
+            acknowledged_at=context.now,
+        )
+        sidecar = CursorAdvanceV1(
+            next_position=next_position_string,
+            ack_directory=str(self._ack_directory),
+            ack_filename=self._ack_filename,
+            ack=ack,
+            max_observed_sequence=result.max_observed_sequence,
+        )
+        return CollectorResult(
+            status="ok",
+            drafts=drafts,
+            diagnostics={
+                "frames": len(drafts),
+                "rejected": rejected,
+                "rotations": result.diagnostics.rotations_crossed,
+            },
+            cursor_advance=sidecar,
+        )
+
+    def _draft(
+        self, context: CollectorContext, frame: OutboxFrameV1, *, offset: int
+    ) -> RecordDraftV1:
+        # INVARIANT (b): the observation coordinate -- the ONLY per-frame varying part of the record
+        # identity -- is derived purely from the frame BYTES, never from ``context.now`` or a
+        # counter, so a replay of the same frame re-derives the same record_id and the delivery
+        # ledger dedups it. Its parts are the producer, the producer's declared occurred_at, a
+        # SHA-256 over the whole frame, AND the frame's per-file byte ``offset`` -- the plan
+        # section 4.9 "file identity plus byte offset" FALLBACK identity. The offset is what
+        # DISTINGUISHES two genuinely distinct but byte-identical frames (same producer, same-
+        # millisecond occurred_at, identical body -> identical content digest): they sit at
+        # different offsets, so they get distinct record_ids and ReplacingMergeTree does NOT merge
+        # them. The offset is stable across a compliant rotation (a rename never moves bytes) and a
+        # restore (same bytes), so invariant (b) holds: the crash-before-advance replay re-reads the
+        # same frame at the same offset -> same id. Residual: two byte-identical frames at the SAME
+        # offset in two DIFFERENT files (per-file offset) would still collide -- an accepted edge.
+        now = context.now
+        stamp = format_timestamp(now)
+        digest = _frame_digest(frame)
+        observation = ObservationCoordinateV1(
+            kind=_OBSERVATION_KIND,
+            parts={
+                "producer": frame.producer_id,
+                "occurred_at": format_timestamp(frame.occurred_at),
+                "offset": offset,
+                "content": digest,
+            },
+        )
+        source = SourceDescriptorV1(
+            id=context.collector.id,
+            type=_SOURCE_TYPE,
+            producer="collector",
+            observation_namespace_id=_OUTBOX_NAMESPACE,
+            source_generation_digest=self._source_generation_digest,
+            observation=observation,
+        )
+        # PRIVACY: ``frame.data`` is UNTRUSTED producer input. The pipeline's defense-in-depth pass
+        # only re-scans enumerated free-text leaves (for an event, just ``message``) and explicitly
+        # does NOT rewrite structured attributes -- the collector is the PRIMARY redaction authority
+        # for structured fields. So the collector MUST redact these string values here, or a
+        # producer URL / email / token in ``frame.data`` would reach the durable record (and
+        # ClickHouse in full mode) unredacted. Redaction is deterministic for a fixed key, and
+        # ``data`` is excluded from the record identity and derives the content hash only after
+        # redaction, so this never
+        # perturbs invariant (b). (The identity digest above hashes the RAW frame, but that is a
+        # one-way SHA-256 folded into an opaque record_id; no raw byte is ever stored or surfaced.)
+        data = EventDataV1(
+            category=frame.kind,
+            status=frame.actionability,
+            attributes=_redact_attributes(frame.data, redactor=context.redactor),
+        )
+        return RecordDraftV1(
+            record_type="event",
+            name=_RECORD_NAME,
+            # occurred_at is the producer's declared instant (frame-derived, identity-stable); the
+            # observed/ingested/expiry instants are the run instant and never affect record identity
+            # or the content hash.
+            occurred_at=frame.occurred_at,
+            observed_at=now,
+            ingested_at=now,
+            expires_at=now + _NOMINAL_EXPIRY,
+            operation_id=f"{context.collector.id}:{stamp}",
+            collector_run_id=f"{context.collector.id}:{stamp}",
+            scope="target",
+            source=source,
+            collector=context.collector,
+            target=context.target,
+            severity="info",
+            trust_level="authenticated",
+            privacy_class="internal",
+            redaction_version="r1-e1",
+            data=data,
+        )
+
+
+def _redact_attributes(
+    attributes: Mapping[str, ScalarV1], *, redactor: LayeredRedactor
+) -> dict[str, ScalarV1]:
+    """Redact the free-text string values of untrusted producer attributes, preserving structure.
+
+    The collector is the primary redaction authority for structured fields (the pipeline's pass does
+    not rewrite attributes). Every string value is run through the layered redactor (URLs, emails,
+    paths, and known secrets become fixed markers) and then CLAMPED to the dimension-value byte
+    bound; non-string scalars pass through unchanged. The keys are Milhouse-validated dimension
+    keys, not producer free text, so they are left as-is.
+
+    Why the clamp is load-bearing: a producer value is bounded to ``MAX_DIMENSION_VALUE_BYTES`` at
+    parse, but redaction EXPANDS a short token into a ~24-byte marker, so a value densely packed
+    with redactable tokens can redact past that bound (the redactor caps only at its own larger
+    limit). Handing such a value to ``EventDataV1.attributes`` -- which re-validates at the
+    dimension bound -- would RAISE, so the frame would never commit and the cursor would never
+    advance: the identical frame would re-fail every run, a PERMANENT STALL of the whole outbox that
+    an untrusted producer could trigger (a denial-of-ingestion). Clamping the already-redacted value
+    keeps every attribute within the bound, so ``EventDataV1`` never raises. The clamp only trims
+    redaction-marker tail text (never raw producer data, which redaction already removed).
+    """
+
+    return {
+        key: (_clamp_dimension_value(redactor.redact(value).value) if type(value) is str else value)
+        for key, value in attributes.items()
+    }
+
+
+def _clamp_dimension_value(value: str) -> str:
+    """Truncate a string to at most ``MAX_DIMENSION_VALUE_BYTES`` UTF-8 bytes on a char boundary.
+
+    The bound is imported from the domain records module (never hardcoded), so it tracks the
+    ``DimensionsV1`` validation exactly. Truncation is byte-bounded but UTF-8-safe
+    (``errors="ignore"`` drops only the partial trailing multibyte sequence), and a fixed marker
+    signals the clamp while staying inside the budget.
+    """
+
+    encoded = value.encode("utf-8")
+    if len(encoded) <= MAX_DIMENSION_VALUE_BYTES:
+        return value
+    marker = "[mh:clamp]"
+    budget = MAX_DIMENSION_VALUE_BYTES - len(marker)  # marker is pure ASCII, so len == byte length
+    return encoded[:budget].decode("utf-8", errors="ignore") + marker
+
+
+def _frame_digest(frame: OutboxFrameV1) -> str:
+    """A SHA-256 over the frame's whole canonical projection: deterministic from the frame bytes."""
+
+    return hashlib.sha256(
+        canonical_json_bytes(frame.model_dump(mode="python", exclude_none=True))
+    ).hexdigest()
+
+
+def _fold_high_water(prior: int | None, observed: int | None) -> int | None:
+    """Fold the durable rotation high-water forward monotonically: ``max(prior, observed)``."""
+
+    if observed is None:
+        return prior
+    if prior is None:
+        return observed
+    return max(prior, observed)
+
+
+def _source_generation_digest() -> str:
+    """A stable 64-hex source-generation digest for the outbox collector's source lineage.
+
+    It binds ONLY the collector type and implementation version -- both constant -- so it never
+    changes with a config edit or a machine-local path, keeping every already-committed frame's
+    record identity stable across config changes, restores, and hosts.
+    """
+
+    material = f"{_COLLECTOR_TYPE}\x00{_IMPLEMENTATION_VERSION}"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def build_collector(
+    config: FileOutboxConfig, *, outbox_path: Path, ack_directory: Path
+) -> FileOutboxCollector:
+    """Build one file-outbox collector bound to its resolved outbox path and ack directory."""
+
+    return FileOutboxCollector(config, outbox_path=outbox_path, ack_directory=ack_directory)
+
+
+def file_outbox_factory(
+    outbox_paths: dict[str, FileOutboxBinding],
+) -> Callable[[CollectorConfig], Collector]:
+    """Build the path-bound first-party factory dispatching each config id to its resolved binding.
+
+    ``outbox_paths`` maps each configured ``file_outbox`` collector id to its resolved
+    :class:`FileOutboxBinding`. The registry hands the returned factory the shared collector-config
+    union; a config whose id is unbound -- or that is not a file_outbox configuration -- fails
+    closed with ``MH_COLLECTOR_CONFIG`` rather than reading an unresolved relative path.
+    """
+
+    def factory(config: CollectorConfig) -> Collector:
+        binding = outbox_paths.get(str(getattr(config, "id", "")))
+        if binding is None:
+            raise CollectorError(
+                "MH_COLLECTOR_CONFIG", "no resolved outbox path is bound for this collector"
+            )
+        return build_collector(
+            cast(FileOutboxConfig, config),
+            outbox_path=binding.outbox_path,
+            ack_directory=binding.ack_directory,
+        )
+
+    return factory
+
+
+def register_file_outbox(
+    registry: CollectorRegistry, *, outbox_paths: dict[str, FileOutboxBinding]
+) -> None:
+    """Register the file-outbox factory, path-bound per collector id, into a runtime registry."""
+
+    registry.register(FILE_OUTBOX_TYPE, file_outbox_factory(outbox_paths))
+
+
+__all__ = [
+    "FILE_OUTBOX_TYPE",
+    "FileOutboxBinding",
+    "FileOutboxCollector",
+    "build_collector",
+    "file_outbox_factory",
+    "register_file_outbox",
+]

--- a/src/milhouse/outbox/__init__.py
+++ b/src/milhouse/outbox/__init__.py
@@ -18,6 +18,7 @@ from milhouse.outbox.ack import (
     read_outbox_ack,
     write_outbox_ack,
 )
+from milhouse.outbox.advance import CursorAdvanceV1
 from milhouse.outbox.cursor import (
     OUTBOX_POSITION_VERSION,
     OutboxPosition,
@@ -44,6 +45,7 @@ __all__ = [
     "MAX_ACK_BYTES",
     "MAX_OUTBOX_FRAME_BYTES",
     "OUTBOX_POSITION_VERSION",
+    "CursorAdvanceV1",
     "OutboxAckV1",
     "OutboxActionabilityV1",
     "OutboxDiagnostics",

--- a/src/milhouse/outbox/advance.py
+++ b/src/milhouse/outbox/advance.py
@@ -1,0 +1,88 @@
+"""The outbox collector's post-commit cursor-advance sidecar (W07 increment 2b, plan section 4.9).
+
+A cursor-bearing collector (the ``file_outbox`` collector today) cannot advance its own durable
+checkpoint: the pipeline owns every durable side effect, and a source cursor may advance ONLY in a
+transaction that references an already-committed segment (pipeline rule 9). So the collector returns
+a :class:`CursorAdvanceV1` alongside its drafts, and the pipeline -- strictly AFTER the segment is
+durably committed -- advances the cursor and writes the acknowledgement from it. Non-cursor
+collectors leave the sidecar ``None`` and are entirely unaffected.
+
+The sidecar has exactly two shapes, and :meth:`~CursorAdvanceV1.__post_init__` enforces that they
+are mutually exclusive and complete:
+
+* **An advance** (``loss_signal is None``): ``next_position`` is the opaque encoded cursor position
+  the pipeline hands to :func:`~milhouse.state.cursors.advance_cursor`, and ``ack`` /
+  ``ack_directory`` / ``ack_filename`` are the fully-formed acknowledgement the pipeline writes with
+  :func:`~milhouse.outbox.ack.write_outbox_ack` once the cursor has advanced. The collector, which
+  already read the prior ack to seed the reader's rotation high-water, owns the monotonic
+  ``last_sequence`` fold inside ``ack`` -- the pipeline writes the blob verbatim.
+* **A data-loss short-circuit** (``loss_signal`` set): the read found an un-recoverable
+  discontinuity, so the collector returned NO drafts; the pipeline commits and advances NOTHING and
+  surfaces ``loss_signal.code`` as the collector's fixed error code. ``next_position`` stays
+  ``None`` so the post-commit hook is a no-op even though (by contract) no segment was committed.
+
+Everything here is internal control metadata handed back to the trusted pipeline, never a spooled
+record: it carries a machine-local ack directory path and the privacy-safe cursor/ack scalars, but
+never a producer payload byte.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from milhouse.outbox.ack import OutboxAckV1
+from milhouse.outbox.errors import OutboxError
+from milhouse.outbox.reader import OutboxLossSignal
+
+
+@dataclass(frozen=True, slots=True)
+class CursorAdvanceV1:
+    """One collector's post-commit cursor-advance instruction, or a data-loss short-circuit."""
+
+    next_position: str | None = None
+    ack_directory: str | None = None
+    ack_filename: str | None = None
+    ack: OutboxAckV1 | None = None
+    max_observed_sequence: int | None = None
+    loss_signal: OutboxLossSignal | None = None
+
+    def __post_init__(self) -> None:
+        # Validated in BOTH shapes: a loss sidecar must not carry a nonsense high-water either.
+        if self.max_observed_sequence is not None and (
+            type(self.max_observed_sequence) is not int or self.max_observed_sequence < 0
+        ):
+            raise OutboxError(
+                "MH_OUTBOX_ADVANCE", "the observed rotation sequence must be a non-negative integer"
+            )
+        if self.loss_signal is not None:
+            if not isinstance(self.loss_signal, OutboxLossSignal):
+                raise OutboxError(
+                    "MH_OUTBOX_ADVANCE", "a loss signal must be an outbox loss signal"
+                )
+            # A loss short-circuits: NOTHING advances, so the advance fields must all be absent.
+            if (
+                self.next_position is not None
+                or self.ack is not None
+                or self.ack_directory is not None
+                or self.ack_filename is not None
+            ):
+                raise OutboxError(
+                    "MH_OUTBOX_ADVANCE", "a loss short-circuit must carry no advance instruction"
+                )
+            return
+        # An advance MUST be complete: the pipeline advances the cursor and writes the ack together.
+        if (
+            type(self.next_position) is not str
+            or not self.next_position
+            or type(self.ack_directory) is not str
+            or not self.ack_directory
+            or type(self.ack_filename) is not str
+            or not self.ack_filename
+            or not isinstance(self.ack, OutboxAckV1)
+        ):
+            raise OutboxError(
+                "MH_OUTBOX_ADVANCE", "a cursor advance requires a position, ack, and ack location"
+            )
+
+
+__all__ = ["CursorAdvanceV1"]

--- a/src/milhouse/outbox/reader.py
+++ b/src/milhouse/outbox/reader.py
@@ -161,6 +161,16 @@ class OutboxReadResult:
     monotonic rotation high-water and advances it as ``max(persisted, max_observed_sequence)``, then
     threads it back as ``read_outbox(..., last_acknowledged_sequence=...)`` so a later read can flag
     a deleted top-run of rotated segments (``MH_OUTBOX_LOSS_TOP_RUN_GONE``).
+
+    ``frame_offsets`` is a parallel tuple (same length and order as ``new_frames``) carrying each
+    frame's BYTE OFFSET -- the start byte of its line WITHIN ITS OWN physical file (0-based). It is
+    the plan-section-4.9 "file identity plus byte offset" FALLBACK identity a consumer folds into a
+    frame's record identity so two genuinely distinct but byte-identical frames (same producer,
+    same-millisecond ``occurred_at``, identical body) do not collapse to one record. The offset is
+    stable across a compliant rotation (a rename never moves bytes) and a restore (the same bytes),
+    so a crash-before-advance replay re-reads the same frame at the same offset and re-derives the
+    same identity. It is per-file, so a frame at the same offset in two DIFFERENT files is the one
+    residual collision (see the collector).
     """
 
     new_frames: tuple[OutboxFrameV1, ...]
@@ -169,6 +179,7 @@ class OutboxReadResult:
     loss_signal: OutboxLossSignal | None
     diagnostics: OutboxDiagnostics
     max_observed_sequence: int | None = None
+    frame_offsets: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -181,6 +192,8 @@ class _FileRead:
 @dataclass(frozen=True, slots=True)
 class _Parsed:
     frames: list[OutboxFrameV1] = field(default_factory=list)
+    #: The per-file byte offset of each emitted frame, kept in lockstep with ``frames``.
+    offsets: list[int] = field(default_factory=list)
     rejected: Counter[str] = field(default_factory=Counter)
 
 
@@ -262,15 +275,27 @@ def _iter_complete_lines(region: bytes) -> list[bytes]:
     return [part + _LF for part in parts]
 
 
-def _parse_region(region: bytes, config: OutboxReaderConfig, into: _Parsed) -> None:
+def _parse_region(
+    region: bytes, config: OutboxReaderConfig, into: _Parsed, *, base_offset: int
+) -> None:
     """Parse every complete line in ``region``, rejecting oversized/invalid/denied lines by code.
 
     A rejected line's raw bytes are never captured: the oversize branch never parses, and the parse
     branch discards the value-safe :class:`OutboxError` after reading only its fixed ``.code``.
+
+    ``base_offset`` is the byte offset of ``region``'s first byte WITHIN ITS OWN physical file (the
+    cursor offset for the active file, ``0`` for a whole rotated file), so each emitted frame
+    records ``base_offset + <bytes of prior lines in this region>`` -- its start byte in that file.
+    The
+    running total advances over EVERY line, including rejected ones, so a valid line after a skipped
+    one still gets its true file offset.
     """
 
     allowlist = config.producer_allowlist
+    running = 0
     for line in _iter_complete_lines(region):
+        line_offset = base_offset + running
+        running += len(line)
         if len(line) > config.max_line_bytes:
             into.rejected[_LINE_OVERSIZE_CODE] += 1
             continue
@@ -284,6 +309,7 @@ def _parse_region(region: bytes, config: OutboxReaderConfig, into: _Parsed) -> N
             into.rejected[_PRODUCER_DENIED_CODE] += 1
             continue
         into.frames.append(frame)
+        into.offsets.append(line_offset)
 
 
 def _loss(
@@ -323,8 +349,7 @@ def _loss(
 
 
 def _success(
-    frames: list[OutboxFrameV1],
-    rejected: Counter[str],
+    parsed: _Parsed,
     *,
     next_position: OutboxPosition,
     bytes_consumed: int,
@@ -333,20 +358,21 @@ def _success(
     max_observed_sequence: int | None = None,
 ) -> OutboxReadResult:
     diagnostics = OutboxDiagnostics(
-        frames_emitted=len(frames),
-        rejected_lines=sum(rejected.values()),
-        rejected_codes=MappingProxyType(dict(rejected)),
+        frames_emitted=len(parsed.frames),
+        rejected_lines=sum(parsed.rejected.values()),
+        rejected_codes=MappingProxyType(dict(parsed.rejected)),
         bytes_consumed=bytes_consumed,
         rotations_crossed=rotations_crossed,
         torn_tail_bytes=torn_tail_bytes,
     )
     return OutboxReadResult(
-        new_frames=tuple(frames),
+        new_frames=tuple(parsed.frames),
         next_position=next_position,
         next_position_string=encode_outbox_position(next_position),
         loss_signal=None,
         diagnostics=diagnostics,
         max_observed_sequence=max_observed_sequence,
+        frame_offsets=tuple(parsed.offsets),
     )
 
 
@@ -386,7 +412,12 @@ def read_outbox(
     prior_string = prior_cursor.position if prior_cursor is not None else None
     active = _read_regular_file(file_path, config.max_file_bytes)
 
-    if prior is None or (active.device, active.inode) == (prior.device, prior.inode):
+    if prior is None:
+        # No cursor yet (never committed for this source): the WHOLE retained stream is unread, so a
+        # first read must ingest any retained rotated files too -- reading only the active file
+        # would silently drop frames in files that rotated before this first read (permanent loss).
+        return _read_from_start(file_path, active, config)
+    if (active.device, active.inode) == (prior.device, prior.inode):
         return _read_same_file(active, prior, config)
     assert prior_string is not None
     return _recover_rotation(
@@ -421,7 +452,7 @@ def _read_same_file(
         complete_end = start
     region = content[start:complete_end]
     parsed = _Parsed()
-    _parse_region(region, config, parsed)
+    _parse_region(region, config, parsed, base_offset=start)
     next_position = OutboxPosition(
         device=active.device,
         inode=active.inode,
@@ -429,12 +460,107 @@ def _read_same_file(
         content_sha256=_sha256_hex(content[:complete_end]),
     )
     return _success(
-        parsed.frames,
-        parsed.rejected,
+        parsed,
         next_position=next_position,
         bytes_consumed=complete_end - start,
         rotations_crossed=0,
         torn_tail_bytes=len(content) - complete_end,
+    )
+
+
+def _read_from_start(
+    file_path: str | Path, active: _FileRead, config: OutboxReaderConfig
+) -> OutboxReadResult:
+    """First read with NO cursor: ingest the whole retained chain, not only the active file.
+
+    With no cursor every retained byte is unread, so -- when a ``rotation_glob`` is set -- the
+    reader discovers the retained rotated files and reads them (numeric order, lowest first) then
+    the active file, exactly as :func:`_recover_rotation` does past a cursor but from offset 0 in
+    each rotated file. This closes the silent-loss window where run 1 committed nothing (cursor
+    still ``None``) and the outbox rotated before run 2: the older-but-retained frames are ingested.
+
+    Fail-closed, mirroring the cursor path: the retained rotated sequences must be a CONTIGUOUS run
+    (a gap is a rotated segment deleted out of order -- nothing is acked yet, so a compliant
+    producer would not have -- an unrecoverable ``MH_OUTBOX_LOSS_ROTATION_GONE``); each rotated file
+    must be
+    whole (a torn rotated tail is ``MH_OUTBOX_LOSS_ROTATED_TORN``), and an unparseable/ambiguous
+    rotated name fails closed as it does under a cursor. A loss with no cursor is reported against a
+    synthetic zero position of the active file. With no ``rotation_glob``, or none retained, the
+    active file is the whole stream so far and is read from its start.
+    """
+
+    if config.rotation_glob is None:
+        return _read_same_file(active, None, config)
+    directory = lexical_absolute_path(file_path).parent
+    by_sequence, discovery_loss = _discover_rotations(directory, active, config)
+    if discovery_loss is not None:
+        return _loss_no_cursor(active, discovery_loss)
+    if not by_sequence:
+        return _read_same_file(active, None, config)
+
+    max_observed = max(by_sequence)
+    rotated = sorted(by_sequence)
+    if rotated != list(range(rotated[0], rotated[0] + len(rotated))):
+        return _loss_no_cursor(
+            active, "MH_OUTBOX_LOSS_ROTATION_GONE", max_observed_sequence=max_observed
+        )
+
+    regions: list[bytes] = []
+    bytes_consumed = 0
+    for sequence in rotated:
+        read = by_sequence[sequence]
+        if _has_torn_tail(read.content):
+            return _loss_no_cursor(
+                active, "MH_OUTBOX_LOSS_ROTATED_TORN", max_observed_sequence=max_observed
+            )
+        regions.append(read.content)
+        bytes_consumed += len(read.content)
+
+    complete_end = active.content.rfind(_LF) + 1
+    regions.append(active.content[:complete_end])
+    bytes_consumed += complete_end
+
+    parsed = _Parsed()
+    for region in regions:
+        # Each region is a whole rotated file or the active file's complete prefix, so every frame's
+        # offset is measured from its own file's start (base_offset 0), matching the per-file offset
+        # a later read of the same file (rotated or not) reproduces.
+        _parse_region(region, config, parsed, base_offset=0)
+
+    next_position = OutboxPosition(
+        device=active.device,
+        inode=active.inode,
+        offset=complete_end,
+        content_sha256=_sha256_hex(active.content[:complete_end]),
+    )
+    return _success(
+        parsed,
+        next_position=next_position,
+        bytes_consumed=bytes_consumed,
+        rotations_crossed=len(rotated),
+        torn_tail_bytes=len(active.content) - complete_end,
+        max_observed_sequence=max_observed,
+    )
+
+
+def _loss_no_cursor(
+    active: _FileRead, code: str, *, max_observed_sequence: int | None = None
+) -> OutboxReadResult:
+    """Report a first-read (no cursor) data loss against a synthetic zero position of the file.
+
+    A loss signal is anchored on a cursor position; with no cursor, the anchor is the active file's
+    identity at offset 0 with the empty-prefix hash -- privacy-safe (integers + a fixed digest), and
+    the collector reads only ``loss_signal.code`` from it.
+    """
+
+    synthetic = OutboxPosition(
+        device=active.device, inode=active.inode, offset=0, content_sha256=_sha256_hex(b"")
+    )
+    return _loss(
+        code,
+        synthetic,
+        encode_outbox_position(synthetic),
+        max_observed_sequence=max_observed_sequence,
     )
 
 
@@ -576,8 +702,11 @@ def _recover_rotation(
             max_observed_sequence=max_observed,
         )
 
-    regions: list[bytes] = [cursor_file.content[prior.offset :]]
-    bytes_consumed = len(regions[0])
+    # Each region is paired with its base offset WITHIN ITS OWN file: the cursor file resumes at
+    # ``prior.offset``, every rotated file above and the active file start at 0. So a frame keeps
+    # its per-file offset whether it is read here (mid-rotation) or later from its own file.
+    regions: list[tuple[bytes, int]] = [(cursor_file.content[prior.offset :], prior.offset)]
+    bytes_consumed = len(regions[0][0])
     for sequence in above:
         read = by_sequence[sequence]
         if _has_torn_tail(read.content):
@@ -588,18 +717,18 @@ def _recover_rotation(
                 observed_size=len(read.content),
                 max_observed_sequence=max_observed,
             )
-        regions.append(read.content)
+        regions.append((read.content, 0))
         bytes_consumed += len(read.content)
 
     complete_end = active.content.rfind(_LF) + 1
     active_region = active.content[:complete_end]
-    regions.append(active_region)
+    regions.append((active_region, 0))
     bytes_consumed += complete_end
 
     # Phase B: parse every region now that the chain is proven continuous.
     parsed = _Parsed()
-    for region in regions:
-        _parse_region(region, config, parsed)
+    for region, base_offset in regions:
+        _parse_region(region, config, parsed, base_offset=base_offset)
 
     next_position = OutboxPosition(
         device=active.device,
@@ -608,8 +737,7 @@ def _recover_rotation(
         content_sha256=_sha256_hex(active.content[:complete_end]),
     )
     return _success(
-        parsed.frames,
-        parsed.rejected,
+        parsed,
         next_position=next_position,
         bytes_consumed=bytes_consumed,
         rotations_crossed=1 + len(above),

--- a/src/milhouse/runtime/context.py
+++ b/src/milhouse/runtime/context.py
@@ -19,6 +19,7 @@ from milhouse.domain.records import CollectorDescriptorV1, TargetDescriptorV1
 from milhouse.privacy.redact import LayeredRedactor
 from milhouse.runtime.errors import PipelineError
 from milhouse.spooling.reader import INSTALLATION_ID_PATTERN
+from milhouse.state.cursors import SourceCursor
 
 # Matches the collector configuration bound (``_CollectorBase.request_timeout_seconds``): a request
 # budget is a positive, bounded number of seconds so a collector cannot be handed an unbounded one.
@@ -36,6 +37,11 @@ class CollectorContext:
     target: TargetDescriptorV1 | None
     request_timeout_seconds: int
     redactor: LayeredRedactor
+    #: The collector's current durable source cursor, or ``None`` if it has never advanced (W07
+    #: increment 2b). A cursor-bearing collector resumes its incremental read from here; every
+    #: non-cursor collector ignores it. The pipeline reads it with
+    #: :func:`~milhouse.state.cursors.read_cursor` before building this context.
+    prior_cursor: SourceCursor | None = None
 
     def __post_init__(self) -> None:
         # Normalize and re-validate the run instant to an aware UTC millisecond value; the injected
@@ -72,6 +78,10 @@ class CollectorContext:
         if type(self.redactor) is not LayeredRedactor:
             raise PipelineError(
                 "MH_RUNTIME_CONTEXT_REDACTOR", "a layered redactor handle is required"
+            )
+        if self.prior_cursor is not None and not isinstance(self.prior_cursor, SourceCursor):
+            raise PipelineError(
+                "MH_RUNTIME_CONTEXT_CURSOR", "the prior cursor must be a source cursor or absent"
             )
 
 

--- a/src/milhouse/runtime/pipeline.py
+++ b/src/milhouse/runtime/pipeline.py
@@ -66,6 +66,7 @@ from milhouse.domain.records import (
     TargetDescriptorV1,
     finalize_record,
 )
+from milhouse.outbox import CursorAdvanceV1, write_outbox_ack
 from milhouse.privacy.redact import LayeredRedactor
 from milhouse.runtime.alerting import (
     CANARY_STATE_RULE_VERSION,
@@ -90,8 +91,11 @@ from milhouse.spooling.reader import INSTALLATION_ID_PATTERN
 from milhouse.state import (
     ControlDatabase,
     GlobalCommitBarrier,
+    SourceCursor,
     advance_alert_state,
+    advance_cursor,
     read_alert_state,
+    read_cursor,
 )
 from milhouse.storage import CLICKHOUSE_EXPORTER_ID
 
@@ -490,6 +494,12 @@ class RuntimePipeline:
             "the resolved collector id does not match its configuration",
         )
         target = _target_descriptor(config, target_by_id)
+        # Read the collector's durable source cursor BEFORE building the context so a cursor-bearing
+        # collector resumes its incremental read from it (generic opt-in: a non-cursor collector
+        # ignores it, and this read never creates a row, so its runtime behaviour is unchanged). The
+        # SAME snapshot's revision is the compare-and-set base for the post-commit advance below, so
+        # the frontier can only advance from the position this run actually read.
+        prior_cursor = read_cursor(self._control, source=str(config.id))
         context = CollectorContext(
             now=now,
             installation_id=self._installation_id,
@@ -497,6 +507,7 @@ class RuntimePipeline:
             target=target,
             request_timeout_seconds=int(getattr(config, "request_timeout_seconds", 30)),
             redactor=self._redactor,
+            prior_cursor=prior_cursor,
         )
         result = collector.collect(context)
         if not isinstance(result, CollectorResult):
@@ -507,6 +518,15 @@ class RuntimePipeline:
             )
         item.status = result.status
         item.drafts_produced = len(result.drafts)
+        advance = result.cursor_advance
+        if advance is not None and advance.loss_signal is not None:
+            # INVARIANT (c): a data-loss read commits NOTHING and advances NOTHING. Surface the
+            # fixed loss code as the collector's error, and return BEFORE the availability sample so
+            # a loss never becomes an alert failure sample (firing on a loss is a deferred
+            # follow-up, not this slice). The reader guarantees no drafts accompany a loss.
+            item.status = "failed"
+            item.error_code = advance.loss_signal.code
+            return
         if result.status == "failed":
             # A collector that failed with no drafts is a failure sample with no privacy-safe
             # record to cite as evidence. The site_canary no longer reaches this path (its probe
@@ -514,17 +534,69 @@ class RuntimePipeline:
             # collector, whose transition then defers to the first evidence-bearing failure.
             availability[str(config.id)] = ("failure", None)
         if not result.drafts:
+            # INVARIANT (a): no drafts -> no commit -> no advance. An empty/unchanged outbox read
+            # leaves the cursor untouched, so the next run re-reads from the same position -- an
+            # idempotent no-op, never a silent skip past unread bytes.
             return
         records = tuple(self._finalize(draft) for draft in result.drafts)
         header, frames = self._build_segment(str(config.id), records, now=context.now)
         committed = spool.commit_segment(header, frames, committed_at=context.now)
         item.records_committed = committed.record_count
         item.batch_id = committed.batch_id
+        # INVARIANT (a): the cursor advances STRICTLY AFTER the segment is durably committed above.
+        if advance is not None and advance.next_position is not None:
+            self._advance_source_cursor(
+                item, advance, source=str(config.id), prior_cursor=prior_cursor, now=now
+            )
         # Capture the committed availability record as the alert sample; its record id is the
         # evidence a firing/resolution transition cites.
         sample = _availability_sample(records)
         if sample is not None:
             availability[str(config.id)] = sample
+
+    def _advance_source_cursor(
+        self,
+        item: _CollectorWork,
+        advance: CursorAdvanceV1,
+        *,
+        source: str,
+        prior_cursor: SourceCursor | None,
+        now: datetime,
+    ) -> None:
+        """Advance the durable cursor and write the ack, in isolation, AFTER the segment committed.
+
+        The commit-before-frontier ordering the source cursors and the alert-rule state already use
+        (see :meth:`_evaluate_rule`): the segment is durably committed, so this only moves the
+        checkpoint forward against ``committed.batch_id``. The cursor is the PRIMARY checkpoint and
+        is advanced FIRST -- under a revision compare-and-set against the exact ``prior_cursor``
+        this run read -- then the auxiliary ack (whose ``last_sequence`` high-water the collector
+        folded monotonically) is written. Any failure here is isolated exactly like an alert
+        advance: it NEVER unwinds the durable commit and NEVER aborts the run; it records a fixed
+        code, and the un-advanced cursor makes the next run re-read and re-commit the same frames --
+        which, because the frame->record identity is deterministic (invariant (b)), the downstream
+        delivery ledger collapses. This is commit-before-frontier AT-LEAST-ONCE, not exactly-once.
+        """
+
+        assert advance.next_position is not None  # guarded by the caller
+        try:
+            advance_cursor(
+                self._control,
+                source=source,
+                position=advance.next_position,
+                batch_id=item.batch_id or "",
+                now=now,
+                expected_revision=prior_cursor.revision if prior_cursor is not None else 0,
+            )
+            if (
+                advance.ack is not None
+                and advance.ack_directory is not None
+                and advance.ack_filename is not None
+            ):
+                write_outbox_ack(advance.ack_directory, advance.ack_filename, advance.ack)
+        except Exception as error:
+            # The commit is durable; a failed advance is retried next run (at-least-once). Record
+            # the fixed code without touching the committed segment or the other collectors.
+            item.error_code = normalize_error(error).code
 
     def _drive_alerts(
         self,

--- a/src/milhouse/runtime/result.py
+++ b/src/milhouse/runtime/result.py
@@ -17,6 +17,7 @@ from typing import Literal
 from milhouse.core.canonical import MAX_CANONICAL_INT
 from milhouse.core.immutable import freeze_dict
 from milhouse.domain.records import RecordDraftV1
+from milhouse.outbox.advance import CursorAdvanceV1
 from milhouse.runtime.errors import PipelineError
 
 CollectorStatus = Literal["ok", "failed"]
@@ -29,11 +30,21 @@ _DIAGNOSTIC_KEY = re.compile(r"[a-z][a-z0-9_]{0,63}", flags=re.ASCII)
 
 @dataclass(frozen=True, slots=True)
 class CollectorResult:
-    """One collector's ordered drafts, run status, and privacy-safe diagnostic counts."""
+    """One collector's ordered drafts, run status, and privacy-safe diagnostic counts.
+
+    ``cursor_advance`` is the OPTIONAL post-commit sidecar a cursor-bearing collector (the
+    ``file_outbox`` collector) returns so the pipeline can advance its durable source cursor and
+    write its acknowledgement STRICTLY AFTER the segment commits (W07 increment 2b, plan section
+    4.9). It is ``None`` for every non-cursor collector, whose behaviour is entirely unchanged. On a
+    data-loss read it carries only ``loss_signal`` (with no drafts), so the pipeline commits and
+    advances nothing and surfaces the loss code -- see
+    :class:`~milhouse.outbox.advance.CursorAdvanceV1`.
+    """
 
     status: CollectorStatus
     drafts: tuple[RecordDraftV1, ...] = ()
     diagnostics: Mapping[str, int] = field(default_factory=dict)
+    cursor_advance: CursorAdvanceV1 | None = None
 
     def __post_init__(self) -> None:
         if self.status not in ("ok", "failed"):
@@ -67,6 +78,10 @@ class CollectorResult:
                     "MH_RUNTIME_RESULT_DIAGNOSTICS",
                     "each diagnostic must be a machine key and a non-negative count",
                 )
+        if self.cursor_advance is not None and not isinstance(self.cursor_advance, CursorAdvanceV1):
+            raise PipelineError(
+                "MH_RUNTIME_RESULT_CURSOR", "a cursor advance sidecar must be a CursorAdvanceV1"
+            )
         object.__setattr__(self, "diagnostics", freeze_dict(dict(self.diagnostics)))
 
 

--- a/tests/unit/test_collect_cli.py
+++ b/tests/unit/test_collect_cli.py
@@ -57,6 +57,12 @@ _NON_CANARY_COLLECTOR = (
     '\n[[collectors]]\nid = "example-outbox"\ntype = "file_outbox"\n'
     'target = "example-app"\npath = "outbox"\n'
 )
+# A file_outbox collector whose relative outbox path the test plants as a SYMLINK, so the real
+# collect registry's path resolution fails closed with a config-error (exit 2), not a traceback.
+_SYMLINK_OUTBOX_COLLECTOR = (
+    '\n[[collectors]]\nid = "sym-outbox"\ntype = "file_outbox"\n'
+    'target = "example-app"\npath = "outbox.jsonl"\n'
+)
 
 
 def _config_file(
@@ -88,7 +94,7 @@ def _use_fake_registry(monkeypatch: pytest.MonkeyPatch, factory: object) -> None
     """Swap the production collect registry for one resolving ``site_canary`` to ``factory``."""
 
     registry = registry_with("site_canary", factory)
-    monkeypatch.setattr(root, "_new_collect_registry", lambda: registry)
+    monkeypatch.setattr(root, "_new_collect_registry", lambda *args, **kwargs: registry)
 
 
 def _isolation_factory(fail_id: str) -> object:
@@ -226,6 +232,28 @@ def test_collect_run_commits_a_segment_and_exits_zero(
     assert payload["records_delivered"] == 0
     # A durable segment reached the spool.
     assert list((paths.spool / "pending").rglob("*.jsonl"))
+
+
+def test_collect_run_maps_a_symlinked_outbox_path_to_a_config_error(tmp_path: Path) -> None:
+    # A symlinked/uninspectable file_outbox path is a CONFIGURATION fault: the real registry
+    # resolves it symlink-free, so it must surface as the clean exit-2 config-error contract (not an
+    # uncaught traceback). No fake registry here -- the real path resolution must run.
+    config_file = _config_file(
+        tmp_path, extra=_SYMLINK_OUTBOX_COLLECTOR, mode="spool_only", clickhouse_enabled=False
+    )
+    runner = CliRunner()
+    assert runner.invoke(main, ["--config", str(config_file), "init"]).exit_code == 0
+    # Plant a symlink at the resolved outbox path (config-dir relative).
+    (tmp_path / "cfg" / "outbox.jsonl").symlink_to(tmp_path / "nonexistent-target")
+
+    result = runner.invoke(main, ["--config", str(config_file), "collect", "run"])
+
+    assert (
+        result.exit_code == 2
+    )  # the config-error contract, not the exit-1 run abort or a traceback
+    assert "config.path.symlink" in result.output
+    # A clean coded exit, never a raw traceback escaping to the user.
+    assert result.exception is None or isinstance(result.exception, SystemExit)
 
 
 def test_collect_run_json_is_stable_and_privacy_safe(

--- a/tests/unit/test_file_outbox_collector.py
+++ b/tests/unit/test_file_outbox_collector.py
@@ -1,0 +1,68 @@
+"""Unit tests for the ``file_outbox`` collector's construction, factory, and helper guards (W07).
+
+These pin the fail-closed paths the end-to-end pipeline tests do not exercise: the constructor's
+config-type guard, the monotonic rotation-high-water fold, and the registry factory's "no resolved
+path bound for this collector" guard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from milhouse.collectors.errors import CollectorError
+from milhouse.collectors.file_outbox import (
+    _fold_high_water,
+    build_collector,
+    register_file_outbox,
+)
+from milhouse.config._models import FileOutboxCollector as FileOutboxConfig
+from milhouse.runtime import CollectorRegistry
+
+
+def _config(collector_id: str = "app-outbox") -> FileOutboxConfig:
+    return FileOutboxConfig.model_validate(
+        {
+            "id": collector_id,
+            "target": "t1",
+            "type": "file_outbox",
+            "path": "feedback-outbox.jsonl",
+            "producer_allowlist": [],
+            "ack_filename": "outbox-ack.json",
+        }
+    )
+
+
+def test_build_collector_rejects_a_non_file_outbox_config() -> None:
+    with pytest.raises(CollectorError) as err:
+        build_collector(
+            object(),  # type: ignore[arg-type]
+            outbox_path=Path("/tmp/.milhouse/feedback-outbox.jsonl"),
+            ack_directory=Path("/tmp/.milhouse"),
+        )
+    assert err.value.code == "MH_COLLECTOR_CONFIG"
+
+
+@pytest.mark.parametrize(
+    ("prior", "observed", "expected"),
+    [
+        (None, None, None),
+        (None, 5, 5),
+        (5, None, 5),
+        (3, 7, 7),
+        (7, 3, 7),
+    ],
+)
+def test_fold_high_water_is_monotonic(
+    prior: int | None, observed: int | None, expected: int | None
+) -> None:
+    assert _fold_high_water(prior, observed) == expected
+
+
+def test_register_file_outbox_factory_rejects_an_unbound_collector() -> None:
+    registry = CollectorRegistry()
+    register_file_outbox(registry, outbox_paths={})  # no bindings resolved
+    with pytest.raises(CollectorError) as err:
+        registry.resolve(_config("not-bound"))
+    assert err.value.code == "MH_COLLECTOR_CONFIG"

--- a/tests/unit/test_file_outbox_pipeline.py
+++ b/tests/unit/test_file_outbox_pipeline.py
@@ -1,0 +1,677 @@
+"""End-to-end: the ``file_outbox`` collector driven through the real W07 runtime pipeline.
+
+These offline tests exercise the highest-risk increment of W07 -- the durable cursor advance and the
+frame->record mapping -- through a REAL :class:`~milhouse.runtime.pipeline.RuntimePipeline` over a
+temp outbox, control database, and spool. They prove the three load-bearing invariants directly:
+
+* **(a)** a segment commits BEFORE the cursor/ack advance, and an empty/unchanged read advances
+  nothing;
+* **(b)** a commit-then-crash-before-advance replay re-reads the same frame and produces the SAME
+  ``record_id`` (deterministic identity -> downstream dedup collapses the duplicate) -- the
+  load-bearing test;
+* **(c)** a data-loss read commits and advances NOTHING and surfaces the fixed loss code.
+
+Plus the generic opt-in (a non-cursor collector never touches a cursor or ack) and the post-commit
+advance-failure isolation (a failed advance never unwinds the durable commit).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from _record_factories import INSTALLATION_ID, NOW
+from _runtime_harness import (
+    KNOWN_SECRET,
+    SECRET_MARKER,
+    FakeCollector,
+    build_control,
+    make_pipeline,
+    registry_with,
+    target_config,
+)
+
+from milhouse.collectors.file_outbox import FileOutboxBinding, register_file_outbox
+from milhouse.config._models import FileOutboxCollector as FileOutboxConfig
+from milhouse.core.clock import FixedClock
+from milhouse.domain.records import MAX_DIMENSION_VALUE_BYTES, CollectorDescriptorV1
+from milhouse.outbox import read_outbox_ack
+from milhouse.runtime import CollectorRegistry
+from milhouse.spooling import read_trusted_segment
+from milhouse.state import read_cursor
+
+_OUTBOX_NAME = "feedback-outbox.jsonl"
+_ACK_NAME = "outbox-ack.json"
+_COLLECTOR_ID = "app-outbox"
+_TARGET_ID = "t1"
+_DAY = NOW.date().isoformat()
+_TS = "2026-08-17T12:00:00.000Z"
+
+
+# --- helpers ------------------------------------------------------------------------------------
+
+
+def _frame_document(**overrides: object) -> dict[str, object]:
+    document: dict[str, object] = {
+        "schema_version": "1.0",
+        "producer_id": "web-ci",
+        "occurred_at": _TS,
+        "target": "web-service",
+        "kind": "deploy.completed",
+        "actionability": "observe",
+        "evidence_references": ["ev-1"],
+        "data": {"count": 3},
+    }
+    document.update(overrides)
+    return document
+
+
+def _frame_line(**overrides: object) -> bytes:
+    return json.dumps(_frame_document(**overrides)).encode("utf-8") + b"\n"
+
+
+def _milhouse_dir(tmp_path: Path) -> Path:
+    """Create the owner-only 0700 ``.milhouse`` directory the ack read/writer requires."""
+
+    directory = tmp_path / ".milhouse"
+    directory.mkdir(mode=0o700)
+    os.chmod(directory, 0o700)
+    return directory
+
+
+def _outbox_config(**overrides: object) -> FileOutboxConfig:
+    body: dict[str, object] = {
+        "id": _COLLECTOR_ID,
+        "target": _TARGET_ID,
+        "type": "file_outbox",
+        "path": _OUTBOX_NAME,
+        "producer_allowlist": [],
+        "ack_filename": _ACK_NAME,
+    }
+    body.update(overrides)
+    return FileOutboxConfig.model_validate(body)
+
+
+def _registry(outbox_path: Path, ack_directory: Path) -> CollectorRegistry:
+    registry = CollectorRegistry()
+    register_file_outbox(
+        registry,
+        outbox_paths={
+            _COLLECTOR_ID: FileOutboxBinding(outbox_path=outbox_path, ack_directory=ack_directory)
+        },
+    )
+    return registry
+
+
+def _record_ids(spool_root: Path, batch_id: str) -> list[str]:
+    path = spool_root / "pending" / _DAY / f"{batch_id}.jsonl"
+    parsed = read_trusted_segment(path, installation_id=INSTALLATION_ID)
+    return [frame.record.record_id for frame in parsed.frames]
+
+
+# --- (a) happy path -----------------------------------------------------------------------------
+
+
+def test_happy_path_commits_then_advances_cursor_and_writes_ack(tmp_path: Path) -> None:
+    directory = _milhouse_dir(tmp_path)
+    outbox = directory / _OUTBOX_NAME
+    body = _frame_line(kind="deploy.completed", data={"count": 3}) + _frame_line(
+        kind="deploy.started", data={"count": 1}
+    )
+    outbox.write_bytes(body)
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        pipeline = make_pipeline(
+            mode="spool_only",
+            registry=_registry(outbox, directory),
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW),
+        )
+        summary = pipeline.run([_outbox_config()], [target_config(_TARGET_ID)])
+
+        assert summary.records_committed == 2
+        item = summary.collectors[0]
+        assert item.status == "ok"
+        assert item.error_code is None
+        assert item.batch_id is not None
+
+        # The cursor advanced exactly once against the committed segment, past the whole file.
+        cursor = read_cursor(database, source=_COLLECTOR_ID)
+        assert cursor is not None
+        assert cursor.revision == 1
+        assert cursor.batch_id == item.batch_id
+        position = json.loads(cursor.position)
+        assert position["offset"] == len(body)
+
+        # The ack Milhouse owns records the committed file identity and offset.
+        ack = read_outbox_ack(directory, _ACK_NAME)
+        assert ack is not None
+        assert ack.committed_offset == len(body)
+        assert ack.last_sequence is None  # no rotation seen
+        assert ack.producer_id == _COLLECTOR_ID
+
+        # The committed records mirror the frames (kind->category, actionability->status).
+        path = spool_root / "pending" / _DAY / f"{item.batch_id}.jsonl"
+        records = [
+            frame.record
+            for frame in read_trusted_segment(path, installation_id=INSTALLATION_ID).frames
+        ]
+        assert [r.record_type for r in records] == ["event", "event"]
+        assert {r.data.category for r in records} == {"deploy.completed", "deploy.started"}
+        assert all(r.data.status == "observe" for r in records)
+        assert {dict(r.data.attributes)["count"] for r in records} == {3, 1}
+    finally:
+        database.close()
+
+
+# --- (a) idempotency / no-dup -------------------------------------------------------------------
+
+
+def test_rerun_over_unchanged_file_commits_nothing_then_only_the_new_frame(
+    tmp_path: Path,
+) -> None:
+    directory = _milhouse_dir(tmp_path)
+    outbox = directory / _OUTBOX_NAME
+    outbox.write_bytes(_frame_line(kind="deploy.completed"))
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        pipeline = make_pipeline(
+            mode="spool_only",
+            registry=_registry(outbox, directory),
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW),
+        )
+        config = [_outbox_config()]
+        targets = [target_config(_TARGET_ID)]
+
+        first = pipeline.run(config, targets)
+        assert first.records_committed == 1
+        cursor_after_first = read_cursor(database, source=_COLLECTOR_ID)
+        assert cursor_after_first is not None and cursor_after_first.revision == 1
+
+        # Second run over the byte-identical file: NOTHING new, cursor unchanged (no advance).
+        second = pipeline.run(config, targets)
+        assert second.records_committed == 0
+        assert second.collectors[0].status == "ok"
+        cursor_after_second = read_cursor(database, source=_COLLECTOR_ID)
+        assert cursor_after_second == cursor_after_first  # revision + position identical
+
+        # Append ONE frame: only the new frame becomes a record; the cursor advances once more.
+        with outbox.open("ab") as handle:
+            handle.write(_frame_line(kind="deploy.rolled_back"))
+        third = pipeline.run(config, targets)
+        assert third.records_committed == 1
+        item = third.collectors[0]
+        records = [
+            frame.record
+            for frame in read_trusted_segment(
+                spool_root / "pending" / _DAY / f"{item.batch_id}.jsonl",
+                installation_id=INSTALLATION_ID,
+            ).frames
+        ]
+        assert [r.data.category for r in records] == ["deploy.rolled_back"]
+        cursor_after_third = read_cursor(database, source=_COLLECTOR_ID)
+        assert cursor_after_third is not None and cursor_after_third.revision == 2
+    finally:
+        database.close()
+
+
+# --- (b) commit-before-advance replay (the load-bearing test) -----------------------------------
+
+
+def test_replay_before_advance_reproduces_identical_record_ids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    directory = _milhouse_dir(tmp_path)
+    outbox = directory / _OUTBOX_NAME
+    outbox.write_bytes(_frame_line(kind="deploy.completed", data={"count": 7}))
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        config = [_outbox_config()]
+        targets = [target_config(_TARGET_ID)]
+
+        # Run 1 CRASHES between commit and advance: the segment commits durably, but advance_cursor
+        # raises so the cursor + ack are NEVER written (isolated -> the run continues).
+        import milhouse.runtime.pipeline as pipeline_module
+        from milhouse.state import StateError
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise StateError("MH_STATE_CURSOR", "simulated crash before advance")
+
+        monkeypatch.setattr(pipeline_module, "advance_cursor", _boom)
+        crashed = make_pipeline(
+            mode="spool_only",
+            registry=_registry(outbox, directory),
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW),
+        ).run(config, targets)
+        first_item = crashed.collectors[0]
+        assert first_item.records_committed == 1  # committed despite the advance failure
+        assert first_item.error_code == "MH_STATE_CURSOR"
+        assert read_cursor(database, source=_COLLECTOR_ID) is None  # never advanced
+        first_ids = _record_ids(spool_root, first_item.batch_id or "")
+        monkeypatch.undo()
+
+        # Run 2 replays with a LATER clock (a real re-run): the cursor is still unadvanced, so the
+        # SAME frame is re-read and re-committed under a DISTINCT batch_id -- but the record_id is
+        # derived from the frame bytes, so it is IDENTICAL. Downstream dedup collapses it.
+        replay = make_pipeline(
+            mode="spool_only",
+            registry=_registry(outbox, directory),
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW + timedelta(hours=1)),
+        ).run(config, targets)
+        second_item = replay.collectors[0]
+        assert second_item.records_committed == 1
+        assert second_item.error_code is None
+        second_ids = _record_ids(spool_root, second_item.batch_id or "")
+
+        assert second_item.batch_id != first_item.batch_id  # a genuinely distinct replay segment
+        assert first_ids == second_ids  # ... yet identical record identity -> dedup collapses it
+
+        # The replay's advance DID land this time.
+        cursor = read_cursor(database, source=_COLLECTOR_ID)
+        assert cursor is not None and cursor.revision == 1
+    finally:
+        database.close()
+
+
+# --- (c) loss short-circuits --------------------------------------------------------------------
+
+
+def test_data_loss_commits_nothing_and_leaves_the_cursor_unchanged(tmp_path: Path) -> None:
+    directory = _milhouse_dir(tmp_path)
+    outbox = directory / _OUTBOX_NAME
+    outbox.write_bytes(_frame_line(kind="deploy.completed") + _frame_line(kind="deploy.started"))
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        registry = _registry(outbox, directory)
+        config = [_outbox_config()]
+        targets = [target_config(_TARGET_ID)]
+
+        first = make_pipeline(
+            mode="spool_only",
+            registry=registry,
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW),
+        ).run(config, targets)
+        assert first.records_committed == 2
+        cursor_before = read_cursor(database, source=_COLLECTOR_ID)
+        assert cursor_before is not None
+
+        segments_before = list((spool_root / "pending" / _DAY).glob("*.jsonl"))
+
+        # Truncate already-consumed bytes IN PLACE (same inode) below the cursor offset: an
+        # un-recoverable P1 data loss the reader must refuse to resume past.
+        with outbox.open("r+b") as handle:
+            handle.truncate(10)
+
+        lost = make_pipeline(
+            mode="spool_only",
+            registry=registry,
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW + timedelta(hours=1)),
+        ).run(config, targets)
+        item = lost.collectors[0]
+        assert item.status == "failed"
+        assert item.error_code == "MH_OUTBOX_LOSS_TRUNCATED"
+        assert item.records_committed == 0
+        # Nothing committed and nothing advanced: the cursor is byte-for-byte what it was.
+        assert read_cursor(database, source=_COLLECTOR_ID) == cursor_before
+        assert list((spool_root / "pending" / _DAY).glob("*.jsonl")) == segments_before
+    finally:
+        database.close()
+
+
+# --- generic opt-in: a non-cursor collector never touches a cursor or ack -----------------------
+
+
+def test_non_cursor_collector_leaves_no_cursor_or_ack(tmp_path: Path) -> None:
+    directory = _milhouse_dir(tmp_path)
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        descriptor = CollectorDescriptorV1(
+            id="canary1", type="site.canary", implementation_version="1.0.0"
+        )
+
+        def factory(config: object) -> FakeCollector:
+            return FakeCollector(descriptor=descriptor, messages=("probe ok",))
+
+        pipeline = make_pipeline(
+            mode="spool_only",
+            registry=registry_with("site_canary", factory),
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW),
+        )
+        from _runtime_harness import canary_config
+
+        summary = pipeline.run([canary_config("canary1")], [target_config(_TARGET_ID)])
+        assert summary.records_committed == 1  # the collector still commits its event
+        assert summary.collectors[0].error_code is None
+        # ... but no cursor advanced and no ack was written for a non-cursor collector.
+        assert read_cursor(database, source="canary1") is None
+        assert not (directory / _ACK_NAME).exists()
+    finally:
+        database.close()
+
+
+# --- post-commit advance-failure isolation ------------------------------------------------------
+
+
+def test_advance_failure_does_not_unwind_the_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    directory = _milhouse_dir(tmp_path)
+    outbox = directory / _OUTBOX_NAME
+    outbox.write_bytes(_frame_line(kind="deploy.completed"))
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        import milhouse.runtime.pipeline as pipeline_module
+        from milhouse.state import StateError
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise StateError("MH_STATE_CURSOR_CONFLICT", "simulated concurrent advance")
+
+        monkeypatch.setattr(pipeline_module, "advance_cursor", _boom)
+        summary = make_pipeline(
+            mode="spool_only",
+            registry=_registry(outbox, directory),
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW),
+        ).run([_outbox_config()], [target_config(_TARGET_ID)])
+
+        item = summary.collectors[0]
+        # The commit is durable (records committed, segment readable) even though advance failed.
+        assert item.records_committed == 1
+        assert item.batch_id is not None
+        assert item.error_code == "MH_STATE_CURSOR_CONFLICT"
+        path = spool_root / "pending" / _DAY / f"{item.batch_id}.jsonl"
+        assert len(read_trusted_segment(path, installation_id=INSTALLATION_ID).frames) == 1
+        # The cursor stayed un-advanced AND no ack was written (advance failed before the ack).
+        assert read_cursor(database, source=_COLLECTOR_ID) is None
+        assert not (directory / _ACK_NAME).exists()
+    finally:
+        database.close()
+
+
+# --- FIX 1 (P1): a first run (cursor None) ingests retained rotations, not just the active file ---
+
+
+def test_first_run_ingests_retained_rotations_when_cursor_is_none(tmp_path: Path) -> None:
+    directory = _milhouse_dir(tmp_path)
+    outbox = directory / _OUTBOX_NAME
+    # A rotated file already exists BEFORE Milhouse's first successful read (cursor still None): run
+    # 1 saw an empty/all-rejected outbox and the producer rotated before run 2.
+    (directory / "feedback-outbox.00000001.jsonl").write_bytes(_frame_line(kind="deploy.older"))
+    outbox.write_bytes(_frame_line(kind="deploy.newer"))
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        config = [_outbox_config(rotation_glob="feedback-outbox.*.jsonl")]
+        summary = make_pipeline(
+            mode="spool_only",
+            registry=_registry(outbox, directory),
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW),
+        ).run(config, [target_config(_TARGET_ID)])
+
+        # BOTH the retained rotated frame and the active frame are ingested, in order.
+        assert summary.records_committed == 2
+        item = summary.collectors[0]
+        assert item.error_code is None
+        records = [
+            frame.record
+            for frame in read_trusted_segment(
+                spool_root / "pending" / _DAY / f"{item.batch_id}.jsonl",
+                installation_id=INSTALLATION_ID,
+            ).frames
+        ]
+        assert [r.data.category for r in records] == ["deploy.older", "deploy.newer"]
+        cursor = read_cursor(database, source=_COLLECTOR_ID)
+        assert cursor is not None and cursor.revision == 1
+        # The rotation high-water is persisted in the ack for later top-run detection.
+        ack = read_outbox_ack(directory, _ACK_NAME)
+        assert ack is not None and ack.last_sequence == 1
+    finally:
+        database.close()
+
+
+# --- FIX 2 (P2): distinct byte-identical frames get distinct record ids (byte-offset fallback) ----
+
+
+def test_distinct_byte_identical_frames_get_distinct_record_ids(tmp_path: Path) -> None:
+    directory = _milhouse_dir(tmp_path)
+    outbox = directory / _OUTBOX_NAME
+    # Two BYTE-IDENTICAL frames (same producer, same-millisecond occurred_at, same kind + data): a
+    # content-ONLY identity would derive one record_id and ReplacingMergeTree would collapse them,
+    # losing an observation. The per-file byte offset in the coordinate keeps them distinct.
+    line = _frame_line(kind="deploy.completed", data={"count": 1})
+    outbox.write_bytes(line + line)
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        summary = make_pipeline(
+            mode="spool_only",
+            registry=_registry(outbox, directory),
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW),
+        ).run([_outbox_config()], [target_config(_TARGET_ID)])
+
+        assert summary.records_committed == 2
+        ids = _record_ids(spool_root, summary.collectors[0].batch_id or "")
+        assert len(ids) == 2
+        assert len(set(ids)) == 2  # two DISTINCT record ids -> neither observation is merged away
+    finally:
+        database.close()
+
+
+# --- FIX 3 (P2 privacy): untrusted producer attributes are redacted before durable commit ---------
+
+
+def test_producer_attributes_are_redacted_in_the_committed_record(tmp_path: Path) -> None:
+    directory = _milhouse_dir(tmp_path)
+    outbox = directory / _OUTBOX_NAME
+    outbox.write_bytes(
+        _frame_line(
+            kind="deploy.completed",
+            data={
+                "note": f"leaked {KNOWN_SECRET} here",
+                "contact": "oncall@secret.example",
+                "log": "/var/log/deploy/private/token.txt",
+                "count": 5,
+            },
+        )
+    )
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        summary = make_pipeline(
+            mode="spool_only",
+            registry=_registry(outbox, directory),
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW),
+        ).run([_outbox_config()], [target_config(_TARGET_ID)])
+
+        assert summary.records_committed == 1
+        item = summary.collectors[0]
+        record = (
+            read_trusted_segment(
+                spool_root / "pending" / _DAY / f"{item.batch_id}.jsonl",
+                installation_id=INSTALLATION_ID,
+            )
+            .frames[0]
+            .record
+        )
+        attributes = dict(record.data.attributes)
+        # The pipeline's defense-in-depth pass does NOT scan structured attributes, so ONLY the
+        # collector's redaction can have produced these markers -- proving FIX 3 is wired.
+        assert KNOWN_SECRET not in attributes["note"]
+        assert SECRET_MARKER in attributes["note"]
+        # A producer email and a filesystem path in structured attributes are redacted too.
+        assert "oncall@secret.example" not in attributes["contact"]
+        assert "secret.example" not in attributes["contact"]
+        assert "/var/log/deploy/private" not in attributes["log"]
+        # A non-string scalar passes through unchanged.
+        assert attributes["count"] == 5
+    finally:
+        database.close()
+
+
+# --- P2: redaction expansion must NOT poison-stall the outbox (clamp to the dimension bound) ---
+
+
+def test_redaction_expansion_is_clamped_and_does_not_stall(tmp_path: Path) -> None:
+    directory = _milhouse_dir(tmp_path)
+    outbox = directory / _OUTBOX_NAME
+    # A value that PARSES within the dimension bound (<= 2048 bytes) but whose redacted form EXPANDS
+    # past it: many short emails, each redacting to a ~40-byte marker. Without the clamp,
+    # EventDataV1.attributes would raise -> the frame never commits -> the cursor never advances ->
+    # the identical frame re-fails forever (a permanent outbox stall / denial-of-ingestion).
+    packed = "user@host.example " * 100  # ~1800 bytes raw (<= 2048), ~5000 bytes once redacted
+    assert len(packed.encode("utf-8")) <= MAX_DIMENSION_VALUE_BYTES
+    outbox.write_bytes(_frame_line(kind="deploy.completed", data={"blob": packed}))
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        registry = _registry(outbox, directory)
+        config = [_outbox_config()]
+        targets = [target_config(_TARGET_ID)]
+
+        first = make_pipeline(
+            mode="spool_only",
+            registry=registry,
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW),
+        ).run(config, targets)
+
+        # The frame COMMITS (no stall) and the cursor ADVANCES.
+        assert first.records_committed == 1
+        item = first.collectors[0]
+        assert item.error_code is None
+        cursor = read_cursor(database, source=_COLLECTOR_ID)
+        assert cursor is not None and cursor.revision == 1
+
+        record = (
+            read_trusted_segment(
+                spool_root / "pending" / _DAY / f"{item.batch_id}.jsonl",
+                installation_id=INSTALLATION_ID,
+            )
+            .frames[0]
+            .record
+        )
+        blob = dict(record.data.attributes)["blob"]
+        assert isinstance(blob, str)
+        # Clamped within the dimension bound, still redacted (no raw email), and marked as clamped.
+        assert len(blob.encode("utf-8")) <= MAX_DIMENSION_VALUE_BYTES
+        assert "user@host.example" not in blob
+        assert blob.endswith("[mh:clamp]")
+
+        # No stall: a second run over the unchanged file commits nothing and the cursor is unmoved.
+        second = make_pipeline(
+            mode="spool_only",
+            registry=registry,
+            control=database,
+            barrier=barrier,
+            spool_root=spool_root,
+            clock=FixedClock(instant=NOW + timedelta(hours=1)),
+        ).run(config, targets)
+        assert second.records_committed == 0
+        assert read_cursor(database, source=_COLLECTOR_ID) == cursor
+    finally:
+        database.close()
+
+
+# --- P3: cross-path replay-offset equality (_read_same_file == _recover_rotation offset) ---
+
+
+def test_replay_across_rotation_matches_offset_from_same_file_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    directory = _milhouse_dir(tmp_path)
+    outbox = directory / _OUTBOX_NAME
+    line_a = _frame_line(kind="deploy.a")
+    outbox.write_bytes(line_a)
+
+    database, barrier, spool_root = build_control(tmp_path)
+    try:
+        config = [_outbox_config(rotation_glob="feedback-outbox.*.jsonl")]
+        targets = [target_config(_TARGET_ID)]
+
+        def _pipeline(instant: object) -> object:
+            return make_pipeline(
+                mode="spool_only",
+                registry=_registry(outbox, directory),
+                control=database,
+                barrier=barrier,
+                spool_root=spool_root,
+                clock=FixedClock(instant=instant),  # type: ignore[arg-type]
+            )
+
+        # Run 1: commit frame A (offset 0) and advance -> the cursor now sits at offset len(line_a).
+        _pipeline(NOW).run(config, targets)
+        assert read_cursor(database, source=_COLLECTOR_ID).revision == 1  # type: ignore[union-attr]
+
+        # Run 2: append B (at offset len(line_a)); it is read via _read_same_file
+        # (base_offset=start=len(line_a)) and committed, but a crash before advance keeps cursor.
+        with outbox.open("ab") as handle:
+            handle.write(_frame_line(kind="deploy.b"))
+        import milhouse.runtime.pipeline as pipeline_module
+        from milhouse.state import StateError
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise StateError("MH_STATE_CURSOR", "crash before advance")
+
+        monkeypatch.setattr(pipeline_module, "advance_cursor", _boom)
+        crashed = _pipeline(NOW).run(config, targets)
+        b_id_same_file = _record_ids(spool_root, crashed.collectors[0].batch_id or "")[0]
+        assert read_cursor(database, source=_COLLECTOR_ID).revision == 1  # type: ignore[union-attr]
+        monkeypatch.undo()
+
+        # Rotate the file the cursor points into (A+B) and start a fresh active file. Now the
+        # cursor's inode differs from the active inode, so run 3 re-reads B via _recover_rotation's
+        # cursor-file region with base_offset=prior.offset=len(line_a) -- the SAME absolute per-file
+        # offset as the _read_same_file path in run 2. If both paths agree, the id is identical.
+        os.rename(outbox, directory / "feedback-outbox.00000001.jsonl")
+        outbox.write_bytes(b"")
+
+        replay = _pipeline(NOW + timedelta(hours=1)).run(config, targets)
+        item = replay.collectors[0]
+        assert item.records_committed == 1  # only B is re-read (A is before the cursor)
+        b_id_rotation = _record_ids(spool_root, item.batch_id or "")[0]
+
+        assert b_id_rotation == b_id_same_file  # cross-path offsets agree -> identical identity
+        assert read_cursor(database, source=_COLLECTOR_ID).revision == 2  # type: ignore[union-attr]
+    finally:
+        database.close()

--- a/tests/unit/test_outbox_advance.py
+++ b/tests/unit/test_outbox_advance.py
@@ -1,0 +1,141 @@
+"""Unit tests for the ``CursorAdvanceV1`` post-commit sidecar validation (W07 increment 2b).
+
+The sidecar has exactly two valid shapes -- a complete advance or a loss-only short-circuit -- and
+its ``__post_init__`` fails closed on anything else. These tests pin every validation branch: the
+high-water guard (checked in BOTH shapes), the loss-signal type guard, the "a loss carries no
+advance instruction" guard, and the "an advance must be complete" guard.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from milhouse.outbox import CursorAdvanceV1, OutboxAckV1
+from milhouse.outbox.errors import OutboxError
+from milhouse.outbox.reader import OutboxLossSignal
+
+_TS = datetime(2026, 1, 1, tzinfo=UTC)
+_SHA = "0" * 64
+
+
+def _loss() -> OutboxLossSignal:
+    return OutboxLossSignal(
+        code="MH_OUTBOX_LOSS_TRUNCATED",
+        cursor_device=1,
+        cursor_inode=2,
+        cursor_offset=0,
+        cursor_sha256=_SHA,
+    )
+
+
+def _ack() -> OutboxAckV1:
+    return OutboxAckV1(
+        producer_id="producer",
+        file_device=1,
+        file_inode=2,
+        committed_offset=0,
+        content_sha256=_SHA,
+        acknowledged_at=_TS,
+    )
+
+
+def _advance_kwargs() -> dict[str, object]:
+    return {
+        "next_position": "pos",
+        "ack_directory": "/tmp/.milhouse",
+        "ack_filename": "outbox-ack.json",
+        "ack": _ack(),
+    }
+
+
+# --- valid shapes -------------------------------------------------------------------------------
+
+
+def test_valid_loss_only_sidecar_is_accepted() -> None:
+    sidecar = CursorAdvanceV1(loss_signal=_loss())
+    assert sidecar.loss_signal is not None
+    assert sidecar.next_position is None
+    assert sidecar.ack is None
+
+
+def test_valid_advance_sidecar_is_accepted() -> None:
+    sidecar = CursorAdvanceV1(**_advance_kwargs(), max_observed_sequence=3)
+    assert sidecar.ack is not None
+    assert sidecar.next_position == "pos"
+    assert sidecar.loss_signal is None
+
+
+def test_valid_advance_without_high_water_is_accepted() -> None:
+    sidecar = CursorAdvanceV1(**_advance_kwargs())
+    assert sidecar.max_observed_sequence is None
+
+
+# --- the high-water guard (validated in BOTH shapes) --------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [-1, "x", 1.5])
+def test_invalid_max_observed_sequence_raises_in_loss_shape(bad: object) -> None:
+    with pytest.raises(OutboxError) as err:
+        CursorAdvanceV1(loss_signal=_loss(), max_observed_sequence=bad)  # type: ignore[arg-type]
+    assert err.value.code == "MH_OUTBOX_ADVANCE"
+
+
+def test_invalid_max_observed_sequence_raises_in_advance_shape() -> None:
+    with pytest.raises(OutboxError) as err:
+        CursorAdvanceV1(**_advance_kwargs(), max_observed_sequence=-5)
+    assert err.value.code == "MH_OUTBOX_ADVANCE"
+
+
+# --- the loss-signal type guard and the "loss carries no advance" guard -------------------------
+
+
+def test_non_loss_signal_object_raises() -> None:
+    with pytest.raises(OutboxError) as err:
+        CursorAdvanceV1(loss_signal="not-a-loss-signal")  # type: ignore[arg-type]
+    assert err.value.code == "MH_OUTBOX_ADVANCE"
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"next_position": "pos"},
+        {"ack": _ack()},
+        {"ack_directory": "/tmp/.milhouse"},
+        {"ack_filename": "outbox-ack.json"},
+    ],
+)
+def test_loss_sidecar_carrying_an_advance_field_raises(extra: dict[str, object]) -> None:
+    with pytest.raises(OutboxError) as err:
+        CursorAdvanceV1(loss_signal=_loss(), **extra)  # type: ignore[arg-type]
+    assert err.value.code == "MH_OUTBOX_ADVANCE"
+
+
+# --- the "an advance must be complete" guard ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("next_position", None),
+        ("next_position", ""),
+        ("ack_directory", None),
+        ("ack_directory", ""),
+        ("ack_filename", None),
+        ("ack_filename", ""),
+        ("ack", None),
+    ],
+)
+def test_incomplete_advance_raises(field: str, value: object) -> None:
+    kwargs = _advance_kwargs()
+    kwargs[field] = value
+    with pytest.raises(OutboxError) as err:
+        CursorAdvanceV1(**kwargs)  # type: ignore[arg-type]
+    assert err.value.code == "MH_OUTBOX_ADVANCE"
+
+
+def test_empty_sidecar_is_neither_a_valid_loss_nor_advance() -> None:
+    with pytest.raises(OutboxError) as err:
+        CursorAdvanceV1()
+    assert err.value.code == "MH_OUTBOX_ADVANCE"

--- a/tests/unit/test_outbox_reader.py
+++ b/tests/unit/test_outbox_reader.py
@@ -372,6 +372,105 @@ def test_multiple_rotations_recovered_in_monotonic_order(tmp_path: Path) -> None
     assert result.diagnostics.rotations_crossed == 2
 
 
+def test_first_read_no_cursor_ingests_retained_rotations(tmp_path: Path) -> None:
+    # FIX 1 (P1): a FIRST read (cursor still None: run 1 committed nothing) after the outbox ALREADY
+    # rotated must ingest the retained rotated file too -- reading only the active file would drop
+    # those frames forever with no loss signal.
+    path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
+    _rotate(path, 1)  # feedback-outbox.00000001.jsonl now holds a, b
+    _write(path, _frame_line(kind="c"))  # the fresh active file holds c
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+
+    result = read_outbox(file_path=path, prior_cursor=None, config=config)
+    assert result.loss_signal is None
+    assert [frame.kind for frame in result.new_frames] == ["a", "b", "c"]  # whole chain, in order
+    assert result.diagnostics.rotations_crossed == 1
+    assert result.max_observed_sequence == 1
+    # The cursor is established at the active file's EOF.
+    assert result.next_position is not None
+    assert result.next_position.inode == os.stat(path).st_ino
+    assert result.next_position.offset == len(_frame_line(kind="c"))
+
+
+def test_first_read_no_cursor_without_glob_reads_only_active(tmp_path: Path) -> None:
+    # Without a rotation_glob the reader cannot enumerate rotations, so a first read reads only the
+    # active file -- the pre-existing, safe single-file behaviour (there is nothing to discover).
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    _rotate(path, 1)
+    _write(path, _frame_line(kind="c"))
+    result = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+    assert result.loss_signal is None
+    assert [frame.kind for frame in result.new_frames] == ["c"]
+
+
+def test_first_read_no_cursor_gap_in_rotations_is_p1_loss(tmp_path: Path) -> None:
+    # A gap in the retained rotated run on a first read is unrecoverable loss (nothing is acked, so
+    # a compliant producer would not have deleted an intermediate segment). Reported at zero.
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    _rotate(path, 1)
+    _write(path, _frame_line(kind="b"))
+    _rotate(path, 3)  # sequences {1, 3} retained -- 2 is missing
+    _write(path, _frame_line(kind="c"))
+    result = read_outbox(
+        file_path=path, prior_cursor=None, config=OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    )
+    assert result.new_frames == ()
+    assert result.loss_signal is not None
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_ROTATION_GONE"
+
+
+def test_frame_offsets_are_per_file_byte_positions(tmp_path: Path) -> None:
+    # FIX 2: each frame exposes its start byte WITHIN its own file, so a consumer can fold the
+    # offset into identity to keep byte-identical-but-distinct frames apart.
+    line_a = _frame_line(kind="a")
+    path = _outbox(tmp_path, line_a + _frame_line(kind="b"))
+    result = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+    assert [frame.kind for frame in result.new_frames] == ["a", "b"]
+    assert result.frame_offsets == (0, len(line_a))
+
+
+def test_frame_offset_skips_a_preceding_rejected_line(tmp_path: Path) -> None:
+    # A rejected line BEFORE a valid frame must not shift the valid frame's offset: the running
+    # total advances over the rejected line so the frame records its TRUE byte start.
+    rejected = b"this is not a valid json frame\n"
+    good = _frame_line(kind="ok")
+    path = _outbox(tmp_path, rejected + good)
+    result = read_outbox(file_path=path, prior_cursor=None, config=OutboxReaderConfig())
+    assert [frame.kind for frame in result.new_frames] == ["ok"]
+    assert result.diagnostics.rejected_lines == 1
+    assert result.frame_offsets == (len(rejected),)  # the true offset, past the skipped bad line
+
+
+def test_frame_offset_skips_a_preceding_oversized_line(tmp_path: Path) -> None:
+    # The oversize branch also advances the running total, so a valid frame after an oversized line
+    # still records its true offset. The bound is set above the valid frame but below the bad line.
+    good = _frame_line(kind="ok")
+    config = OutboxReaderConfig(max_line_bytes=len(good) + 100)
+    oversized = b"o" * (len(good) + 200) + b"\n"  # over max_line_bytes -> rejected as oversize
+    path = _outbox(tmp_path, oversized + good)
+    result = read_outbox(file_path=path, prior_cursor=None, config=config)
+    assert [frame.kind for frame in result.new_frames] == ["ok"]
+    assert result.diagnostics.rejected_lines == 1
+    assert result.frame_offsets == (len(oversized),)
+
+
+def test_frame_offset_is_stable_across_rotation(tmp_path: Path) -> None:
+    # The per-file offset is what makes the replay/identity property survive rotation: a rename
+    # never moves bytes, so frame "b" keeps the same offset once it lives in the rotated file.
+    line_a = _frame_line(kind="a")
+    path = _outbox(tmp_path, line_a + _frame_line(kind="b"))
+    config = OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    first = read_outbox(file_path=path, prior_cursor=None, config=config)
+    b_first = [frame.kind for frame in first.new_frames].index("b")
+    assert first.frame_offsets[b_first] == len(line_a)
+
+    _rotate(path, 1)  # "b" now lives in the rotated file, at the SAME byte offset
+    _write(path, _frame_line(kind="c"))
+    second = read_outbox(file_path=path, prior_cursor=None, config=config)
+    b_second = [frame.kind for frame in second.new_frames].index("b")
+    assert second.frame_offsets[b_second] == len(line_a)
+
+
 def test_needed_rotated_file_removed_is_p1_loss(tmp_path: Path) -> None:
     path = _outbox(tmp_path, _frame_line(kind="a") + _frame_line(kind="b"))
     cursor = _cursor_for(path, _frame_line(kind="a"))
@@ -947,3 +1046,125 @@ def test_ack_rejects_malformed_last_sequence(tmp_path: Path, bad_value: object) 
     with pytest.raises(OutboxError) as raised:
         read_outbox_ack(directory, "outbox-ack.json")
     assert raised.value.code == "MH_OUTBOX_ACK"
+
+
+# --- reader: guards, config validation, and none-cursor rotation edges (coverage) ---------------
+
+
+def test_read_outbox_rejects_a_non_config() -> None:
+    with pytest.raises(OutboxError) as err:
+        read_outbox(file_path="/x", prior_cursor=None, config=object())  # type: ignore[arg-type]
+    assert err.value.code == "MH_OUTBOX_CONFIG"
+
+
+def test_read_outbox_rejects_a_non_cursor() -> None:
+    with pytest.raises(OutboxError) as err:
+        read_outbox(
+            file_path="/x",
+            prior_cursor=object(),  # type: ignore[arg-type]
+            config=OutboxReaderConfig(),
+        )
+    assert err.value.code == "MH_OUTBOX_CURSOR"
+
+
+def test_config_rejects_an_empty_rotation_glob() -> None:
+    with pytest.raises(OutboxError) as err:
+        OutboxReaderConfig(rotation_glob="")
+    assert err.value.code == "MH_OUTBOX_CONFIG"
+
+
+def test_config_rejects_a_non_string_producer_allowlist_entry() -> None:
+    with pytest.raises(OutboxError) as err:
+        OutboxReaderConfig(producer_allowlist=("ok", 1))  # type: ignore[arg-type]
+    assert err.value.code == "MH_OUTBOX_CONFIG"
+
+
+def test_read_outbox_on_a_directory_is_not_regular(tmp_path: Path) -> None:
+    directory = tmp_path / "a-directory"
+    directory.mkdir()
+    with pytest.raises(OutboxError) as err:
+        read_outbox(file_path=directory, prior_cursor=None, config=OutboxReaderConfig())
+    assert err.value.code == "MH_OUTBOX_NOT_REGULAR"
+
+
+def test_first_read_no_cursor_unparseable_rotation_is_loss(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    # matches the glob but the wildcard is not a pure integer run
+    _write(path.parent / "feedback-outbox.abc.jsonl", _frame_line(kind="x"))
+    result = read_outbox(
+        file_path=path, prior_cursor=None, config=OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    )
+    assert result.new_frames == ()
+    assert result.loss_signal is not None
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_ROTATION_UNPARSEABLE"
+
+
+def test_first_read_no_cursor_torn_rotation_is_loss(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    _write(path.parent / "feedback-outbox.00000001.jsonl", b"torn line without a newline")
+    result = read_outbox(
+        file_path=path, prior_cursor=None, config=OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    )
+    assert result.new_frames == ()
+    assert result.loss_signal is not None
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_ROTATED_TORN"
+
+
+def test_first_read_no_cursor_glob_matching_active_link_is_excluded(tmp_path: Path) -> None:
+    # A hard link with a rotated-looking name that resolves to the ACTIVE inode is excluded (never
+    # double-counted), so the read falls back to the active file alone.
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    os.link(path, path.parent / "feedback-outbox.00000001.jsonl")
+    result = read_outbox(
+        file_path=path, prior_cursor=None, config=OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    )
+    assert result.loss_signal is None
+    assert [frame.kind for frame in result.new_frames] == ["a"]
+
+
+def test_rotated_cursor_file_truncated_below_offset_is_loss(tmp_path: Path) -> None:
+    body = _frame_line(kind="a") + _frame_line(kind="b")
+    path = _outbox(tmp_path, body)
+    cursor = _cursor_for(path, body)  # consumed A+B
+    rotated = _rotate(path, 1)
+    _write(path, _frame_line(kind="c"))
+    with rotated.open("r+b") as handle:
+        handle.truncate(5)  # shrink the rotated cursor file below the cursor offset
+    result = read_outbox(
+        file_path=path, prior_cursor=cursor, config=OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    )
+    assert result.new_frames == ()
+    assert result.loss_signal is not None
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_TRUNCATED"
+
+
+def test_rotated_cursor_file_rewritten_prefix_is_loss(tmp_path: Path) -> None:
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    cursor = _cursor_for(path, _frame_line(kind="a"))  # consumed A
+    rotated = _rotate(path, 1)
+    _write(path, _frame_line(kind="c"))
+    # rewrite the consumed prefix with a same-length but different frame -> prefix hash mismatch
+    rotated.write_bytes(_frame_line(kind="z"))
+    result = read_outbox(
+        file_path=path, prior_cursor=cursor, config=OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    )
+    assert result.new_frames == ()
+    assert result.loss_signal is not None
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_REWRITE"
+
+
+def test_torn_rotated_file_above_cursor_is_loss(tmp_path: Path) -> None:
+    # The cursor sits (consuming nothing) in the file that becomes seq 1; seq 2 -- ABOVE the cursor
+    # -- is torn, so the whole recovery fails closed.
+    path = _outbox(tmp_path, _frame_line(kind="a"))
+    cursor = _cursor_for(path, b"")
+    _rotate(path, 1)  # seq 1 = A (complete), the cursor's file
+    _write(path, b"torn-no-newline")
+    _rotate(path, 2)  # seq 2 = torn, above the cursor
+    _write(path, _frame_line(kind="c"))
+    result = read_outbox(
+        file_path=path, prior_cursor=cursor, config=OutboxReaderConfig(rotation_glob=_ROTATION_GLOB)
+    )
+    assert result.new_frames == ()
+    assert result.loss_signal is not None
+    assert result.loss_signal.code == "MH_OUTBOX_LOSS_ROTATED_TORN"

--- a/tests/unit/test_runtime_context_result.py
+++ b/tests/unit/test_runtime_context_result.py
@@ -13,8 +13,10 @@ from _record_factories import INSTALLATION_ID, NOW, event_record
 from _runtime_harness import make_redactor
 
 from milhouse.domain.records import CollectorDescriptorV1, TargetDescriptorV1
+from milhouse.outbox import CursorAdvanceV1, OutboxLossSignal
 from milhouse.runtime import CollectorContext, CollectorResult
 from milhouse.runtime.errors import PipelineError
+from milhouse.state import SourceCursor
 
 _COLLECTOR = CollectorDescriptorV1(id="canary1", type="site.canary", implementation_version="1.0.0")
 _TARGET = TargetDescriptorV1(id="t1", name="Example", kind="web_service", environment="test")
@@ -96,6 +98,20 @@ def test_a_non_redactor_handle_fails_closed() -> None:
     assert caught.value.code == "MH_RUNTIME_CONTEXT_REDACTOR"
 
 
+def test_a_valid_prior_cursor_is_accepted() -> None:
+    cursor = SourceCursor(
+        source="app-outbox", position="pos", batch_id=None, revision=0, updated_at="2026-01-01"
+    )
+    context = _context(prior_cursor=cursor)
+    assert context.prior_cursor is cursor
+
+
+def test_a_non_cursor_prior_cursor_fails_closed() -> None:
+    with pytest.raises(PipelineError) as caught:
+        _context(prior_cursor=object())
+    assert caught.value.code == "MH_RUNTIME_CONTEXT_CURSOR"
+
+
 # --- result ------------------------------------------------------------------------------------
 
 
@@ -142,3 +158,22 @@ def test_a_non_mapping_diagnostics_collection_fails_closed() -> None:
     with pytest.raises(PipelineError) as caught:
         CollectorResult(status="ok", diagnostics=[("samples", 1)])  # type: ignore[arg-type]
     assert caught.value.code == "MH_RUNTIME_RESULT_DIAGNOSTICS"
+
+
+def test_a_valid_cursor_advance_sidecar_is_accepted() -> None:
+    loss = OutboxLossSignal(
+        code="MH_OUTBOX_LOSS_TRUNCATED",
+        cursor_device=1,
+        cursor_inode=2,
+        cursor_offset=0,
+        cursor_sha256="0" * 64,
+    )
+    result = CollectorResult(status="failed", cursor_advance=CursorAdvanceV1(loss_signal=loss))
+    assert result.cursor_advance is not None
+    assert result.cursor_advance.loss_signal is not None
+
+
+def test_a_non_cursor_advance_sidecar_fails_closed() -> None:
+    with pytest.raises(PipelineError) as caught:
+        CollectorResult(status="ok", cursor_advance=object())  # type: ignore[arg-type]
+    assert caught.value.code == "MH_RUNTIME_RESULT_CURSOR"


### PR DESCRIPTION
## What & why

W07 increment **2b+2c** — makes the outbox reader actually **ingest**, end-to-end. The `file_outbox` collector reads an application-owned outbox incrementally and the pipeline durably advances the cursor after each commit. **Closes #157.** Refs #149.

**Owner-chosen design:** generic **opt-in** cursor threading (shared `CollectorContext`/`CollectorResult`, non-cursor collectors unaffected) + land 2b (the seam) with 2c (the first real user) together so the seam is validated by a real collector.

## 2b — cursor threading + post-commit advance
- `CollectorContext` gains optional `prior_cursor`; the pipeline `read_cursor`s it before `collect()`. `CollectorResult` gains an optional `CursorAdvanceV1` sidecar (`next_position`, `loss_signal`, `max_observed_sequence`, ack inputs). Non-cursor collectors (site_canary) set neither → **zero runtime change to their path** (tested).
- `_run_collector` post-commit hook: **after** `commit_segment` returns, `advance_cursor(position, batch_id=committed.batch_id, expected_revision=prior.revision)` **then** `write_outbox_ack(last_sequence=max(prior, max_observed))`, isolated so a failure records a code **without unwinding the commit**.

## 2c — file_outbox collector
`FileOutboxCollector` (path-bound to the resolved outbox path + the `.milhouse` ack dir) maps each `OutboxFrameV1` → an `event` `RecordDraftV1`, reads the prior ack's high-water → `read_outbox(last_acknowledged_sequence=…)`, and returns drafts + the sidecar. Wired into `_new_collect_registry` (which now resolves file_outbox paths symlink-free).

## The three safety invariants
- **(a) advance strictly after commit** — empty read commits/advances nothing (idempotent re-read); loss returns before commit.
- **(b) deterministic identity** — the observation coordinate is `{producer_id, occurred_at, byte-offset, content-sha256}`, all frame-derived (never the run instant), so a commit-then-crash-before-advance **replay** re-reads the same frame at the same offset → **same `record_id`** → the delivery ledger collapses the duplicate.
- **(c) loss short-circuits** — a `loss_signal` → no commit, no advance, and it returns before the availability sample (never leaks into the alert engine); surfaces as the collector's `error_code` + a WARNING.

## Review — two adversarial rounds, four real bugs caught + fixed
A 4-angle then 3-angle workflow (a dedicated angle per invariant) confirmed the core pipeline wiring + generic-opt-in **sound**, and caught four issues in the collector, all fixed:
- **P1 silent loss** — a None-cursor first read after a rotation skipped retained frames → new `_read_from_start` reads the full retained chain (gap/torn → fails closed).
- **P2 distinct-frame merge** — content-only identity merged distinct byte-identical frames → the plan §4.9 **byte-offset fallback identity** is now wired (`read_outbox` exposes per-frame offsets; distinct frames get distinct ids, replays still dedup).
- **P2 privacy** — untrusted `frame.data` reached the record unredacted → the collector now redacts it via `context.redactor`.
- **P2 poison-stall** — a redaction-expanded value could exceed the 2048-byte `DimensionsV1` bound and permanently stall the outbox → a UTF-8-safe post-redaction **clamp** to the imported bound.

### Documented residuals / deferred
- Two byte-identical frames at the **same** per-file offset in **two different** files still collide (per-file offset) — documented.
- Deferred follow-ups (noted): `record_id` folds the collector impl-version (a replay after a version bump duplicates); a persistent ack-write failure advances the cursor but not the rotation high-water (cursor-first/ack-second is intentional — ack-first would risk a false top-run positive).

## Tests / gates
End-to-end through a real `RuntimePipeline`: happy path (cursor advanced + ack written + records match), idempotency (2nd run 0 committed; append → only-new), the **replay → same record_id** test, distinct-byte-identical → **2 distinct ids**, attribute **redaction**, redaction-clamp **no-stall**, None-cursor **retained-rotation ingest**, loss → no-commit/no-advance, generic-opt-in (site_canary unchanged), advance-failure isolation, symlink-path → **exit 2**, and the per-file offset invariants. `test` → **5219 passed / 6 skipped / 0 failed**; `quality` clean (mypy strict, 113 files). DCO + co-author trailers, no session locator, no CodeQL substring pattern.

## Scope / next
Deferred: the `workflow_file`/`error_report_file` collectors, the HTTP receiver, firing the alert engine on an outbox loss, and the two P3 follow-ups above. **G07 is not claimed** (needs the full vertical + live evidence, E06/#108).

Closes #157
Refs #149
