### PR TITLE
docs(g03): land the supported-host physical-crash procedure as the E06 spec

### DIFF
--- a/docs/gate-evidence/G03-physical-crash-procedure.md
+++ b/docs/gate-evidence/G03-physical-crash-procedure.md
@@ -1,0 +1,165 @@
+# G03 supported-host physical-crash test procedure
+
+Status: **procedure only — not yet executed.** This document specifies the manual, supported-host
+physical-crash tests recorded as deferred evidence item **E06** (issue #108).
+
+**It is not a G03 blocker.** G03 was accepted by the owner on 2026-08-07 against the re-scoped W03
+core; per the owner's 2026-08-03 direction, supported-host physical-crash evidence moved to a later
+hardening lane rather than gating acceptance. This procedure is the specification for that lane. It
+is a companion to [G03.md](G03.md); run it when a supported clean host is available, and again at the
+RC soak.
+
+## Why this exists
+
+The automated [crash/concurrency/failure-injection harness](../../tests/unit/_g03_harness.py) proves
+every durable-write boundary **deterministically** by in-process fault injection and
+restart-by-reconciliation: a fault is raised at a chosen syscall or SQLite statement, and a fresh
+writer's mandatory reconciliation is treated as the "restart". That proves the *logic* is correct.
+
+It does **not** prove behaviour under a **real** process death — a `SIGKILL` or a host power-loss
+that stops the process at an arbitrary machine-code instruction, with in-flight page-cache and
+filesystem-journal state that no in-process test can reproduce. G03 requires that "a kill before
+rename exposes no partial batch" and "a kill after commit loses no acknowledged record" hold against
+those real kills on each supported filesystem. This procedure produces that evidence.
+
+The two are complementary: the harness is the fast, always-on regression; this procedure is the
+periodic, host-specific acceptance evidence.
+
+## Environment to record (per run)
+
+Capture all of the following into the run's evidence file, because crash behaviour is
+filesystem- and platform-specific:
+
+- OS name + exact patch/build (e.g. `Ubuntu 24.04.1`, `macOS 14.6.1 (23G93)`), architecture.
+- Filesystem and mount options of the directory holding `STATE_ROOT` (e.g. `ext4`, `apfs`,
+  `data=ordered`, `barrier=1`). Power-loss results are only meaningful with write barriers enabled.
+- Python version, and the exact repository commit under test (`git rev-parse HEAD`).
+- For power-loss cases: the exact method used to cut power (hardware switch, hypervisor
+  `stop`/`reset`, `echo b > /proc/sysrq-trigger`), since a clean hypervisor stop that flushes caches
+  is a weaker test than a true power cut.
+
+## Method
+
+Each case uses three roles:
+
+1. **Setup** — create a fresh `STATE_ROOT` (an initialized control database, `commit.lock`, and an
+   empty `spool/` tree) and any preconditioning segments, using the W03 library API exactly as
+   `tests/unit/_g03_harness.py::build_spool` and `commit_segment` do. The driver is a short Python script that imports
+   `milhouse.spooling` / `milhouse.state`. The `milhouse` CLI now exists (W06) and is the right tool
+   for setup and verification around each case (`milhouse init`, `health`, `doctor`, `spool list`),
+   but the **kill** step still needs the library: these cases kill at boundaries *inside* one durable
+   operation, which no operator-level command exposes.
+2. **Kill** — run a **driver subprocess** that performs one durable-write operation and, at the chosen
+   boundary, either (a) is sent `SIGKILL` by a controller, or (b) is running when the host loses
+   power. The boundary is reached by having the driver signal readiness (write a sentinel byte to a
+   pipe / touch a file) immediately before the target syscall, then block; the controller kills it on
+   the sentinel. This makes the kill point exact and repeatable without the driver ever completing the
+   operation.
+3. **Restart + verify** — from a new process, open the same `STATE_ROOT` (constructing a
+   `DurableSpool` runs mandatory reconciliation — the real restart path) and assert the case's pass
+   criteria against the ledger rows, the on-disk spool, and a `replay_segments` pass.
+
+Record, for every case: the pre-kill state, the post-kill on-disk artifacts (before restart), the
+post-restart state, and PASS/FAIL. Run each case **≥5 times** per filesystem; a single pass is not
+sufficient because the kill can land in slightly different sub-states.
+
+## Test cases
+
+Each maps to a G03 assertion and to the deterministic harness test that already covers the logic.
+
+### C1 — Kill before the atomic rename exposes no partial batch
+- Harness analogue: `test_g03_failure_injection.py::test_a_kill_before_rename_exposes_no_partial_batch`.
+- Setup: empty spool.
+- Kill: driver stages+fsyncs the segment temporary, signals readiness, blocks *before* the atomic
+  rename; controller `SIGKILL`s it (or power is cut here).
+- Restart + verify: **no committed `pending/<day>/<batch>.jsonl` exists**, **no `_segments` row
+  exists**, and the batch was never acknowledged (the driver never returned success). A staged
+  temporary (`.milhouse-stage-*`) may remain; reconciliation must recover/quarantine it and it must
+  never become a committed batch.
+
+### C2 — Kill after commit loses no acknowledged record
+- Harness analogue: `test_a_kill_after_commit_loses_no_acknowledged_record`.
+- Setup: empty spool.
+- Kill: driver commits the segment fully (the commit returns = acknowledged), records the acknowledged
+  record ids to a durable side-file, signals readiness, then blocks; controller kills it.
+- Restart + verify: the `_segments` row and durable file are intact, and `replay_segments` returns
+  exactly the acknowledged record ids. **No acknowledged record is lost.**
+
+### C3 — Kill during the ledger transaction (post-publish, pre/mid-commit)
+- Harness analogue: `test_spool_commit.py` (ledger transaction failure) + `test_spool_reconcile.py`
+  (orphan re-registration).
+- Kill: driver publishes+fsyncs the file, then is killed during/just after the `BEGIN IMMEDIATE …
+  INSERT` but before the transaction is durably committed.
+- Restart + verify: either the row is present (commit was durable) **or** the file is a
+  re-registrable orphan that reconciliation adopts into the ledger. **Never a `_segments` row without
+  its file, and never a lost acknowledged record.**
+
+### C4 — Kill during a source-cursor / derivation-checkpoint update
+- Harness analogue: `test_a_cursor_update_fault_rolls_back_atomically`,
+  `test_a_derivation_checkpoint_fault_rolls_back_atomically`.
+- Setup: a committed segment and a cursor/checkpoint at revision N.
+- Kill: driver advances the cursor/checkpoint to N+1 and is killed mid-transaction.
+- Restart + verify: the stored revision is **exactly N or exactly N+1**, never a half-applied row,
+  and its `(position, revision)` are internally consistent.
+
+### C5 — Kill between destination confirmation and the exporter checkpoint
+- Harness analogue: `test_an_exporter_checkpoint_fault_leaves_delivery_retryable`.
+- Setup: a committed, undelivered segment with a fake exporter that confirms (returns) then writes a
+  "confirmed" side-file.
+- Kill: after the exporter confirms but before the delivery-status compare-and-set commits.
+- Restart + verify: the exporter row is still `pending` (retryable). A re-delivery pass re-confirms
+  and marks it `delivered` exactly once logically (**at-least-once physical, effectively-once
+  logical** via the record ids). No duplicate logical record downstream.
+
+### C6 — Concurrent writers under a kill produce valid non-interleaved segments
+- Harness analogue: `test_g03_concurrent_writers.py`.
+- Setup: empty spool.
+- Kill: launch N independent writer subprocesses each committing M segments; `SIGKILL` a random
+  subset mid-run (or cut power with all running).
+- Restart + verify: after reconciliation, every segment that any writer *acknowledged* is present and
+  valid; **no segment file is torn, interleaved with another's frames, or duplicated**; every present
+  file's frames belong only to its own batch id. Unacknowledged in-flight commits leave at most a
+  recoverable staged temporary.
+
+### C7 — Kill during a retention prune
+- Harness analogue: `test_spool_retention_apply.py` (crash-during-prune convergence).
+- Setup: a fully-expired committed segment (optionally cursor-referenced).
+- Kill: after the row-first delete transaction commits, before the durable file is unlinked.
+- Restart + verify: the ledger row is gone, the orphan file is re-registered by reconciliation, and a
+  later retention pass re-prunes it to convergence. A referenced cursor is detached with its
+  `(position, revision)` preserved. **A pending (undelivered) segment is never pruned before its
+  record-class privacy expiry.**
+
+### C8 — Torn tail from a power-loss mid-write
+- Harness analogue: `test_spool_reader.py` / `test_spool_quarantine.py` (torn-tail rejection + valid
+  frames preserved).
+- Kill: cut power (or `SIGKILL`) while a segment file is being written, leaving a truncated tail.
+- Restart + verify: the trusted reader rejects the torn file closed (`MH_SPOOL_TRUNCATED`);
+  reconciliation quarantines it with a safe reason; any *previously committed* segments remain valid
+  and replayable. Valid frames are never dropped because of a neighbouring torn file.
+
+## Pass criteria (all cases)
+
+- No acknowledged record is ever lost (the overriding W03 invariant).
+- No `_segments` row exists without its durable file after reconciliation.
+- No partial/interleaved/torn file is ever treated as a committed batch.
+- Privacy-expired data is never retained past its hard deadline through any crash path, and expired
+  data is never egressed mid-operation.
+- Every convergence completes within a bounded number of restart+reconcile passes.
+
+A run passes only when every case passes on every tested supported filesystem for the required
+repetitions, with the environment recorded. File the completed run as dated evidence and link it from
+[G03.md](G03.md).
+
+## Open items / when to run
+
+- Runnable **now** at the library level (C1–C8 via driver scripts + `SIGKILL`). True host power-loss
+  (C8 and the power variants of C1–C7) needs a supported clean host and, ideally, hypervisor or
+  hardware power control — that is what E06 (#108) is waiting on.
+- Use the `milhouse` CLI for setup and verification around each case; the kill step stays at the
+  library level, because these boundaries sit inside a single durable operation.
+- Scope note: an earlier draft carried a **C7 "kill during audited compaction"** case. Owner-approved
+  amendment **A09** removed the audited mixed-expiry compaction subsystem from W03
+  (`spooling/compaction.py` and `test_spool_compaction.py` no longer exist; migrations 11–12 were
+  withdrawn), so that case is dropped rather than left pointing at deleted code. If compaction
+  returns in a later package it needs its own crash case, written against whatever it then is.

--- a/docs/gate-evidence/G03.md
+++ b/docs/gate-evidence/G03.md
@@ -228,7 +228,9 @@ reusable vocabulary and hosts the net-new 10,000-record scale and concurrent-wri
 - **Supported-host physical-crash evidence.** The harness proves the crash boundaries deterministically
   by in-process fault injection and restart-by-reconciliation; the plan additionally records real
   power-loss / `SIGKILL` evidence on a supported host as owner-provided acceptance evidence (E06), not
-  reproducible in CI.
+  reproducible in CI. That evidence is deferred to a later hardening lane (issue #108) and is not a
+  G03 blocker; the cases, environment capture, and pass criteria for it are specified in
+  [G03-physical-crash-procedure.md](G03-physical-crash-procedure.md).
 - **Compaction audit lineage — the earlier "wired into W03" and "load a file for provenance" claims
   are both DISPROVEN (see D07, D08).** The PR #76 packet's threaded-`Pseudonymizer` claim was unwired
   (NULL `_audit` lineage), and the round-1/round-2 PR #79 attempts that merely loaded a key at the

--- a/docs/gate-evidence/README.md
+++ b/docs/gate-evidence/README.md
@@ -10,7 +10,9 @@ commit and every required result marks a gate passed.
 
 - [G01 package and quality-toolchain foundation](G01.md) — passed 2026-07-19
 - [G02 domain, configuration, identity, trust, and privacy](G02.md) — accepted 2026-07-24
-- [G03 SQLite control plane, durable spool, replay, and retention](G03.md) — candidate, not yet
-  accepted (pending independent review and supported-host physical-crash evidence)
+- [G03 SQLite control plane, durable spool, replay, and retention](G03.md) — accepted 2026-08-07
+  (re-scoped by amendment A09; supported-host physical-crash evidence deferred to E06, issue #108)
+- [G03 supported-host physical-crash test procedure](G03-physical-crash-procedure.md) — procedure
+  only, not yet executed; the specification for the deferred E06 evidence
 - [PR #21 squash DCO incident and remediation](PR21-DCO.md) — immediate recovery complete;
   historical disposition recorded by amendment A03 (2026-07-22)


### PR DESCRIPTION
## What & why

Salvages the one piece of genuinely unlanded work in **PR #74** (open since 2026-08-01, `CONFLICTING`) and brings it current.

I originally planned to close #74 as superseded. It isn't: `docs/gate-evidence/G03-physical-crash-procedure.md` is a 165-line specification that exists nowhere on `main`, and it is the only place the physical-crash cases, environment capture, and pass criteria are written down.

**The rest of #74 is deliberately not taken.** It predates G03 acceptance, so its `G03.md` edit would *delete* the accepted status record — which is exactly why it conflicts. Only the new file is carried over, then corrected.

**Why now:** dedicated hardware for this project now exists, which is the single thing **E06 (#108)** has been waiting on.

## Corrections applied to the salvaged document

**Reframed.** It claimed to be "pending for G03 acceptance". G03 was **accepted 2026-08-07** against the re-scoped W03 core, and supported-host physical-crash evidence moved to a later hardening lane per the owner's 2026-08-03 direction. It is the spec for that lane, not a gate blocker.

**Removed case C7 — "kill during audited compaction".** Amendment **A09** deleted that subsystem. Verified at this commit:

| referenced by C7 | status |
|---|---|
| `src/milhouse/spooling/compaction.py` | **gone** |
| `tests/unit/test_spool_compaction.py` | **gone** |

The case pointed at deleted code *and* a deleted harness analogue. C8/C9 renumber to C7/C8, and a scope note records the removal rather than silently dropping it — noting that a returning compaction needs its own case written against whatever it then is.

**Corrected the driver guidance.** It said "until the `milhouse` CLI exists (W06)". The CLI exists. It's now the right tool for setup and verification around each case (`init`, `health`, `doctor`, `spool list`) — but the **kill** step stays at the library level, because these cases kill at boundaries *inside* one durable operation, which no operator-level command exposes.

**Verified every surviving reference.** `_g03_harness.build_spool`, the failure-injection and concurrent-writer suites, and each named test (`test_a_kill_before_rename_exposes_no_partial_batch`, `test_a_kill_after_commit_loses_no_acknowledged_record`, `test_a_cursor_update_fault_rolls_back_atomically`, `test_a_derivation_checkpoint_fault_rolls_back_atomically`, `test_an_exporter_checkpoint_fault_leaves_delivery_retryable`, `test_a_crash_before_unlink_self_completes_via_reconciliation`) all still exist.

## Bonus fix

While wiring the link I found `docs/gate-evidence/README.md` still describing G03 as *"candidate, not yet accepted (pending independent review and supported-host physical-crash evidence)"*. It was accepted 2026-08-07. Corrected, and the procedure is now indexed and linked from `G03.md`'s E06 boundary.

## Tests / gates

Documentation only — no source or test changes. `docs-check` passes (73 files, 306 links, 80 external probes).

## Follow-up

**#74 should be closed once this merges** — its unique content is here, and its remaining diff would revert the G03 acceptance record.

Refs #108
Refs #74
