### PR TITLE
fix(setup): make a first-time contributor install diagnosable and unblockable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,12 @@ remain W05 work; that registry must revalidate and bind the exact object it will
 
 ## Contributor quickstart
 
-Contributors need Python 3.11-3.14 and exactly uv 0.11.29. The bootstrap verifies that uv version
-and installs the hash-locked development environment:
+Contributors need Python 3.11-3.14 and exactly uv 0.11.29. A package manager will usually install a
+different version, so pin it explicitly (`curl -LsSf https://astral.sh/uv/0.11.29/install.sh | sh`,
+or `pipx install uv==0.11.29`). Set `MILHOUSE_UV` if the exact executable is not the one found on
+`PATH`, and `MILHOUSE_PYTHON` to choose a different bootstrap interpreter — see
+[setup](docs/setup.md) for both. The bootstrap verifies that uv version and installs the hash-locked
+development environment:
 
 ```bash
 ./setup.sh

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -141,7 +141,8 @@ mutable tag.
 
 ## Lock and update procedure
 
-The only supported resolver is exactly uv 0.11.29:
+The only supported resolver is exactly uv 0.11.29 ([how to install that
+version](setup.md#installing-exactly-uv-01129)):
 
 ```bash
 python3 -I scripts/run_uv.py

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,9 +7,11 @@ pre-alpha infrastructure; it does not make later product commands available.
 
 ## Reproducible environment
 
-The repository requires Python 3.11-3.14 and exactly uv 0.11.29. `scripts/run_uv.py` resolves the
-uv executable from `MILHOUSE_UV` or `PATH`, verifies its exact version, and then delegates without
-falling back to another package manager. It anchors commands to this checkout and ignores ambient
+The repository requires Python 3.11-3.14 and exactly uv 0.11.29 — see
+[setup](setup.md) for how to install that exact version, and for the `MILHOUSE_UV` /
+`MILHOUSE_PYTHON` overrides when the executable found on `PATH` is not the right one.
+`scripts/run_uv.py` resolves the uv executable from `MILHOUSE_UV` or `PATH`, verifies its exact
+version, and then delegates without falling back to another package manager. It anchors commands to this checkout and ignores ambient
 uv/Python project redirection, user-level uv configuration, and gate-altering pytest, coverage,
 typing, property-test, and tool control variables. The Makefile invokes the wrapper with Python
 isolated mode and refuses Make modes that can skip recipes or ignore failures. Canonical gate

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,9 +1,11 @@
 # Contributor setup
 
-This page describes the pre-alpha source-checkout environment used to build and test Milhouse. It
-is not an end-user installation or product-initialization guide. `milhouse init`, user
-configuration, local state, and the deterministic demo are W06 deliverables and are not available
-from the W01 foundation.
+This page describes the pre-alpha source-checkout environment used to build and test Milhouse: it
+gets the hash-locked contributor toolchain working. It is not an end-user installation guide.
+
+Once setup succeeds, `milhouse config validate`, `milhouse init`, `milhouse health`, and
+`milhouse demo` all work from the checkout against a local, spool-only state root — no Docker,
+ClickHouse, or credentials required. [Quickstart](quickstart.md) covers that path.
 
 ## Prerequisites
 
@@ -15,14 +17,57 @@ from the W01 foundation.
 Docker, ClickHouse, provider credentials, and production data are not needed for W01. Normal tests
 must remain offline and use only tracked synthetic fixtures or runtime-generated adversarial values.
 
-The repository wrapper rejects a missing uv executable or any uv version other than 0.11.29. If
-the exact executable is not on `PATH`, set `MILHOUSE_UV` to its absolute path:
+### Installing exactly uv 0.11.29
+
+The pin is exact: the wrapper rejects a missing uv executable or any other version, and CI installs
+the same one. A package manager will generally give you the wrong version — `brew install uv`
+tracks latest — so install the pinned version directly:
 
 ```bash
-MILHOUSE_UV=/absolute/path/to/uv python3 -I scripts/run_uv.py
+# Astral's installer, pinned to the exact version (installs into ~/.local/bin):
+curl -LsSf https://astral.sh/uv/0.11.29/install.sh | sh
+
+# or, into an isolated tool environment:
+pipx install uv==0.11.29
 ```
 
-The command prints `uv 0.11.29 ready` only after checking the executable and version.
+Confirm the wrapper agrees before going further:
+
+```bash
+python3 -I scripts/run_uv.py
+```
+
+It prints `uv 0.11.29 ready` only after checking the executable and its version. Any other version
+is refused, and the message names the executable it resolved — which is the part you need when the
+resolved one is not the one you expected.
+
+### When the wrong uv is found first
+
+The wrapper resolves uv the way Python does, not the way your shell does. A version manager whose
+`python3` is a **shim** — pyenv and conda both do this — prepends its own `bin` directory to `PATH`
+*inside* the interpreter. If that directory holds a different uv, it wins, even though `which uv`
+in your shell shows the correct one:
+
+```console
+$ uv --version
+uv 0.11.29 (901092ee1 2026-07-15 aarch64-apple-darwin)     # what your shell sees
+
+$ ./scripts/run_make.py test
+run_uv: expected uv 0.11.29; ~/.pyenv/versions/3.12.8/bin/uv reported another version. Install
+that exact version or set MILHOUSE_UV to the absolute path of the correct one
+```
+
+Set `MILHOUSE_UV` to the absolute path of the correct executable — export it from your shell profile
+on a machine where this applies, so every target uses it:
+
+```bash
+export MILHOUSE_UV="$HOME/.local/bin/uv"
+```
+
+This matters beyond convenience: running the suite under an unpinned uv produces numbers that do
+not count as evidence. Defect **D07** in [implementation status](implementation-status.md) records a
+review whose results were discounted for exactly this reason (host `uv 0.7.10` against the locked
+`0.11.29`).
 
 ## Bootstrap the locked environment
 
@@ -47,6 +92,23 @@ MILHOUSE_PYTHON="$(/usr/bin/env python3 -I -c \
   --locked --all-groups --all-extras --exact \
   --link-mode copy --python "$MILHOUSE_PYTHON"
 ```
+
+### Choosing the bootstrap interpreter
+
+By default the bootstrap uses the first `python3` on `PATH`. Set `MILHOUSE_PYTHON` to an absolute
+path to choose a different one — the same escape hatch `MILHOUSE_UV` provides for uv:
+
+```bash
+MILHOUSE_PYTHON=/opt/homebrew/opt/python@3.12/bin/python3 ./setup.sh
+```
+
+Use it when the default `python3` is below the 3.11 floor, or is installed but broken. A Homebrew
+Python whose `platform.mac_ver()` returns empty values is the common case; uv refuses it with
+`Broken Python installation`, and without the override there is no way past it.
+
+The override selects an interpreter; it does not bypass any check. The chosen interpreter is still
+required to be a resolvable executable in the supported 3.11–3.14 range, and is rejected with a
+message naming it and its version if it is not.
 
 It creates or updates the project `.venv` from `uv.lock`, including the development dependency
 group and optional receiver extra used by the complete test matrix. The lock includes hashes for the
@@ -94,6 +156,7 @@ any implementation gate passed.
 
 ## Next steps
 
+- [Quickstart](quickstart.md) initializes a local state root and runs the spool-only path.
 - [Development workflow](development.md) explains every supported Make target and test suite.
 - [Dependency policy](dependencies.md) explains dependency groups, locking, licensing, and review.
 - [Contributing](../CONTRIBUTING.md) covers DCO sign-off and pull-request requirements.

--- a/scripts/prepare_environment.py
+++ b/scripts/prepare_environment.py
@@ -192,9 +192,24 @@ def _open_regular_at(parent_fd: int, name: str, *, follow_symlinks: bool = False
     raise last_error
 
 
+def _describe_entry(relative: tuple[str, ...], info: os.stat_result | None = None) -> str:
+    """Name one offending entry for an operator diagnostic, with its mode when relevant.
+
+    The name is the entry's path RELATIVE to the environment root (``bin/activate``), never an
+    absolute machine path, so the diagnostic identifies the entry to act on without disclosing where
+    the checkout lives. The root itself is named, not rendered as an empty path.
+    """
+
+    location = "/".join(relative) if relative else "the environment root"
+    if info is None:
+        return location
+    return f"{location} (mode {stat.S_IMODE(info.st_mode):04o})"
+
+
 def _validate_policy(
     info: os.stat_result,
     *,
+    relative: tuple[str, ...],
     root: bool,
     owner: int,
     trusted_sync_result: bool,
@@ -203,18 +218,34 @@ def _validate_policy(
     mount_id: int | None,
     nested_mount: bool,
 ) -> tuple[str, int | None]:
+    # Every policy rejection names the entry that tripped it. The check stays fail-closed and
+    # unchanged; only the diagnostic gains the offending path (and, where the mode is the fault, the
+    # mode) so an operator can fix the environment instead of guessing which of thousands of entries
+    # is at fault. A stale group-writable ``.venv/`` from another checkout is the common cause.
     if info.st_uid != owner:
-        raise EnvironmentSafetyError("the environment contains an entry owned by another user")
+        raise EnvironmentSafetyError(
+            "the environment contains an entry owned by another user: "
+            f"{_describe_entry(relative)} (uid {info.st_uid}, expected {owner})"
+        )
     if root_device is not None and info.st_dev != root_device:
-        raise EnvironmentSafetyError("the environment contains an entry on another filesystem")
+        raise EnvironmentSafetyError(
+            f"the environment contains an entry on another filesystem: {_describe_entry(relative)}"
+        )
     if not root and nested_mount:
-        raise EnvironmentSafetyError("the environment contains a nested mount point")
+        raise EnvironmentSafetyError(
+            f"the environment contains a nested mount point: {_describe_entry(relative)}"
+        )
     kind, desired = _classify(info, root=root)
     if kind != "symlink" and root_mount_id is not None and mount_id != root_mount_id:
-        raise EnvironmentSafetyError("the environment contains a nested mount point")
+        raise EnvironmentSafetyError(
+            f"the environment contains a nested mount point: {_describe_entry(relative)}"
+        )
     write_exposed = kind != "symlink" and bool(info.st_mode & (stat.S_IWGRP | stat.S_IWOTH))
     if write_exposed and (not trusted_sync_result or root or desired is None):
-        raise EnvironmentSafetyError("the environment contains a group- or world-writable entry")
+        raise EnvironmentSafetyError(
+            "the environment contains a group- or world-writable entry: "
+            f"{_describe_entry(relative, info)}; remove the environment and re-run setup"
+        )
     return kind, desired
 
 
@@ -341,6 +372,7 @@ def _capture_tree(
 ) -> tuple[list[EntrySnapshot], dict[tuple[str, ...], EntrySnapshot]]:
     root_kind, root_desired = _validate_policy(
         root_info,
+        relative=(),
         root=True,
         owner=owner,
         trusted_sync_result=trusted_sync_result,
@@ -389,6 +421,7 @@ def _capture_tree(
                     nested_mount = False
                 kind, desired = _validate_policy(
                     pinned_info,
+                    relative=child_relative,
                     root=False,
                     owner=owner,
                     trusted_sync_result=trusted_sync_result,

--- a/scripts/run_uv.py
+++ b/scripts/run_uv.py
@@ -82,10 +82,23 @@ def verify_uv(path: Path) -> None:
             timeout=10,
         )
     except (OSError, subprocess.TimeoutExpired):
-        fail("could not execute uv --version")
+        fail(f"could not execute uv --version using {path}")
     output = (completed.stdout or completed.stderr).strip()
     if completed.returncode != 0 or not _VERSION_PATTERN.fullmatch(output):
-        fail(f"expected uv {UV_VERSION}; the resolved executable reported another version")
+        # Name the executable that was RESOLVED, and the override that redirects it. Without the
+        # path this message is unactionable whenever the wrong uv is earlier on PATH than the right
+        # one -- the common case being a version manager (pyenv, conda) whose shim prepends its own
+        # bin directory INSIDE the interpreter, so the uv the operator sees in their shell is not
+        # the uv ``shutil.which`` resolves here.
+        #
+        # The resolved path is operator-supplied (MILHOUSE_UV or PATH), so echoing it discloses
+        # nothing the caller did not provide. The executable's OWN output stays unreported: it is
+        # untrusted foreign process output, and reflecting it would let a hostile binary write
+        # terminal escapes into this diagnostic.
+        fail(
+            f"expected uv {UV_VERSION}; {path} reported another version. Install that exact "
+            f"version or set {UV_ENVIRONMENT_OVERRIDE} to the absolute path of the correct one"
+        )
 
 
 def uv_environment() -> dict[str, str]:

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env -S -u BASH_ENV -u ENV -u SHELLOPTS -u BASHOPTS /bin/sh
 
-if ! MILHOUSE_PYTHON="$(/usr/bin/env python3 -I -c '
+# The bootstrap interpreter. Defaults to the first python3 on PATH; set MILHOUSE_PYTHON to an
+# absolute path to override it -- the same escape hatch MILHOUSE_UV provides for the pinned uv.
+# Without this, whichever python3 happens to be first on PATH is the only interpreter setup can
+# ever use, so one broken or too-old default (a Homebrew Python whose platform.mac_ver() is empty,
+# or a system 3.9) makes setup unrunnable with no supported way out. The override is validated by
+# exactly the same checks as the default: it is a choice of interpreter, never a bypass.
+MILHOUSE_BOOTSTRAP_PYTHON="${MILHOUSE_PYTHON:-python3}"
+
+if [ -n "${MILHOUSE_PYTHON:-}" ] && [ ! -x "${MILHOUSE_PYTHON}" ]; then
+  printf '%s\n' \
+    "setup: MILHOUSE_PYTHON is set but is not an executable file: ${MILHOUSE_PYTHON}" >&2
+  exit 1
+fi
+
+if ! MILHOUSE_PYTHON="$(/usr/bin/env "$MILHOUSE_BOOTSTRAP_PYTHON" -I -c '
 import os
 import sys
 from pathlib import Path
@@ -8,7 +22,11 @@ from pathlib import Path
 if any(name.startswith("BASH_FUNC_") for name in os.environ):
     raise SystemExit("setup: exported shell functions are prohibited")
 if not (3, 11) <= sys.version_info[:2] < (3, 15):
-    raise SystemExit("setup: Python 3.11-3.14 is required")
+    raise SystemExit(
+        f"setup: Python 3.11-3.14 is required, but {sys.executable} is "
+        f"{sys.version_info[0]}.{sys.version_info[1]}; "
+        "set MILHOUSE_PYTHON to a supported interpreter"
+    )
 try:
     interpreter = Path(sys.executable).resolve(strict=True)
 except OSError:
@@ -45,4 +63,5 @@ printf '%s\n' "Synchronizing the hash-locked Milhouse contributor environment...
 
 printf '%s\n' \
   "Contributor environment ready. Run './scripts/run_make.py quality' and './scripts/run_make.py test-coverage'."
-printf '%s\n' "Product initialization and local state creation remain gated to W06."
+printf '%s\n' \
+  "Then initialize local state with 'milhouse init' and try it with 'milhouse demo'."

--- a/tests/security/test_tool_prepare_environment.py
+++ b/tests/security/test_tool_prepare_environment.py
@@ -138,6 +138,7 @@ def test_policy_rejects_owner_and_nested_mount_mismatches(tmp_path: Path) -> Non
     entry.write_text("synthetic\n", encoding="utf-8")
     info = entry.stat()
     common = {
+        "relative": ("entry",),
         "root": False,
         "trusted_sync_result": False,
         "root_device": info.st_dev,
@@ -509,6 +510,86 @@ def test_write_exposed_tree_is_rejected_before_any_modes_change(
         prepare_environment.prepare_environment(environment)
 
     assert stat.S_IMODE(exposed.stat().st_mode) == mode
+
+
+def test_write_exposed_rejection_names_the_offending_entry_and_mode(tmp_path: Path) -> None:
+    """The fail-closed rejection must identify WHICH entry tripped it, not just that one did.
+
+    Without the name an operator has to guess among thousands of environment entries; the usual
+    cause is a stale ``.venv`` carried over from another checkout.
+    """
+
+    environment = tmp_path / "environment"
+    environment.mkdir(mode=0o700)
+    nested = environment / "bin"
+    nested.mkdir(mode=0o700)
+    exposed = nested / "activate"
+    exposed.write_text("synthetic\n", encoding="utf-8")
+    exposed.chmod(0o664)
+
+    with pytest.raises(
+        prepare_environment.EnvironmentSafetyError,
+        match="group- or world-writable",
+    ) as caught:
+        prepare_environment.prepare_environment(environment)
+
+    message = str(caught.value)
+    # The entry is named RELATIVE to the environment root -- identifying, but never an absolute
+    # machine path, so the diagnostic does not disclose where the checkout lives.
+    assert "bin/activate" in message
+    assert "0664" in message
+    assert os.fspath(tmp_path) not in message
+
+
+def test_policy_rejections_name_the_offending_entry(tmp_path: Path) -> None:
+    """Each policy rejection identifies the entry that tripped it, by environment-relative path."""
+
+    entry = tmp_path / "entry"
+    entry.write_text("synthetic\n", encoding="utf-8")
+    info = entry.stat()
+    common = {
+        "relative": ("bin", "activate"),
+        "root": False,
+        "trusted_sync_result": False,
+        "root_device": info.st_dev,
+        "root_mount_id": None,
+        "mount_id": None,
+    }
+
+    with pytest.raises(
+        prepare_environment.EnvironmentSafetyError,
+        match="owned by another user",
+    ) as owner_error:
+        prepare_environment._validate_policy(
+            info,
+            owner=info.st_uid + 1,
+            nested_mount=False,
+            **common,
+        )
+    assert "bin/activate" in str(owner_error.value)
+
+    with pytest.raises(
+        prepare_environment.EnvironmentSafetyError,
+        match="nested mount point",
+    ) as mount_error:
+        prepare_environment._validate_policy(
+            info,
+            owner=info.st_uid,
+            nested_mount=True,
+            **common,
+        )
+    assert "bin/activate" in str(mount_error.value)
+
+
+def test_describe_entry_names_the_root_and_renders_the_mode(tmp_path: Path) -> None:
+    entry = tmp_path / "entry"
+    entry.write_text("synthetic\n", encoding="utf-8")
+    entry.chmod(0o640)
+    info = entry.stat()
+
+    assert prepare_environment._describe_entry(()) == "the environment root"
+    assert prepare_environment._describe_entry(("bin", "activate")) == "bin/activate"
+    assert prepare_environment._describe_entry(("bin",), info) == "bin (mode 0640)"
 
 
 def test_trusted_sync_result_restricts_new_single_link_entries(tmp_path: Path) -> None:

--- a/tests/unit/test_tool_run_uv.py
+++ b/tests/unit/test_tool_run_uv.py
@@ -76,6 +76,33 @@ def test_run_uv_rejects_an_ambient_executable_with_the_wrong_version(
     diagnostic = capsys.readouterr().err
     assert f"expected uv {run_uv.UV_VERSION}" in diagnostic
     assert untrusted_output not in diagnostic
+    # The diagnostic must be ACTIONABLE: it names the executable that was actually resolved (which
+    # the caller supplied through PATH or the override) and the override that redirects it, so an
+    # operator whose shell shows the right uv can see which wrong one was found instead.
+    assert os.fspath(ambient) in diagnostic
+    assert run_uv.UV_ENVIRONMENT_OVERRIDE in diagnostic
+
+
+def test_wrong_version_diagnostic_never_reflects_hostile_executable_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A hostile uv cannot inject terminal escapes or noise into the operator's diagnostic."""
+
+    hostile = _fake_uv(tmp_path / "uv", "uv 0.0.0\x1b[31mINJECTED\x1b[0m" + "A" * 4000)
+    monkeypatch.delenv(run_uv.UV_ENVIRONMENT_OVERRIDE, raising=False)
+    monkeypatch.setenv("PATH", str(hostile.parent))
+
+    with pytest.raises(SystemExit) as caught:
+        run_uv.run_uv([])
+
+    assert caught.value.code == 2
+    diagnostic = capsys.readouterr().err
+    assert "INJECTED" not in diagnostic
+    assert "\x1b" not in diagnostic
+    assert "AAAA" not in diagnostic
+    assert len(diagnostic) < 400
 
 
 def test_explicit_exact_uv_wins_over_a_poisoned_ambient_path_and_forwards_exit_code(


### PR DESCRIPTION
## What & why

Four defects found during a clean contributor install on dedicated Apple Silicon hardware (the machine this project will actually run on). Each turns a recoverable environment problem into a dead end — the tooling refuses *correctly*, but never says what to change. **Closes #159, #160, #161, #162.**

## #161 — no interpreter override, so a broken default `python3` blocks setup entirely

`setup.sh` derived `MILHOUSE_PYTHON` from `/usr/bin/env python3` with no override, so whichever `python3` is first on `PATH` is the only interpreter setup can ever use. On the affected host that is a Homebrew 3.14 whose `platform.mac_ver()` returns empty values — uv rejects it as `Broken Python installation` — with only the 3.9 system Python behind it. Setup was unrunnable with no supported way out.

`MILHOUSE_PYTHON` is now honoured as the bootstrap interpreter, mirroring what `MILHOUSE_UV` already does for the pinned resolver. **It selects an interpreter; it does not bypass a check** — the chosen one still must be a resolvable executable in 3.11–3.14, and the rejection now names the interpreter and the version it found:

```console
$ MILHOUSE_PYTHON=/usr/bin/python3 ./setup.sh
setup: Python 3.11-3.14 is required, but /Library/.../python3 is 3.9; set MILHOUSE_PYTHON to a supported interpreter
```

## #160 — environment-safety failure did not identify the offending entry

The fail-closed check is correct and is **unchanged**; the diagnostic was the defect. It reported only `the environment contains a group- or world-writable entry` against a tree with thousands of entries.

Every policy rejection now names the entry that tripped it by **environment-relative** path — `bin/activate`, never an absolute machine path, so it identifies the entry without disclosing where the checkout lives — plus the mode where the mode is the fault:

```
the environment contains a group- or world-writable entry: bin/activate (mode 0664); remove the environment and re-run setup
```

## #159 — no documented way to obtain uv 0.11.29

Four documents stated the exact requirement; none said how to satisfy it, and `brew install uv` gives a different version. `docs/setup.md` now carries the pinned installer and a `pipx` alternative, and README / development / dependencies point at it.

The same section documents the trap that motivated this. `run_uv` resolves uv the way **Python** does, not the way the shell does — a version manager whose `python3` is a shim (pyenv, conda) prepends its own `bin` *inside* the interpreter, so a different uv there wins even though `which uv` shows the correct one. That is not hypothetical: it is exactly how defect **D07** discounted a reviewer's evidence (host `uv 0.7.10` against the locked `0.11.29`), and it reproduced on this host.

The mismatch message now names the resolved executable and the override:

```
run_uv: expected uv 0.11.29; /Users/…/.pyenv/versions/3.12.8/bin/uv reported another version. Install that exact version or set MILHOUSE_UV to the absolute path of the correct one
```

### Security note on that message

It deliberately does **not** echo what the executable printed. `test_run_uv_rejects_an_ambient_executable_with_the_wrong_version` already pins that contract — foreign process output stays unreflected so a hostile binary on `PATH` cannot write terminal escapes into the diagnostic. My first draft echoed the banner and would have broken it. The resolved *path* is caller-supplied (via `MILHOUSE_UV` or `PATH`), so naming it discloses nothing the caller did not provide. A new regression test pins both halves.

## #162 — `docs/setup.md` was stale

It claimed `milhouse init`, user configuration, local state, and the demo were unavailable W06 deliverables. All work on `main`; the page now says so and points at the quickstart.

## Tests / gates

New coverage: the run_uv mismatch diagnostic names the path + override and never reflects hostile output (including escapes and a 4 KB flood); the policy rejections name the offending entry; `_describe_entry` renders the root and the mode. The pre-existing direct `_validate_policy` call site is updated for the new required argument.

On the affected host: `test` **5261 passed / 6 skipped**, `quality`, `docs-check` (306 links, 80 external probes), `skill-check`, `secret-scan` all green.

## Note

`audit` is currently failing on `main` and on every PR — `pip 26.1.2` / PYSEC-2026-3721, unrelated to this change. Fixed separately; this PR cannot go green until that lands.

Closes #159
Closes #160
Closes #161
Closes #162
